### PR TITLE
README: one-liner clone+run under Human Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Point your coding agent (Claude Code, Cursor, Copilot, etc.) at [`AGENTS.md`](AG
 
 # <img src="static/icons/person.svg" width="28" height="28"> Human Quick Start
 
+```bash
+git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
+```
+
 **Prerequisites:** [Python 3.11+](https://python.org), [uv](https://docs.astral.sh/uv/), and a container engine — [Docker](https://www.docker.com/) **or** [Podman](https://podman.io/). ClawBench auto-detects whichever is installed; force one with `export CONTAINER_ENGINE=docker` or `export CONTAINER_ENGINE=podman`.
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,6 +60,10 @@
 
 # <img src="static/icons/person.svg" width="28" height="28"> 手动快速开始
 
+```bash
+git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
+```
+
 **前置条件:** [Python 3.11+](https://python.org)、[uv](https://docs.astral.sh/uv/)，以及一个容器引擎 —— [Docker](https://www.docker.com/) **或** [Podman](https://podman.io/)。ClawBench 会自动检测已安装的那个；也可以用 `export CONTAINER_ENGINE=docker` 或 `export CONTAINER_ENGINE=podman` 强制指定。
 
 <details>


### PR DESCRIPTION
## Summary

- Add `git clone && cd && ./run.sh` one-liner right below the Human Quick Start heading for quick copy-paste