### PR TITLE
README: remove middot separators from feature row

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ order food, book travel, apply for jobs, write reviews, manage projects.<br/>
 
 <p align="center">
 <img src="static/icons/globe.svg" width="24" height="24">&nbsp;<b>Live Websites</b>
-&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="static/icons/cube.svg" width="24" height="24">&nbsp;<b>Isolated Containers</b>
-&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="static/icons/shield-halved.svg" width="24" height="24">&nbsp;<b>Request Interceptor</b>
-&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="static/icons/layer-group.svg" width="24" height="24">&nbsp;<b>Five-Layer Recording</b>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,11 +26,11 @@
 
 <p align="center">
 <img src="static/icons/globe.svg" width="24" height="24">&nbsp;<b>真实网站</b>
-&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="static/icons/cube.svg" width="24" height="24">&nbsp;<b>隔离容器</b>
-&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="static/icons/shield-halved.svg" width="24" height="24">&nbsp;<b>请求拦截器</b>
-&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="static/icons/layer-group.svg" width="24" height="24">&nbsp;<b>五层录制</b>
 </p>
 


### PR DESCRIPTION
Drop the `&middot;` dots between the four feature labels (Live Websites / Isolated Containers / Request Interceptor / Five-Layer Recording) and replace them with wider whitespace. Applied to both README.md and README.zh-CN.md.