### PR TITLE
Add ClawBench-Lite intro section to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ The TUI guides you through model selection, test case picking, and run mode (sin
 
 <br/>
 
+# <img src="static/icons/chart-bar.svg" width="28" height="28"> ClawBench-Lite
+
+**New here? Run this first.** [`test-cases/lite.json`](test-cases/lite.json) is a **20-task curated subset** of the full 153, selected for household-name sites, real-world relevance, difficulty, and category diversity. It matches the 20-tasks-per-source convention of [browser-use/benchmark](https://github.com/browser-use/benchmark) and gives you a credible signal at a fraction of the full-benchmark cost.
+
+Tier distribution: **flagship 9 / core 8 / wildcard 3** — spanning daily life (OpenTable, DoorDash, Instacart, TaskRabbit), entertainment (Eventbrite, Goodreads, Fandango), creation (Asana, Mailchimp, Squarespace), travel (Airbnb), education (LeetCode), dev-tech (GitHub), academia (Overleaf), personal management (1Password), and more. All Lite tasks are judged by [`eval/agentic_eval.md`](eval/agentic_eval.md) regardless of `url_pattern` shape.
+
+See [`test-cases/lite.schema.json`](test-cases/lite.schema.json) for the manifest shape and the `notes` field in `lite.json` for the 4-axis selection rubric + full swap history.
+
+<br/>
+
 # <img src="static/icons/video.svg" width="28" height="28"> Tutorial
 
 <div align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,6 +93,16 @@ TUI 会引导你完成模型选择、测试用例选取和运行模式 (单次 /
 
 <br/>
 
+# <img src="static/icons/chart-bar.svg" width="28" height="28"> ClawBench-Lite
+
+**第一次跑？先跑这个。** [`test-cases/lite.json`](test-cases/lite.json) 是完整 153 任务的 **20 个精选子集**，按站点知名度、真实日常相关度、难度和类别多样性挑选。它对齐了 [browser-use/benchmark](https://github.com/browser-use/benchmark) 的 20-tasks-per-source 规范，用完整 benchmark 一小部分的成本就能拿到可信的信号。
+
+分层: **flagship 9 / core 8 / wildcard 3** —— 覆盖日常生活 (OpenTable, DoorDash, Instacart, TaskRabbit)、娱乐爱好 (Eventbrite, Goodreads, Fandango)、创建初始化 (Asana, Mailchimp, Squarespace)、旅行 (Airbnb)、教育 (LeetCode)、开发技术 (GitHub)、学术研究 (Overleaf)、个人管理 (1Password) 等类别。所有 Lite 任务均由 [`eval/agentic_eval.md`](eval/agentic_eval.md) 判定，不依赖 `url_pattern` 形态。
+
+完整 manifest 格式见 [`test-cases/lite.schema.json`](test-cases/lite.schema.json)；4 轴选择 rubric 与完整 swap history 见 `lite.json` 的 `notes` 字段。
+
+<br/>
+
 # <img src="static/icons/video.svg" width="28" height="28"> 教程
 
 <div align="center">


### PR DESCRIPTION
## Summary
- Adds a short "run this first" ClawBench-Lite section to both `README.md` and `README.zh-CN.md`, positioned between Human Quick Start and Tutorial.
- Links to `test-cases/lite.json` (merged in #27) and `test-cases/lite.schema.json`, with a one-paragraph tier-distribution summary and pointers to the 4-axis selection rubric.
- Positions Lite as the fast-baseline entry point for new evaluators; full 153-task benchmark remains the default path.

## Context
This is a follow-up to #27 which merged the Lite v0.1 manifest. That PR added `test-cases/lite.json` and `test-cases/lite.schema.json` but did not surface Lite in the README. This PR closes that gap so first-time users see Lite as the recommended starting point.

## Test plan
- [x] `git diff` shows only the two README sections added (20 lines total)
- [x] Section uses the same `chart-bar.svg` icon + `<br/>` spacer style as surrounding sections
- [x] Chinese translation mirrors the English structure and link set
- [x] Links (`test-cases/lite.json`, `test-cases/lite.schema.json`, `eval/agentic_eval.md`, browser-use/benchmark) all resolve on `main` after #27 merged