### PR TITLE
README: add one-line clone+run command under hero tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 <sub><i>Clone → Run → Done. &nbsp; No API keys. &nbsp; No dataset download. &nbsp; No manual setup.</i></sub>
 
+```bash
+git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
+```
+
 ### Can AI Agents Complete Everyday Online Tasks?
 
 We asked 6 frontier AI agents to do what people do every day --<br/>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,10 @@
 
 <sub><i>克隆 → 运行 → 搞定。&nbsp; 无需 API key。&nbsp; 无需下载数据集。&nbsp; 无需手动配置。</i></sub>
 
+```bash
+git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
+```
+
 ### AI 智能体能完成日常在线任务吗?
 
 我们让 6 个前沿 AI 智能体去做人们每天都在做的事 --<br/>


### PR DESCRIPTION
## Summary

Adds the actual one-liner under the "Clone → Run → Done" subline so visitors can literally see the command to copy:

\`\`\`bash
git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
\`\`\`

Applied to both README.md and README.zh-CN.md.

## Note

Stacked on top of #41 (base = \`readme-hero-badges\`). Merge after #41 lands, or GitHub will auto-retarget base to \`main\`.

## Test plan

- [ ] Render both READMEs on GitHub and confirm the bash code block appears directly under the Clone/Run/Done tagline.
- [ ] Confirm the command copies cleanly (no stray characters).