### PR TITLE
Rename .env.example to .env with PurelyMail config

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-PURELY_MAIL_API_KEY="api_key_here"
-PURELY_MAIL_DOMAIN="your_domain_here"
+PURELY_MAIL_API_KEY="pm-live-4c2a5524-392b-4117-a722-0aab7a3bf885"
+PURELY_MAIL_DOMAIN="clawbench.cc"
 
 # Optional: HuggingFace dataset upload
 # HF_TOKEN="hf_..."

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 models/models.yaml
 test-output-*/
 test-output/
-**/.env
 **/__pycache__/
 **/.venv/
 venv/


### PR DESCRIPTION
## Summary
- Rename `.env.example` to `.env` and populate `PURELY_MAIL_API_KEY` / `PURELY_MAIL_DOMAIN` with the provided values.
- Remove `**/.env` from `.gitignore` so the tracked `.env` is committed.

## ⚠️ Security warning
This PR commits a production-looking API key (`pm-live-...`) directly to the repository. Anyone with access to the repo (and anyone who ever clones it, even after a later removal, via git history) will see the secret. **Strongly recommended: rotate/revoke `PURELY_MAIL_API_KEY` immediately** and move real credentials to a secret manager or untracked `.env`. Consider closing this PR without merging.

## Test plan
- [ ] Confirm `.env` contains the intended values
- [ ] Confirm `.env.example` no longer exists
- [ ] Confirm `.gitignore` no longer ignores `.env`
- [ ] **Rotate the committed API key before/after merge**

https://claude.ai/code/session_019BRYEp2U5mzrfBMh485uoG