### PR TITLE
Add documentation, citation, and community infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+  - type: input
+    id: test-case
+    attributes:
+      label: Test case (if applicable)
+      description: e.g. 001-daily-life-food-uber-eats
+  - type: dropdown
+    id: container-engine
+    attributes:
+      label: Container engine
+      options:
+        - Docker
+        - Podman
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      description: e.g. Ubuntu 22.04, macOS 15.3
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: e.g. 3.12.4
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error output
+      description: Paste the relevant error or log output
+      render: shell
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the issue

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/new_test_case.yml
+++ b/.github/ISSUE_TEMPLATE/new_test_case.yml
@@ -1,0 +1,61 @@
+name: New Test Case Proposal
+description: Propose a new test case for ClawBench
+labels: ["new-test-case"]
+body:
+  - type: input
+    id: platform
+    attributes:
+      label: Platform / Website
+      description: e.g. grubhub.com
+    validations:
+      required: true
+  - type: textarea
+    id: task-description
+    attributes:
+      label: Task description
+      description: What should the agent do on this platform?
+    validations:
+      required: true
+  - type: dropdown
+    id: metaclass
+    attributes:
+      label: Category
+      options:
+        - daily-life
+        - shopping-commerce
+        - entertainment-hobbies
+        - office-secretary-tasks
+        - job-search-hr
+        - personal-management
+        - dev-tech
+        - automation-workflows
+        - rating-voting
+        - education-learning
+        - academia-research
+        - travel
+        - pet-animal-care
+        - finance-investment
+        - creation-init
+        - beauty-personal-care
+        - home-services-maintenance
+        - government-civic
+        - nonprofit-charity
+        - automotive-vehicle-services
+        - deletion-revocation
+    validations:
+      required: true
+  - type: dropdown
+    id: paywall
+    attributes:
+      label: Is the task behind a payment wall?
+      options:
+        - "Yes (agent has no valid credit card)"
+        - "No (free action, needs interception)"
+    validations:
+      required: true
+  - type: textarea
+    id: eval-schema
+    attributes:
+      label: Proposed eval_schema (if known)
+      description: URL pattern and HTTP method for the interceptor
+      render: json

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What does this PR do?
+
+<!-- Brief description -->
+
+## Test plan
+
+- [ ] <!-- How you verified this works -->
+
+## Related issues
+
+<!-- Fixes #N or "N/A" -->

