### PR TITLE
Align PyPI name to clawbench-eval across pyproject and source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.25"]
 build-backend = "hatchling.build"
 
 [project]
-name = "claw-bench"
+name = "clawbench-eval"
 version = "0.1.5"
 description = "ClawBench: Can AI Agents Complete Everyday Online Tasks?"
 readme = "README.md"
@@ -54,12 +54,12 @@ dev = [
 ]
 
 [project.scripts]
-# The hyphenated form is canonical; ``clawbench`` and ``clawbench-eval``
-# are aliases so users who remember the PyPI name they installed under
-# can just type that as the command.
-claw-bench = "clawbench.cli:main"
+# ``clawbench`` is the primary command; ``clawbench-eval`` and
+# ``claw-bench`` are aliases so users who remember the PyPI name they
+# installed under can just type that as the command.
 clawbench = "clawbench.cli:main"
 clawbench-eval = "clawbench.cli:main"
+claw-bench = "clawbench.cli:main"
 
 [project.urls]
 Homepage = "https://claw-bench.com"

--- a/src/clawbench/batch.py
+++ b/src/clawbench/batch.py
@@ -502,7 +502,7 @@ async def async_main(args: argparse.Namespace) -> int:
     # builds show a clear "~2GB, 5–10min" banner and live step counter instead
     # of a wall of apt/npm output.
     engine = detect_engine()
-    # Ensure child `claw-bench run` processes (and the imported helper below)
+    # Ensure child `clawbench run` processes (and the imported helper below)
     # use the same engine as we just detected.
     os.environ["CONTAINER_ENGINE"] = engine
     from clawbench import run as _run_mod  # lazy: import after CONTAINER_ENGINE is set

--- a/src/clawbench/cli.py
+++ b/src/clawbench/cli.py
@@ -1,10 +1,10 @@
-"""``claw-bench`` command-line entry point (click-based).
+"""``clawbench`` command-line entry point (click-based).
 
 Design notes:
 
-- Bare ``claw-bench`` launches the TUI. This preserves muscle memory from
+- Bare ``clawbench`` launches the TUI. This preserves muscle memory from
   the old ``./run.sh`` and keeps the zero-friction experience for users
-  who just typed ``pip install claw-bench`` and hit enter.
+  who just typed ``uv tool install clawbench-eval`` and hit enter.
 - Every power-user action has an explicit subcommand so scripts don't
   need to navigate a menu (``run``, ``batch``, ``build``, ``cases``,
   ``models``, ``configure``, ``doctor``, ``version``).
@@ -58,13 +58,13 @@ def _echo_result(r: _doctor.CheckResult) -> None:
     invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-@click.version_option(__version__, "-V", "--version", prog_name="claw-bench")
+@click.version_option(__version__, "-V", "--version", prog_name="clawbench")
 @click.pass_context
 def main(ctx: click.Context) -> None:
     """ClawBench — benchmark AI agents on 153 everyday web tasks.
 
     Run without a subcommand to launch the interactive TUI. Use
-    ``claw-bench run``, ``batch``, ``build``, ``doctor``, etc. for
+    ``clawbench run``, ``batch``, ``build``, ``doctor``, etc. for
     scripting.
     """
     if ctx.invoked_subcommand is None:
@@ -287,7 +287,7 @@ def models_cmd() -> None:
         click.echo(f"ERROR: cannot read {path}: {e}", err=True)
         sys.exit(1)
     if not data:
-        click.echo(f"No models configured. Edit {path} or run `claw-bench configure`.")
+        click.echo(f"No models configured. Edit {path} or run `clawbench configure`.")
         return
     click.echo(f"Models configured in {path}:")
     for name in sorted(data):
@@ -373,7 +373,7 @@ def _write_secrets_interactive() -> None:
             # future default-rotations.
             updated[key] = default
 
-    lines = ["# claw-bench secrets — chmod 600", ""]
+    lines = ["# clawbench secrets — chmod 600", ""]
     lines += [f'{k}="{v}"' for k, v in updated.items()]
     target.write_text("\n".join(lines) + "\n", encoding="utf-8")
     try:
