### PR TITLE
README: richer hero, publicity badges, star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Project Page](https://img.shields.io/badge/Project-Page-blue.svg)](https://claw-bench.com)
 [![GitHub stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)](https://github.com/reacher-z/ClawBench)
 
+**⚡ Run in one line of code**
+
 ### Can AI Agents Complete Everyday Online Tasks?
 
 We asked 6 frontier AI agents to do what people do every day --<br/>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Project Page](https://img.shields.io/badge/Project-Page-blue.svg)](https://claw-bench.com)
 [![GitHub stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)](https://github.com/reacher-z/ClawBench)
 
-**⚡ Run in one line of code**
+<a href="#-human-quick-start"><img src="https://img.shields.io/badge/%E2%9A%A1%20Run%20in%20one%20line%20of%20code-4F46E5?style=for-the-badge&labelColor=4F46E5" alt="Run in one line of code"></a>
 
 ### Can AI Agents Complete Everyday Online Tasks?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,8 @@
 [![Project Page](https://img.shields.io/badge/Project-Page-blue.svg)](https://claw-bench.com)
 [![GitHub stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)](https://github.com/reacher-z/ClawBench)
 
+**⚡ 一键启动**
+
 ### AI 智能体能完成日常在线任务吗?
 
 我们让 6 个前沿 AI 智能体去做人们每天都在做的事 --<br/>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 [![Project Page](https://img.shields.io/badge/Project-Page-blue.svg)](https://claw-bench.com)
 [![GitHub stars](https://img.shields.io/github/stars/reacher-z/ClawBench?style=social)](https://github.com/reacher-z/ClawBench)
 
-**⚡ 一键启动**
+<a href="#-手动快速开始"><img src="https://img.shields.io/badge/%E2%9A%A1%20%E4%B8%80%E9%94%AE%E5%90%AF%E5%8A%A8-4F46E5?style=for-the-badge&labelColor=4F46E5" alt="一键启动"></a>
 
 ### AI 智能体能完成日常在线任务吗?
 


### PR DESCRIPTION
## Summary
- **Top badges** get icons and brand colors: arXiv (red), HF Daily Paper + HF Dataset (yellow), claw-bench.com Project Page (indigo), GitHub Stars (github logo, shorter cache). Adds publicity links to HF Paper and HF Dataset.
- **One-line-of-code callout** gets a FontAwesome *wand-magic-sparkles* icon (embedded as a data-URI logo) in place of the plain lightning glyph.
- **Ease-of-use subline** under the callout: *Clone → Run → Done. No API keys. No dataset download. No manual setup.* (parallel in Chinese.)
- **Flow diagram** fixed in both READMEs: tightened last-box phrasing (Chinese: 五层数据 / 全部拦截 / 完整录制; English: 5 layers / intercepted / & recorded) and corrected a width-off-by-one on the first box.
- **Star History** section added above License, using star-history.com with dark-mode support.

## Test plan
- [ ] Verify each top badge renders with its logo at right color on both READMEs
- [ ] Verify the wand icon shows up inside the indigo one-line-of-code badge
- [ ] Verify ASCII flow diagram columns align in rendered monospace
- [ ] Verify star-history chart loads and shows real data