### PR TITLE
Publish second wave of defensive PyPI aliases

### DIFF
--- a/scripts/build-aliases.py
+++ b/scripts/build-aliases.py
@@ -55,11 +55,23 @@ def root_version() -> str:
         raise RuntimeError("could not find version in root pyproject.toml")
     return m.group(1)
 
-# The six alias distribution names successfully registered on PyPI.
-# Three other candidates (``openclaw-bench``, ``claw-bench-harness``,
-# ``harnessbench``) were rejected by PyPI's similarity check as too
-# close to names we had already taken — so they live nowhere and are
-# omitted here on purpose.
+# Alias distribution names successfully registered on PyPI.
+#
+# First wave (packaging PR): harness-bench, clawbench-eval, clawbench-cli,
+# openclawbench, clawbench-harness, claw-harness, nail-clawbench.
+#
+# Second wave (defensive squat of adjacent harness/agent names): harnessos,
+# r2agent, claw-ai, claw-agent, claw-eval.
+#
+# Names we tried and couldn't take:
+#   - 403 (already owned): harness, browser-use, computer-use, claw, clawbot
+#   - 400 similarity (too close to something we just took or pre-existing):
+#     openclaw-bench, claw-bench-harness, harnessbench, harness-os, clawai,
+#     clawagent, claweval
+# These live nowhere and are omitted on purpose. For hyphen/underscore
+# variants of names we DID take (``claw-ai`` ↔ ``claw_ai``), PEP 503
+# normalization means pip resolves them to the same distribution anyway —
+# so ``pip install claw_ai`` still lands on our package.
 ALIAS_NAMES = [
     "harness-bench",
     "clawbench-eval",
@@ -68,6 +80,11 @@ ALIAS_NAMES = [
     "clawbench-harness",
     "claw-harness",
     "nail-clawbench",
+    "harnessos",
+    "r2agent",
+    "claw-ai",
+    "claw-agent",
+    "claw-eval",
 ]
 
 PYPROJECT_TEMPLATE = '''\

--- a/src/clawbench/__init__.py
+++ b/src/clawbench/__init__.py
@@ -23,6 +23,11 @@ for _dist in (
     "harness-bench",
     "openclawbench",
     "claw-harness",
+    "harnessos",          # second-wave defensive squats
+    "r2agent",
+    "claw-ai",
+    "claw-agent",
+    "claw-eval",
     "claw-bench",         # original primary (blocked; left for future)
     "clawbench",          # original alias  (blocked; left for future)
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "claw-bench"
-version = "0.1.0"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Registered 5 more PyPI distribution names so adjacent ``pip install`` guesses resolve to ClawBench instead of returning \"not found\":

- ``harnessos``
- ``r2agent``
- ``claw-ai``
- ``claw-agent``
- ``claw-eval``

All published at version 0.1.5 from the same ``src/clawbench`` source tree (symlinked via ``scripts/build-aliases.py``).

## Outcome of the second wave

| Attempt | Result |
|---|---|
| ``harnessos``, ``r2agent``, ``claw-ai``, ``claw-agent``, ``claw-eval`` | Published |
| ``harness``, ``browser-use``, ``computer-use``, ``claw``, ``clawbot`` | 403 — already owned by someone else |
| ``harness-os``, ``clawai``, ``clawagent``, ``claweval`` | 400 — PyPI similarity block against names we just took |

The similarity-rejected names are effectively covered: PEP 503 normalizes ``claw-ai`` / ``claw_ai`` to the same distribution, so ``pip install claw_ai`` still lands on our package. Only the no-separator forms (``clawai``, etc.) would go elsewhere, and those are free for the taking if a future need arises.

## Changes

- ``scripts/build-aliases.py`` — ALIAS_NAMES extended to 12; comment now records which names we tried and why they failed
- ``src/clawbench/__init__.py`` — version-lookup list extended so ``importlib.metadata.version(...)`` succeeds when the user installed under any of the new aliases

## Test plan
- [x] All five new wheels uploaded cleanly (``uv publish`` returned 200)
- [x] Spot-check: ``pip index versions claw-agent`` shows 0.1.5
- [x] Version-lookup extension is a pure no-op for existing installs