### PR TITLE
test-driver: record task.json sha256 in run-meta.json (#28)

### DIFF
--- a/test-driver/run.py
+++ b/test-driver/run.py
@@ -1,6 +1,7 @@
 """ClawBench single test-case driver."""
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -456,7 +457,9 @@ def main():
     if not task_file.exists():
         print(f"ERROR: {task_file} not found")
         sys.exit(1)
-    task = json.loads(task_file.read_text())
+    task_bytes = task_file.read_bytes()
+    task = json.loads(task_bytes)
+    task_json_sha256 = hashlib.sha256(task_bytes).hexdigest()
 
     case_name = task_dir.name
     time_limit_s = task["time_limit"] * 60
@@ -552,6 +555,7 @@ def main():
             meta = {
                 "test_case": case_name,
                 **(task.get("metadata") or {}),
+                "task_json_sha256": task_json_sha256,
                 "instruction": task["instruction"],
                 "model": "human",
                 "thinking_level": None,
@@ -568,6 +572,7 @@ def main():
             meta = {
                 "test_case": case_name,
                 **(task.get("metadata") or {}),
+                "task_json_sha256": task_json_sha256,
                 "instruction": task["instruction"],
                 "model": model_cfg["model"],
                 "thinking_level": model_cfg.get("thinking_level"),


### PR DESCRIPTION
## Summary
Addresses direction 1 of #28 — the smallest fix for cross-version verdict reproducibility.

- `test-driver/run.py` now reads `task.json` as bytes, computes `sha256`, and writes the hex digest into `run-meta.json` under `task_json_sha256`.
- Both the human mode and the model-run mode write this field.
- Adds `import hashlib`. No other changes.

## Why

Problem described in #28: given an old recorded run in `data_new/`, there's no way to tell from the on-disk evidence alone whether its pass/fail verdict was computed against the current `task.json` or an older, looser version. Discovered while validating ClawBench-Lite v0.1 on Zillow `011`, where the 2026-03-27 recording carries an older `eval_schema` than the current `task.json` without any recorded hint.

With this change, an auditor can compute `sha256` of the current `task.json` and compare it to `run-meta.json.task_json_sha256` to know immediately whether a re-score is needed.

## What this does NOT do

- No `version` field on `task.schema.json` (direction 2 in #28).
- No `data/task-snapshot.json` per run (direction 3).
- No retroactive re-scoring of existing `data_new/` runs.

Those can follow once this smaller change has been in the wild for a while.

## Test plan
- [x] `python3 -c \"import ast; ast.parse(...)\"` confirms `run.py` still parses.
- [x] Hash computation verified on a real `task.json` (`test-cases/007-daily-life-food-instacart/task.json` → `24dc9973…`).
- [ ] Next full docker run will produce a `run-meta.json` with `task_json_sha256` populated.

Closes #28