@@ -396,7 +396,7 @@ def _redact(v: str) -> str:
 @main.command("doctor")
 def doctor_cmd() -> None:
     """Validate engine, image, test-cases, output perms, and secrets."""
-    click.echo("claw-bench diagnostics\n")
+    click.echo("clawbench diagnostics\n")
     results = _doctor.run_all()
     for r in results:
         _echo_result(r)

--- a/src/clawbench/doctor.py
+++ b/src/clawbench/doctor.py
@@ -1,10 +1,10 @@
-"""``claw-bench doctor`` — diagnostic checks for a ClawBench install.
+"""``clawbench doctor`` — diagnostic checks for a ClawBench install.
 
 Every check is a callable that returns a :class:`CheckResult`. The CLI
 layer is responsible for rendering; this module just reports facts.
 
 Split out from the TUI's inline engine probe so we can run the same
-checks from CI, from ``claw-bench doctor``, and from inside the TUI
+checks from CI, from ``clawbench doctor``, and from inside the TUI
 "fix this for me" flow without duplicating code.
 """
 
@@ -63,7 +63,7 @@ def check_image() -> CheckResult:
             "container image",
             "warn",
             f"'{_image.IMAGE_NAME}' not present",
-            "Run `claw-bench build` (or let `claw-bench run` pull on first use).",
+            "Run `clawbench build` (or let `clawbench run` pull on first use).",
         )
     ok, msg = _image.verify_image_version(eng)
     if ok:
@@ -94,7 +94,7 @@ def check_models_yaml() -> CheckResult:
             "models.yaml",
             "warn",
             "not yet created",
-            "Run `claw-bench configure` to seed from the bundled template.",
+            "Run `clawbench configure` to seed from the bundled template.",
         )
     try:
         import yaml
@@ -107,7 +107,7 @@ def check_models_yaml() -> CheckResult:
             "models.yaml",
             "warn",
             f"{dst} is empty — no models configured",
-            "Edit the file (`claw-bench configure`) and add at least one model.",
+            "Edit the file (`clawbench configure`) and add at least one model.",
         )
     return CheckResult("models.yaml", "ok", f"{count} model(s) configured")
 

--- a/src/clawbench/image.py
+++ b/src/clawbench/image.py
@@ -8,7 +8,7 @@ build when pull fails (offline, rate-limited, arch mismatch).
 Why pull-first, build-fallback:
 
 - A first-time ``docker build`` takes 5-10 minutes on a fresh system.
-  For users who just typed ``pip install claw-bench``, that is an awful
+  For users who just typed ``uv tool install clawbench-eval``, that is an awful
   first impression. A prebuilt image on GHCR is an order of magnitude
   faster and already exists on the release pipeline.
 - But pulls can fail in ways builds cannot (behind an enterprise proxy,
@@ -123,5 +123,5 @@ def verify_image_version(engine: str | None = None) -> tuple[bool, str]:
         return True, ""
     return False, (
         f"image version label '{label}' != package version '{__version__}'. "
-        f"Consider `claw-bench build --no-cache` to rebuild."
+        f"Consider `clawbench build --no-cache` to rebuild."
     )

--- a/src/clawbench/run.py
+++ b/src/clawbench/run.py
@@ -100,12 +100,12 @@ def _load_runtime_env() -> dict[str, str]:
     1. ``os.environ`` — normal env vars (highest priority).
     2. ``$CWD/.env`` — legacy source-install layout (if present).
     3. ``user_config_dir()/secrets.env`` — persisted secrets from
-       ``claw-bench configure --secrets``.
+       ``clawbench configure --secrets``.
     4. :data:`DEFAULT_SECRETS` — wheel-shipped defaults for the
        PurelyMail credentials so a fresh install works immediately.
 
     Earlier sources win; later sources fill in missing keys only. This lets
-    ``PURELY_MAIL_API_KEY=... claw-bench run ...`` work without any config
+    ``PURELY_MAIL_API_KEY=... clawbench run ...`` work without any config
     file, while still picking up a persisted key for users who prefer one.
     """
     merged: dict[str, str] = {}
