### PR TITLE
README: surface both install paths in Human Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,16 @@ Point your coding agent (Claude Code, Cursor, Copilot, etc.) at [`AGENTS.md`](AG
 
 # <img src="static/icons/person.svg" width="28" height="28"> Human Quick Start
 
+Pick either path — both land you at the same interactive TUI.
+
 ```bash
+# Option A — PyPI install (recommended for most users)
 uv tool install clawbench-eval && clawbench
+```
+
+```bash
+# Option B — Clone the repo (for contributors / source hacking)
+git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
 ```
 
 **Prerequisites:** [Python 3.11+](https://python.org), [uv](https://docs.astral.sh/uv/), and a container engine — [Docker](https://www.docker.com/) **or** [Podman](https://podman.io/). ClawBench auto-detects whichever is installed; force one with `export CONTAINER_ENGINE=docker` or `export CONTAINER_ENGINE=podman`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,8 +68,16 @@ uv tool install clawbench-eval && clawbench
 
 # <img src="static/icons/person.svg" width="28" height="28"> 手动快速开始
 
+两条路任选一条 —— 最终都会打开同一个交互式 TUI。
+
 ```bash
+# 方案 A —— 从 PyPI 安装（推荐大多数用户）
 uv tool install clawbench-eval && clawbench
+```
+
+```bash
+# 方案 B —— 克隆仓库（适合贡献者 / 改代码）
+git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
 ```
 
 **前置条件:** [Python 3.11+](https://python.org)、[uv](https://docs.astral.sh/uv/)，以及一个容器引擎 —— [Docker](https://www.docker.com/) **或** [Podman](https://podman.io/)。ClawBench 会自动检测已安装的那个；也可以用 `export CONTAINER_ENGINE=docker` 或 `export CONTAINER_ENGINE=podman` 强制指定。


### PR DESCRIPTION
## Summary

Show Option A (\`uv tool install clawbench-eval\`) and Option B (\`git clone + ./run.sh\`) side-by-side at the top of Human Quick Start, so contributors don't have to expand a details block to find the source path. Option A is still labeled as recommended.

Mirrored the same change in the Chinese README.

## Test plan
- [x] Verified the two code blocks render cleanly on GitHub preview
- [x] \`README.zh-CN.md\` mirrors the English structure