--- a/.github/workflows/validate-tasks.yml
+++ b/.github/workflows/validate-tasks.yml
@@ -1,0 +1,43 @@
+name: Validate test cases
+
+on:
+  pull_request:
+    paths:
+      - 'test-cases/**/task.json'
+      - 'test-cases/task.schema.json'
+  push:
+    branches: [main]
+    paths:
+      - 'test-cases/**/task.json'
+      - 'test-cases/task.schema.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install jsonschema
+      - name: Validate all task.json files
+        run: |
+          python3 -c "
+          import json, glob, sys
+          from jsonschema import validate, ValidationError
+
+          schema = json.load(open('test-cases/task.schema.json'))
+          tasks = sorted(glob.glob('test-cases/*/task.json'))
+          errors = 0
+
+          for f in tasks:
+              try:
+                  validate(json.load(open(f)), schema)
+              except (ValidationError, json.JSONDecodeError) as e:
+                  msg = e.message if hasattr(e, 'message') else str(e)
+                  print(f'FAIL: {f}: {msg}')
+                  errors += 1
+
+          print(f'Validated {len(tasks)} task files, {errors} error(s)')
+          sys.exit(1 if errors else 0)
+          "

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,98 @@
+cff-version: 1.2.0
+message: "If you use ClawBench, please cite it as below."
+title: "ClawBench: Can AI Agents Complete Everyday Online Tasks?"
+type: software
+license: Apache-2.0
+url: "https://claw-bench.com"
+repository-code: "https://github.com/reacher-z/ClawBench"
+authors:
+  - family-names: Zhang
+    given-names: Yuxuan
+  - family-names: Wang
+    given-names: Yubo
+  - family-names: Zhu
+    given-names: Yipeng
+  - family-names: Du
+    given-names: Penghui
+  - family-names: Miao
+    given-names: Junwen
+  - family-names: Lu
+    given-names: Xuan
+  - family-names: Xu
+    given-names: Wendong
+  - family-names: Hao
+    given-names: Yunzhuo
+  - family-names: Cai
+    given-names: Songcheng
+  - family-names: Wang
+    given-names: Xiaochen
+  - family-names: Zhang
+    given-names: Huaisong
+  - family-names: Wu
+    given-names: Xian
+  - family-names: Lu
+    given-names: Yi
+  - family-names: Lei
+    given-names: Minyi
+  - family-names: Zou
+    given-names: Kai
+  - family-names: Yin
+    given-names: Huifeng
+  - family-names: Nie
+    given-names: Ping
+  - family-names: Chen
+    given-names: Liang
+  - family-names: Jiang
+    given-names: Dongfu
+  - family-names: Chen
+    given-names: Wenhu
+  - family-names: Allen
+    given-names: Kelsey R.
+preferred-citation:
+  type: conference-paper
+  title: "ClawBench: Can AI Agents Complete Everyday Online Tasks?"
+  authors:
+    - family-names: Zhang
+      given-names: Yuxuan
+    - family-names: Wang
+      given-names: Yubo
+    - family-names: Zhu
+      given-names: Yipeng
+    - family-names: Du
+      given-names: Penghui
+    - family-names: Miao
+      given-names: Junwen
+    - family-names: Lu
+      given-names: Xuan
+    - family-names: Xu
+      given-names: Wendong
+    - family-names: Hao
+      given-names: Yunzhuo
+    - family-names: Cai
+      given-names: Songcheng
+    - family-names: Wang
+      given-names: Xiaochen
+    - family-names: Zhang
+      given-names: Huaisong
+    - family-names: Wu
+      given-names: Xian
+    - family-names: Lu
+      given-names: Yi
+    - family-names: Lei
+      given-names: Minyi
+    - family-names: Zou
+      given-names: Kai
+    - family-names: Yin
+      given-names: Huifeng
+    - family-names: Nie
+      given-names: Ping
+    - family-names: Chen
+      given-names: Liang
+    - family-names: Jiang
+      given-names: Dongfu
+    - family-names: Chen
+      given-names: Wenhu
+    - family-names: Allen
+      given-names: Kelsey R.
+  collection-title: "Conference on Language Modeling (COLM)"
+  year: 2026

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to ClawBench
+
+Thanks for your interest in contributing! The most impactful way to contribute is by adding new test cases that expand ClawBench's coverage of real-world web tasks.
+
+## Adding a New Test Case
+
+1. **Pick a task ID** — find the next available number by checking existing directories in `test-cases/`.
+
+2. **Create the directory** following the naming convention:
+   ```
+   test-cases/<id>-<metaclass>-<class>-<platform>/
+   ```
+   Example: `test-cases/887-daily-life-food-grubhub/`
+
+3. **Create `task.json`** in the directory. It must conform to `test-cases/task.schema.json`:
+   ```json
+   {
+     "$schema": "../task.schema.json",
+     "metadata": {
+       "task_id": 887,
+       "metaclass": "daily-life",
+       "class": "food",
+       "description": "Order a burger on Grubhub",
+       "sites_involved": ["grubhub.com"],
+       "platform": "grubhub",
+       "common_info": {
+         "email_credentials": "credentials to use the assigned disposable email account",
+         "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+         "user_resume": "PDF resume with disposable email account injected"
+       }
+     },
+     "instruction": "On Grubhub, order delivery: one cheeseburger to home address",
+     "eval_schema": {
+       "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+       "method": "POST"
+     },
+     "time_limit": 30
+   }
+   ```
+
+4. **Set the eval_schema** — this tells the interceptor which HTTP request to block:
+   - If the task has an irreversible action (form submit, email send, application submit): set `url_pattern` to a regex matching the submission endpoint, and `method` to the HTTP method.
+   - If the task is behind a payment wall (agent has no valid credit card): use `"url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__"` — the interceptor will never fire and the session runs until timeout.
+   - See [test-driver/README.md](test-driver/README.md#eval_schema) for details on `body` and `params` filters.
+
+5. **Test with human mode** to verify the task is completable:
+   ```bash
+   uv run --project test-driver test-driver/run.py test-cases/887-daily-life-food-grubhub --human
+   ```
+
+6. **Submit a PR** with your new test case directory.
+
+## Extra Info Files
+
+If the task requires additional context (e.g., a pre-filled profile, a specific document), add files under `extra_info/` in the test case directory and reference them in `task.json`:
+
+```json
+"extra_info": [
+  {
+    "path": "extra_info/cover_letter.txt",
+    "description": "Cover letter to attach with the application"
+  }
+]
+```
+
+## Code Changes
+
+For changes to the framework itself (test driver, extension server, Chrome extension, container):
+
+1. Read the relevant sub-README for component-specific documentation:
+   - [test-driver/README.md](test-driver/README.md)
+   - [extension-server/README.md](extension-server/README.md)
+   - [chrome-extension/README.md](chrome-extension/README.md)
+2. Open a PR with a clear description of the change and how you tested it.
+
+## Reporting Issues
+
+Please use the [issue templates](https://github.com/reacher-z/ClawBench/issues/new/choose) to report bugs or propose new test cases.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,84 @@
 # ClawBench
 
+[![Paper](https://img.shields.io/badge/Paper-COLM_2026-red.svg)](https://claw-bench.com)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://python.org)
 [![Docker](https://img.shields.io/badge/docker-supported-blue.svg)](https://www.docker.com/)
 
-ClawBench is a benchmarking framework for evaluating web agents in real browser environments. It records user/agent interactions, HTTP requests, action screenshots, and full MP4 video recordings of each session.
+**ClawBench: Can AI Agents Complete Everyday Online Tasks?**
 
-Each test case runs in an isolated container (Docker or Podman) with a Chrome browser, a custom recording extension, and an AI agent. The framework captures everything the agent does and uses a request interceptor to detect task completion.
+A benchmark of **153 everyday online tasks** spanning **144 live websites** and **15 life categories** — from ordering food on Uber Eats to submitting job applications on Greenhouse. Unlike sandbox-based benchmarks, ClawBench evaluates agents on real production websites with full complexity: cookie consent popups, dynamic JavaScript rendering, CAPTCHAs, and multi-step interaction flows.
+
+- Tasks run on **live production websites**, not sandboxed clones
+- Each run is **fully isolated** in a Docker container with a real Chromium browser
+- A **request interceptor** blocks the final irreversible action (checkout, form submit, email send) to prevent real-world side effects
+- **Five-layer recording**: session replay (MP4), action screenshots, HTTP traffic, browser actions, agent messages
+
+## News
+
+- **2026-04** — Paper accepted at [COLM 2026](https://colmweb.org/)
+- **2026-04** — Initial open-source release (153 tasks, 144 platforms)
+
+## Results
+
+Success rate (%) of 6 frontier AI agents on ClawBench. Even the strongest model completes only 33.3% of tasks.
+
+| Rank | Model | Overall | Daily | Finance | Work | Dev | Academic | Travel | Social | Pets |
+|------|-------|---------|-------|---------|------|-----|----------|--------|--------|------|
+| 1 | Claude Sonnet 4.6 | **33.3** | 44.2 | **50.0** | 19.0 | 11.1 | **50.0** | 23.1 | **38.9** | **18.2** |
+| 2 | GLM-5 | 24.2 | **30.8** | 16.7 | **38.1** | 16.7 | 28.6 | 0.0 | 16.7 | **18.2** |
+| 3 | Gemini 3 Flash | 19.0 | 15.4 | 33.3 | 23.8 | **22.2** | 28.6 | **30.8** | 11.1 | 0.0 |
+| 4 | Claude Haiku 4.5 | 18.3 | 15.4 | 22.2 | 19.0 | **27.8** | 21.4 | 7.7 | 16.7 | **18.2** |
+| 5 | GPT-5.4 | 6.5 | 9.6 | 0.0 | 0.0 | 11.1 | 7.1 | 7.7 | 0.0 | 9.1 |
+| 6 | Gemini 3.1 Flash Lite | 3.3 | 1.9 | 0.0 | 0.0 | 5.6 | 14.3 | 0.0 | 0.0 | 9.1 |
+
+<details>
+<summary><b>Task Categories (15 categories, 153 tasks)</b></summary>
+
+| Category | Tasks | Example Platforms |
+|----------|-------|-------------------|
+| Daily Life | 21 | Uber Eats, DoorDash, Instacart, Zillow, Craigslist |
+| Entertainment & Hobbies | 15 | Ticketmaster, AMC Theatres, Topgolf, Crunchyroll |
+| Creation & Initialization | 13 | Squarespace, Wix, Webflow, Ghost, Substack |
+| Rating & Voting | 10 | Trustpilot, G2, Goodreads, RateMyProfessors |
+| Travel | 9 | Booking.com, Expedia, Airbnb, TripAdvisor |
+| Education & Learning | 9 | Coursera, Udemy, Khan Academy, Duolingo |
+| Office & Secretary | 9 | Google Calendar, Slack, Notion, Trello |
+| Beauty & Personal Care | 9 | Sephora, Ulta, Glossier |
+| Job Search & HR | 8 | LinkedIn, Greenhouse, Lever, Workday |
+| Pet & Animal Care | 8 | Chewy, Petco, Rover |
+| Personal Management | 6 | Mint, YNAB, Todoist |
+| Shopping & Commerce | 6 | Amazon, eBay, Etsy, Target |
+| Nonprofit & Charity | 6 | GoFundMe, DonorsChoose |
+| Academia & Research | 5 | Google Scholar, Semantic Scholar, OpenReview |
+| Finance & Investment | 4 | Robinhood, Fidelity, Coinbase |
+| Others | 15 | Automation, Dev & Tech, Government, Home Services, Automotive |
+
+</details>
 
 ## Table of Contents
 
-- [Dependencies](#dependencies)
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
 - [Data Output](#data-output)
 - [Building the Container](#building-the-container)
+- [Test Driver](#test-driver)
+- [Human Mode](#human-mode)
+- [Contributing](#contributing)
+- [Citation](#citation)
+- [License](#license)
+- [Acknowledgments](#acknowledgments)
+
+<details>
+<summary><b>Implementation Details</b></summary>
+
 - [API Endpoints](#api-endpoints)
 - [OpenClaw Agent Integration](#openclaw-agent-integration)
 - [Synthetic User Profile](#synthetic-user-profile)
 - [Tool Restrictions](#tool-restrictions)
 - [Request Interceptor](#request-interceptor)
-- [Test Driver](#test-driver)
-- [Human Mode](#human-mode)
-- [License](#license)
-- [Acknowledgments](#acknowledgments)
+
+</details>
 
 ## Dependencies
 
@@ -366,6 +421,24 @@ The session stops when any of these happen:
 - **Time limit** — the configured time limit expires
 
 After the session ends, results are collected in the same format as agent runs (actions, screenshots, recording, interception).
+
+## Contributing
+
+We welcome contributions — especially new test cases that expand ClawBench's coverage. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding test cases, setting up eval schemas, and submitting PRs.
+
+## Citation
+
+If you use ClawBench in your research, please cite:
+
+```bibtex
+@inproceedings{zhang2026clawbench,
+  title     = {ClawBench: Can AI Agents Complete Everyday Online Tasks?},
+  author    = {Yuxuan Zhang and Yubo Wang and Yipeng Zhu and Penghui Du and Junwen Miao and Xuan Lu and Wendong Xu and Yunzhuo Hao and Songcheng Cai and Xiaochen Wang and Huaisong Zhang and Xian Wu and Yi Lu and Minyi Lei and Kai Zou and Huifeng Yin and Ping Nie and Liang Chen and Dongfu Jiang and Wenhu Chen and Kelsey R. Allen},
+  booktitle = {Conference on Language Modeling (COLM)},
+  year      = {2026},
+  url       = {https://claw-bench.com}
+}
+```
 
 ## License
 


### PR DESCRIPTION
## Summary

- **README**: Add paper badge (COLM 2026), concrete project description (153 tasks, 144 platforms, 15 categories), News section, Results table with 6 frontier models, collapsible Task Categories table, Citation with BibTeX, Contributing link, simplified TOC with implementation details collapsed
- **CITATION.cff**: Enable GitHub's "Cite this repository" button with full 21-author list
- **CONTRIBUTING.md**: Step-by-step guide for adding new test cases (directory naming, task.json schema, eval_schema, human mode testing)
- **Issue templates**: Bug report form and new test case proposal form (YAML-based GitHub forms)
- **PR template**: Lightweight template (what/test plan/related issues)
- **CI**: `validate-tasks.yml` workflow that validates all `task.json` files against `task.schema.json` on PRs

## Test plan

- [x] All 153 task.json files validate successfully
- [x] CITATION.cff is valid YAML
- [x] README renders correctly with badges, tables, and collapsible sections
- [x] No overlap with PR #5 or PR #6