@@ -820,7 +820,7 @@ def main(argv: list[str] | None = None) -> None:
     if missing:
         for k in missing:
             print(f"ERROR: {k} not set (checked env, ./.env, and {_paths.user_secrets_path()})")
-        print("  Tip: run `claw-bench configure --secrets` to persist these keys")
+        print("  Tip: run `clawbench configure --secrets` to persist these keys")
         sys.exit(1)
     pm_key: str = env["PURELY_MAIL_API_KEY"]
     pm_domain: str = env["PURELY_MAIL_DOMAIN"]

--- a/src/clawbench/tui.py
+++ b/src/clawbench/tui.py
@@ -923,17 +923,17 @@ def _require_tty() -> None:
     console.print("  For non-interactive use, call the CLI directly:")
     console.print()
     console.print(
-        f"    [{ACCENT2}]claw-bench run[/] "
+        f"    [{ACCENT2}]clawbench run[/] "
         f"[{ACCENT2}]001-daily-life-food-uber-eats claude-sonnet-4-6[/]"
     )
     console.print()
     console.print(
-        f"    [{ACCENT2}]claw-bench batch[/] "
+        f"    [{ACCENT2}]clawbench batch[/] "
         f"[{ACCENT2}]--all-models --case-range 1-50 --max-concurrent 3[/]"
     )
     console.print()
     console.print(
-        f"  See [{ACCENT2}]claw-bench --help[/] for full CLI usage."
+        f"  See [{ACCENT2}]clawbench --help[/] for full CLI usage."
     )
     console.print()
     sys.exit(1)
@@ -1297,7 +1297,7 @@ def _fix_engine(engine: str, status: str, detail: str) -> bool:
             console.print()
             console.print(
                 "  [yellow]Install finished, but the engine isn't on "
-                "PATH yet.[/] Open a new terminal and re-run ``claw-bench``."
+                "PATH yet.[/] Open a new terminal and re-run ``clawbench``."
             )
             console.print()
             return False


### PR DESCRIPTION
## Why

The root `pyproject.toml` still had `name = \"claw-bench\"`, but that distribution name is owned by an unrelated PyPI project (as `src/clawbench/__init__.py` already acknowledges in its alias-fallback chain). The README Quick Start, every alias README, and all outreach docs tell users to run `uv tool install clawbench-eval` — so the root wheel needs to publish under that name to match.

While aligning, also swap every user-facing `claw-bench` CLI reference in help text and runtime messages to `clawbench` (the primary command name in the README hero). Both binaries remain registered in `[project.scripts]`, so muscle memory for `claw-bench` still works; this is purely a consistency pass on what users see in `--help`, doctor output, TUI hints, and inline tips.

## What

- `pyproject.toml` → `name = \"clawbench-eval\"`; reorder script aliases so `clawbench` is first
- `src/clawbench/cli.py` → docstring, \`--version\` prog_name, runtime messages
- `src/clawbench/image.py` → docstring + rebuild hint
- `src/clawbench/run.py` → docstrings + \`configure --secrets\` tip
- `src/clawbench/batch.py` → comment
- `src/clawbench/tui.py` → headless-mode CLI examples, engine-install hint
- `src/clawbench/doctor.py` → module docstring + all check hints

## Intentionally not changed

- `paths._APP_NAME = \"claw-bench\"` — renaming would orphan any existing user configs in `~/.config/claw-bench`. Change with a migration path in a later release.
- `REGISTRY_REF = \"ghcr.io/reacher-z/claw-bench\"` in `image.py` — the GHCR image tag is a separate decision. Change when the release workflow re-publishes under a new path.
- `[project.scripts] claw-bench = ...` alias — kept so users who install under any historical name can still type \`claw-bench\` as the command.

## Test plan

- [ ] \`uv build\` produces a wheel named \`clawbench_eval-0.1.5-*.whl\`
- [ ] \`pip install dist/clawbench_eval-*.whl\` into a fresh venv; \`clawbench --help\` renders without \`claw-bench\` mentions
- [ ] \`clawbench doctor\` output uses \`clawbench\` in every hint
- [ ] \`clawbench --version\` prints \`clawbench, version X.Y.Z\`