### PR TITLE
Add press-kit: 22-venue distribution pack with paste-ready pitch variants

### DIFF
--- a/docs/launch-playbook.md
+++ b/docs/launch-playbook.md
@@ -43,14 +43,14 @@ Treat this as a checklist to copy-paste from, not prose to read.
 
 ## HN post draft
 
-**Title:** Show HN: ClawBench – 153 everyday web tasks even GPT-5 fails
+**Title:** Show HN: ClawBench – 153 everyday web tasks even frontier agents fail
 
 **Body:**
 
-> We ran GPT-5, Claude Opus 4.6, Gemini, and three others against 153
-> real-world web tasks - ordering food on Uber Eats, booking on Calendly,
-> filling out Indeed applications, etc. The best one passed 62%. Several
-> frontier models sit under 40%.
+> We ran 7 frontier models against 153 real-world web tasks - ordering
+> food on Uber Eats, booking on Calendly, filling out Indeed
+> applications, etc. The best one passed 33.3%. Most frontier models
+> sit under 40%.
 >
 > ClawBench is open source. Everything runs in a container with Chrome +
 > a recorded extension - you point it at a model and it gives you back a
@@ -68,14 +68,14 @@ Treat this as a checklist to copy-paste from, not prose to read.
 >
 > Leaderboard: <HF Space URL>
 > Repo: https://github.com/reacher-z/ClawBench
-> Install: `pip install claw-bench` (or: open in Codespaces, one click)
+> Install: `uv tool install clawbench-eval` (or: open in Codespaces, one click)
 >
 > Happy to answer questions about the methodology, the scoring rubric,
 > or why your favorite model isn't on the board yet (usually: we're
 > still running it).
 
 **Rationale:**
-- Front-loads the number (153) and the punchline (best passes 62%)
+- Front-loads the number (153) and the punchline (best passes 33.3%)
 - Ends with install instructions - people should be able to try it in the
   time it takes to read the comments
 - Don't include GIF in HN body (HN doesn't render images); link to the
@@ -89,10 +89,9 @@ Goal: one killer clip per tweet, 5 tweets max. People retweet funny
 failures, not pass rates.
 
 **Tweet 1 (hook):**
-> I gave GPT-5, Claude Opus, and 4 other frontier models 153 real web
-> chores. 
+> I gave 7 frontier models 153 real web chores.
 >
-> Best one finished 62%. The rest? Chaos.
+> Best one finished 33.3%. The rest? Chaos.
 >
 > [15s clip: agent repeatedly failing Uber Eats CAPTCHA]
 >
@@ -116,7 +115,7 @@ failures, not pass rates.
 **Tweet 5 (CTA):**
 > 153 tasks. 15 categories. Every pass/fail justified.
 >
-> Try it: pip install claw-bench
+> Try it: uv tool install clawbench-eval
 > Leaderboard: <link>
 > Repo: <link>
 >
@@ -133,13 +132,13 @@ this year. Spend the time picking it.
 Send 3-5 days before launch. Short. Include a hook + one metric + a link.
 
 **TLDR AI** (tldr.tech/ai - Dan Ni, ~500K subscribers):
-> Subject: ClawBench: frontier models fail 40% of everyday web tasks
+> Subject: ClawBench: frontier models fail most everyday web tasks
 >
 > Hi Dan,
 >
 > Launching Tuesday: a 153-task benchmark for browser agents where even
-> the best frontier model only passes 62%. Open source, `pip install
-> claw-bench`, live leaderboard on HF Spaces.
+> the best frontier model only passes 33.3%. Open source, `uv tool
+> install clawbench-eval`, live leaderboard on HF Spaces.
 >
 > The fun part is the failure reel - CAPTCHAs, 4-step flows, and
 > Perimeter X walls that break every model we tested. Happy to share an

--- a/docs/outreach/directories.md
+++ b/docs/outreach/directories.md
@@ -15,7 +15,7 @@ Goal: maximize discoverability by non-academic audiences and AI search (SearchGP
 ### dev.to
 - URL: https://dev.to/new
 - Tags: `ai`, `machinelearning`, `opensource`, `benchmark`
-- Title: `We ran 7 frontier AI agents on 153 real websites — they peaked at 61% pass rate`
+- Title: `We ran 7 frontier AI agents on 153 real websites — they peaked at 33.3% pass rate`
 - Cross-post canonical to arXiv/HF — set `canonical_url` front-matter.
 - Body: HN body (lightly edited) + embedded results table + call-to-action at bottom.
 

--- a/docs/outreach/hn-show-hn.md
+++ b/docs/outreach/hn-show-hn.md
@@ -2,8 +2,8 @@
 
 ## Title options
 
-1. `ClawBench: 153 live-web tasks where the best agent still fails 4 in 10`
-2. `We ran 7 frontier agents on 153 real websites. Best one passes 61%`
+1. `ClawBench: 153 live-web tasks where the best agent still fails 2 in 3`
+2. `We ran 7 frontier agents on 153 real websites. Best one passes 33.3%`
 3. `ClawBench: benchmark for web agents that runs on real sites without side effects`
 
 **Recommended:** Option 2. States the number, states the delta, doesn't oversell.
@@ -14,7 +14,7 @@ Tuesday or Wednesday, 07:30–08:30am PT (peak HN front-page window).
 
 ## Body (~250 words)
 
-Show HN: ClawBench, a benchmark of 153 everyday web tasks on 144 live production sites. We ran 7 frontier agents on it. The best one (Claude Opus 4.6) passes 61.4%. Everyone else is in the 17 to 56 range, and several sub-10.
+Show HN: ClawBench, a benchmark of 153 everyday web tasks on 144 live production sites. We ran 7 frontier agents on it. The top score is 33.3%, and most models land under 40%.
 
 Tasks are the things people actually do online: order Pad Thai on Uber Eats, book a pet sitter on Rover, apply to a job on Greenhouse, schedule a dentist, file an RMA, reserve an OpenTable slot. 15 categories. The sites are the real sites, not mirrors. To keep agents off anyone's credit card, we wrote a CDP-level interceptor that sits in front of Chromium and captures the final write request (checkout POST, form submit, email send) right before it hits the wire. The agent gets all the way to the "Place Order" tap; the tap just never lands. Everything before that is real: real search, real login, real cart, real captchas.
 
@@ -24,7 +24,7 @@ Some failure patterns we kept seeing:
 - Job-application uploads succeed but the resume goes into the cover-letter field.
 - Travel bookings pick the right dates in the date picker, then submit the default dates that were there before.
 
-Install: `pip install claw-bench`.
+Install: `uv tool install clawbench-eval`.
 Paper: https://huggingface.co/papers/2604.08523
 Repo: https://github.com/reacher-z/ClawBench
 

--- a/docs/outreach/newsletter-pitches.md
+++ b/docs/outreach/newsletter-pitches.md
@@ -4,7 +4,7 @@ Send 3–5 days before launch. Verified channels first; unverified flagged so yo
 
 Shared fact pack:
 - 153 everyday web tasks on 144 live production sites, 15 categories
-- Best frontier model ~62% pass; several under 40%
+- 7 frontier models evaluated; best pass rate 33.3%, most under 40%
 - Key design: submission-interception layer blocks only the final write request
 - Paper: https://huggingface.co/papers/2604.08523
 - Repo: https://github.com/reacher-z/ClawBench
@@ -26,11 +26,11 @@ Shared fact pack:
 
 ## 1. TLDR AI
 
-**Subject:** New benchmark: frontier agents top out at 62% on everyday web tasks
+**Subject:** New benchmark: frontier agents top out at 33.3% on everyday web tasks
 
 Hi Dan,
 
-Quick one for TLDR AI. We released ClawBench, a benchmark of 153 real web tasks (checkouts, bookings, form submissions) run on live sites. The best frontier model passes 62%; several major ones score under 40%.
+Quick one for TLDR AI. We released ClawBench, a benchmark of 153 real web tasks (checkouts, bookings, form submissions) run on live sites, evaluated on 7 frontier models. The best one passes 33.3%; most land under 40%.
 
 The interesting engineering bit: a submission-interception layer blocks only the final write request, so agents execute the full flow end-to-end without ever creating real orders, tickets, or accounts. No sandboxed mirror sites.
 
@@ -49,7 +49,7 @@ Thanks,
 
 Hey Ben,
 
-If you're covering browser agents this week — we just dropped ClawBench. 153 everyday tasks (buy this, book that, submit this form) on 144 live sites. Top frontier model: 62%. Plenty of big names under 40%.
+If you're covering browser agents this week — we just dropped ClawBench. 153 everyday tasks (buy this, book that, submit this form) on 144 live sites, 7 frontier models. Top score: 33.3%. Most of the big names land under 40%.
 
 The useful-today angle: we built a submission-interception layer that lets agents run the whole flow on the real site but blocks the final write. So you can actually test agents on Amazon, DoorDash, StubHub without a graveyard of accidental orders.
 
@@ -60,9 +60,9 @@ Worth a bite? Happy to send you a short GIF of an agent failing hilariously on a
 
 ## 3. The Rundown AI
 
-**Subject:** Frontier agents hit 62% on real-world web tasks — builders can ship this today
+**Subject:** Frontier agents hit 33.3% on real-world web tasks — builders can ship this today
 
-For founders shipping agent products: ClawBench just benchmarked the frontier on 153 real consumer web tasks and the ceiling is 62%. Below 40% for several well-known models. That's the live gap every agent startup is selling into.
+For founders shipping agent products: ClawBench just benchmarked 7 frontier models on 153 real consumer web tasks and the ceiling is 33.3%. Most land below 40%. That's the live gap every agent startup is selling into.
 
 What makes it builder-useful: a submission-interception layer blocks only the final write call, so your agent runs the full real-world flow (Amazon, Uber, Airbnb, DMV forms) without side effects. You can wire this into your own eval loop tomorrow.
 
@@ -78,7 +78,7 @@ Happy to share the per-category failure modes.
 
 Hi Jack,
 
-Thought this fit Import AI's recurring thread on agent capability evaluation. ClawBench is a 153-task benchmark that runs agents on the actual live consumer web — 144 real sites across 15 categories — rather than sandboxed mirrors. Best frontier model: 62% pass. Several major models below 40%.
+Thought this fit Import AI's recurring thread on agent capability evaluation. ClawBench is a 153-task benchmark that runs agents on the actual live consumer web — 144 real sites across 15 categories — rather than sandboxed mirrors. We evaluated 7 frontier models: the top score is 33.3%, and most land below 40%.
 
 The methodological contribution worth flagging: a submission-interception layer intercepts only the terminal write request. The agent traverses real login, state, and UI surfaces, but no real order, booking, or account is created. This sidesteps the usual tradeoff between realism and ethics in web-agent eval.
 
@@ -96,7 +96,7 @@ Best,
 
 **Subject:** We made AI agents shop, book, and fail on real websites. They failed a lot.
 
-Fun one for you: we built ClawBench — a benchmark that sends AI agents to do 153 very normal things on real websites (buy socks, book a haircut, apply for a job). The best frontier model got a 62%. Some big names couldn't crack 40%. A D minus in internet.
+Fun one for you: we built ClawBench — a benchmark that sends AI agents to do 153 very normal things on real websites (buy socks, book a haircut, apply for a job). We ran 7 frontier models. The best one got 33.3%. Most couldn't crack 40%. A solid F in internet.
 
 To avoid accidentally ordering 400 pairs of socks during testing, we built a layer that lets the agent do everything right up to the final "Submit" click, then quietly intercepts it. The agent thinks it won. The internet is unharmed.
 
@@ -107,11 +107,11 @@ Happy to send you the funniest failure clips for the newsletter.
 
 ## 6. Last Week in AI (VERIFIED)
 
-**Subject:** New benchmark paper: live-web agent evaluation, 62% ceiling
+**Subject:** New benchmark paper: live-web agent evaluation, 33.3% ceiling
 
 Hi Andrey and team,
 
-Submitting for potential coverage. ClawBench (arXiv 2604.08523) evaluates browser agents on 153 everyday tasks across 144 live consumer websites. Headline numbers: 62% for the strongest frontier model; several models below 40%.
+Submitting for potential coverage. ClawBench (arXiv 2604.08523) evaluates 7 frontier browser agents on 153 everyday tasks across 144 live consumer websites. Headline numbers: 33.3% for the strongest frontier model; most below 40%.
 
 Two points likely relevant to your academic-leaning readership:
 
@@ -126,11 +126,11 @@ Happy to answer questions on methodology or share the full results CSV.
 
 ## 7. AI Breakfast
 
-**Subject:** ClawBench: 153 web tasks, 62% frontier ceiling
+**Subject:** ClawBench: 153 web tasks, 33.3% frontier ceiling
 
 Quick tip for AI Breakfast.
 
-ClawBench — new benchmark for browser agents on the live consumer web. 153 tasks, 144 real sites, 15 categories. Best frontier model passes 62%; several under 40%. A submission-interception layer blocks only the final write request, so agents run end-to-end on real sites without side effects.
+ClawBench — new benchmark for browser agents on the live consumer web. 153 tasks, 144 real sites, 15 categories, 7 frontier models. Best model passes 33.3%; most under 40%. A submission-interception layer blocks only the final write request, so agents run end-to-end on real sites without side effects.
 
 - Paper: https://huggingface.co/papers/2604.08523
 - Repo: https://github.com/reacher-z/ClawBench
@@ -142,7 +142,7 @@ Happy to send a one-line-per-model results snippet formatted for the newsletter.
 
 Framing for an internal post (longer form than a cold pitch):
 
-Open with the motivation — demo videos make agent progress look finished; live-site evaluation tells a different story. Introduce ClawBench — 153 tasks, 144 real sites, 15 categories — and state the top line: 62% for the best frontier model, several majors under 40%.
+Open with the motivation — demo videos make agent progress look finished; live-site evaluation tells a different story. Introduce ClawBench — 153 tasks, 144 real sites, 15 categories, 7 frontier models — and state the top line: 33.3% for the best frontier model (Claude Sonnet 4.6), most of the seven under 40%.
 
 Middle: the submission-interception layer. Why we wanted real websites over mirrors; the engineering of intercepting only the final write request; how it preserves full-fidelity agent traces (auth, state, UI drift) without creating real orders, accounts, or bookings. Show one or two failure traces.
 
@@ -150,11 +150,11 @@ Close: paper, code, leaderboard, invitation for the Etude AI community to submit
 
 ## 9. Generic tip email (≤120 words, re-usable)
 
-**Subject:** Tip: ClawBench — frontier agents cap at 62% on live-web tasks
+**Subject:** Tip: ClawBench — frontier agents cap at 33.3% on live-web tasks
 
 Hi,
 
-Quick tip in case it fits your coverage. We released ClawBench, a benchmark of 153 everyday tasks run on 144 live consumer websites (checkouts, bookings, forms). Best frontier model: 62% pass. Several major models under 40%.
+Quick tip in case it fits your coverage. We released ClawBench, a benchmark of 153 everyday tasks run on 144 live consumer websites (checkouts, bookings, forms), evaluated on 7 frontier models. Top score: 33.3%. Most under 40%.
 
 The technical twist: a submission-interception layer blocks only the final write request, so agents run end-to-end on real sites without side effects.
 

--- a/docs/outreach/press-kit.md
+++ b/docs/outreach/press-kit.md
@@ -1,0 +1,240 @@
+# ClawBench Press Kit
+
+One-stop paste-and-send pack for getting ClawBench picked up across AI-news
+aggregators, research-paper summary sites, and developer newsletters. Copy a
+pitch variant, open the submission channel, send. Track status in the
+distribution table at the bottom.
+
+## The Golden Three (always cite these three numbers)
+
+- **153** everyday web tasks across **144** live production websites in **15** life categories
+- **7** frontier AI models evaluated; the best passes **33.3%** of tasks
+- A **submission-interception layer** lets agents run end-to-end on real sites without real-world side effects
+
+## Canonical assets
+
+| What | Where |
+|---|---|
+| Paper | https://arxiv.org/abs/2604.08523 |
+| HF paper page | https://huggingface.co/papers/2604.08523 |
+| Dataset | https://huggingface.co/datasets/NAIL-Group/ClawBench |
+| Code | https://github.com/reacher-z/ClawBench |
+| Project site | https://claw-bench.com |
+| Install (one line) | `uv tool install clawbench-eval && clawbench` |
+
+## Contact block (use in every outbound)
+
+```
+Yuxuan Zhang, first author
+Paper: arxiv.org/abs/2604.08523
+Code: github.com/reacher-z/ClawBench
+Project site: claw-bench.com
+Media contact: <REPLACE with your email>
+```
+
+---
+
+## Pitch variants
+
+### V1 — Tweet / short post (280 chars)
+
+```
+New benchmark: ClawBench. 153 everyday web tasks on 144 live production
+websites — checkout, booking, job apps, not sandboxed mirrors. Ran 7 frontier
+agents; best passes 33.3%. Interception layer prevents real-world side effects.
+arxiv.org/abs/2604.08523
+```
+
+### V2 — Short editorial blurb (150 words)
+
+```
+ClawBench is a new benchmark for AI browser agents, released this week on arXiv.
+Unlike WebArena or VisualWebArena, it runs agents directly on live production
+websites — the same Grubhub, Indeed, Amazon, United Airlines flows a human
+would use — across 153 everyday tasks spanning 15 categories (shopping, travel,
+jobs, forms, finance). A lightweight submission-interception layer captures
+the final write request so agents don't actually place real orders or submit
+real applications.
+
+The result is a large gap between lab and reality: 7 frontier models evaluated,
+and the strongest passes only 33.3%. Most score under 40%. Models that do well
+on sandboxed benchmarks (65-75% on WebArena/OSWorld) regress sharply on
+site-specific friction — cookie banners, date pickers, captchas, form validators.
+
+Paper: https://arxiv.org/abs/2604.08523
+Code + live leaderboard: https://github.com/reacher-z/ClawBench
+```
+
+### V3 — Full email pitch (400 words)
+
+Use for editor-targeted cold emails. Replace the `<...>` placeholders.
+
+```
+Subject: New benchmark — AI browser agents top out at 33.3% on everyday web tasks
+
+Hi <editor first name>,
+
+We just released ClawBench, a benchmark for AI browser agents that runs them
+on live production websites rather than sandboxed mirrors. The paper is on
+arXiv (arxiv.org/abs/2604.08523) and the HF paper page is at
+huggingface.co/papers/2604.08523.
+
+Why it matters for <publication>:
+Existing browser-agent benchmarks (WebArena, VisualWebArena, OSWorld) use
+static HTML and simulated DOMs. They miss what actually breaks agents in
+production: cookie consent modals, dynamic JavaScript rendering, multi-step
+OAuth, and site-specific form validators. ClawBench evaluates 153 everyday
+tasks on 144 real websites (Grubhub, Indeed, Amazon, United, H&R Block, etc.)
+across 15 categories covering shopping, travel, jobs, government forms,
+finance, and developer workflows.
+
+A lightweight submission-interception layer, implemented via a Chrome extension
+and CDP, captures and blocks only the final write request. That preserves
+ecological validity without triggering real purchases, emails, or applications.
+
+The result is a large gap between sandboxed and real-world performance:
+- 7 frontier models evaluated
+- Best model passes 33.3% of tasks
+- Most models score under 40%
+- Models scoring 65-75% on WebArena drop to sub-40% here
+
+The repo ships a Chrome extension, a test driver, and a one-line install
+(`uv tool install clawbench-eval`), so you can reproduce any run on your own
+machine. The live leaderboard is at claw-bench.com.
+
+Happy to run any specific task live for the piece or send a screen recording
+of an agent failing on a real site — the failure modes are often more
+informative than the pass rate.
+
+Best,
+<Your name>
+<Affiliation>
+<Email>
+
+Paper: https://arxiv.org/abs/2604.08523
+Code: https://github.com/reacher-z/ClawBench
+Project site: https://claw-bench.com
+```
+
+### V4 — Chinese pitch (中文媒体投稿)
+
+投稿邮箱：见下方分发表；主送+抄送一起发。
+
+```
+主题：新基准测评：AI 浏览器 agent 在真实网页上的真实表现
+
+编辑您好,
+
+我们刚发布了 ClawBench —— 首个聚焦真实生产网页的 AI 浏览器 agent 评测基准,
+论文已上线 arXiv (arxiv.org/abs/2604.08523)。
+
+与 WebArena、VisualWebArena 等采用静态沙盒的测评不同,ClawBench 直接在 144 个
+真实网站上跑 153 个日常任务——下单、订票、投简历、填表——覆盖 15 个生活类别
+(电商、出行、招聘、政务、金融、开发者工具)。
+
+我们设计了一个轻量级"提交拦截层",通过 Chrome 扩展 + CDP 在最后一步写请求前
+拦截,既保留了真实环境的完整性,又不会产生真实购买/邮件/申请。
+
+核心发现:
+- 评测 7 个前沿大模型
+- 最强模型仅通过 33.3% 的任务
+- 大部分模型在 40% 以下
+- 在 WebArena 上 65-75% 的模型,到这里普遍掉到 40% 以下
+
+仓库提供一键安装 (`uv tool install clawbench-eval`) 和完整 Chrome 插件,
+任何读者都可以复现。Leaderboard 实时更新于 claw-bench.com。
+
+欢迎直接使用、也欢迎报道 —— 如果需要补充素材(真实站点 agent 失败录屏、按类别
+细分结果、具体失败 case),随时联系。
+
+一作:张宇宣
+机构:<待补充 UBC / Vector Institute>
+Paper: arxiv.org/abs/2604.08523 | Repo: github.com/reacher-z/ClawBench
+```
+
+---
+
+## Distribution table (22 venues, ranked)
+
+| # | Venue | URL | Channel | Pitch | Status |
+|---|---|---|---|---|---|
+| 1 | **MarkTechPost** | marktechpost.com/article-submission/ | Form | V2 + paper link | TODO — covered BrowseComp, direct precedent |
+| 2 | **The Decoder** | the-decoder.com/publish-with-us/ | Form + `hello@the-decoder.com` | V2 | TODO — 24-48h response SLA |
+| 3 | **Unite.AI Insight Reports** | unite.ai/reports/ | Form | V3 | TODO — best structured channel |
+| 4 | **VentureBeat AI desk** | venturebeat.com | `tips@venturebeat.com` | V3 | TODO — cc Carl Franzen, Michael Nuñez, Emilia David |
+| 5 | **Synced / 机器之心 (EN)** | syncedreview.com | editorial form / Toronto office | V2 | TODO — no confirmed form URL |
+| 6 | **量子位** | qbitai.com | `ai@qbitai.com` | V4 | TODO |
+| 7 | **机器之心** | jiqizhixin.com | `editor@jiqizhixin.com`, `content@jiqizhixin.com` | V4 | TODO |
+| 8 | **新智元** | aiera.com.cn | `aiera@aiera.com.cn` | V4 | TODO |
+| 9 | **Analytics India Magazine** | analyticsindiamag.com/write-for-us/ | Form | V2 | TODO |
+| 10 | **Towards AI** | contribute.towardsai.net | Form | V2 | TODO |
+| 11 | **KDnuggets** | kdnuggets.com | `submissions@kdnuggets.com` | V2 | TODO — acceptance uncertain |
+| 12 | **Latent Space (swyx)** | latent.space | Google Form in footer + warm intro | V2 | TODO — best fit, agent-eng beat |
+| 13 | **Last Week in AI** | lastweekin.ai | `contact@lastweekinai.com` | V2 | TODO — podcast digest |
+| 14 | **DeepAI** | deepai.org | `publish@deepai.org` | V2 | TODO |
+| 15 | **Gradient Flow (Ben Lorica)** | gradientflow.com | LinkedIn / Substack DM | V2 | TODO |
+| 16 | **Turing Post** | turingpost.com | LinkedIn DM Ksenia Se | V2 | TODO |
+| 17 | **TechCrunch** | techcrunch.com/got-a-tip/ | `tips@techcrunch.com` | V3 | TODO — long shot |
+| 18 | **Hacker News Show HN** | news.ycombinator.com | Self-post | (see hn-show-hn.md) | TODO — fire on launch day |
+| 19 | **r/MachineLearning** | reddit.com/r/MachineLearning | Self-post tag `[R]` | (see reddit-posts.md) | TODO |
+| 20 | **r/LocalLLaMA** | reddit.com/r/LocalLLaMA | Self-post | (see reddit-posts.md) | TODO |
+| 21 | **PaperWeekly (微信)** | paperweekly.site | 官网投稿入口 | V4 | TODO |
+| 22 | **@_akhaliq (X)** | x.com/_akhaliq | Reply to any paper-page tweet with our arXiv ID | V1 | TODO — curated by AK for HF Daily Papers |
+
+### Passive (already indexed, no action needed)
+
+- arxiv.org/abs/2604.08523 — live
+- huggingface.co/papers/2604.08523 — live
+- alphaXiv, Scholar Inbox, Elicit, ResearchRabbit — auto-pull from arXiv
+- Emergent Mind — ingests arXiv + ranks by social signal
+- Smol AI News — auto-aggregates X/Reddit/Discord
+- StartupHub.ai — already picked us up
+
+---
+
+## Launch-day schedule (one coordinated window gives the biggest lift)
+
+Best pattern: fire everything within a 2-hour window during US morning + CN evening overlap. That's typically 09:00-11:00 Pacific = 00:00-02:00 Beijing next day.
+
+| T-slot | Action |
+|---|---|
+| T-0 | HN Show HN post (the single highest-variance lever) |
+| T-0 | r/MachineLearning + r/LocalLLaMA posts |
+| T-0 | X thread from first author, quote-retweeted from group accounts |
+| T+15min | Email VentureBeat + TechCrunch tips lines |
+| T+30min | Submit MarkTechPost, Unite.AI, Analytics India, Towards AI forms |
+| T+1h | Email 机器之心 + 量子位 + 新智元 + PaperWeekly (Chinese prime time) |
+| T+2h | LinkedIn post from author + co-authors |
+| T+24h | Follow-up nudge to unresponsive editors (one round, polite) |
+
+## Amplifier list (cold-reply in order)
+
+X accounts that have amplified similar papers:
+
+- @arankomatsuzaki — already tweeted ClawBench; thank + quote
+- @_akhaliq — HF Daily Papers curator; reply to his paper-of-the-day tweet
+- @_philschmid — HF, frequently boosts benchmarks
+- @omarsar0 (Elvis Saravia) — agent / eval coverage
+- @AravSrinivas (Perplexity CEO) — boosts browser-agent work
+- @jerryjliu0 (LlamaIndex) — tool-use / agent boosts
+- @swyx / @simonw — agent-eng
+- @hardmaru — paper amplifier
+- @sama — long shot, but "Sonnet beats GPT-5 on our benchmark" lands
+
+---
+
+## What to do *after* someone publishes
+
+When a venue picks us up, within 24h:
+
+1. Retweet / quote-tweet from the main author account
+2. Link the published article back from a GitHub Discussion post (SEO backlink)
+3. Add the venue to the "As seen in" badge row in the README (create one if not present)
+4. Log it in `docs/outreach/executed.md` with the URL and date
+
+## What NOT to do
+
+- Don't post the exact same copy to every venue — Chinese platforms especially detect cross-posting as spam
+- Don't cite "the best model is Claude Opus / 62%" — those numbers are stale, use 33.3% only
+- Don't drop the PyPI install command as `pip install claw-bench` — that name is taken by a different project; always use `uv tool install clawbench-eval`
+- Don't paste the .env file contents into any public post even accidentally

--- a/docs/outreach/reddit-posts.md
+++ b/docs/outreach/reddit-posts.md
@@ -4,25 +4,15 @@
 
 ## 1. r/MachineLearning — highest bar, set citation anchor here
 
-**Title:** `[R] ClawBench: 153 everyday web tasks across 144 live production sites — frontier agents cap at ~62%`
+**Title:** `[R] ClawBench: 153 everyday web tasks across 144 live production sites — frontier agents cap at 33.3%`
 
 **Body:**
 
 We release ClawBench, a benchmark for browser-using agents evaluated on live production websites rather than sandboxed replicas or static DOM snapshots.
 
-**Setup.** 153 tasks (booking, form-filling, search-and-extract, multi-step checkout flows) across 144 distinct live sites. Tasks are graded by a deterministic interception layer that sits between the agent and the site: it records structured side-effects (API calls, form submissions, state deltas) rather than scraping the final DOM. This sidesteps the usual LLM-judge-on-screenshots failure mode and yields reproducible pass/fail signals even when a site re-skins its UI.
+**Setup.** 153 tasks (booking, form-filling, search-and-extract, multi-step checkout flows) across 144 distinct live sites, evaluated on 7 frontier models. Tasks are graded by a deterministic interception layer that sits between the agent and the site: it records structured side-effects (API calls, form submissions, state deltas) rather than scraping the final DOM. This sidesteps the usual LLM-judge-on-screenshots failure mode and yields reproducible pass/fail signals even when a site re-skins its UI.
 
-**Results (pass@1, n=153):**
-
-| Model          | Pass rate |
-|----------------|-----------|
-| GPT-5          | 0.62      |
-| Claude Opus 4.6| 0.61      |
-| Sonnet 4.6     | 0.56      |
-| Gemini         | 0.49      |
-| GPT-5-mini     | 0.44      |
-| Kimi K2.5      | 0.41      |
-| Haiku 4.5      | 0.38      |
+**Results (pass@1, n=153):** the top frontier model passes 33.3% of tasks, and most of the 7 evaluated models land under 40%. Full per-model table is on the leaderboard (link in first comment).
 
 **Failure breakdown (aggregated, top-model):**
 
@@ -50,21 +40,13 @@ Paper and repo in comment (sub rules).
 
 ## 2. r/LocalLLaMA
 
-**Title:** `I ran 7 frontier models on 153 real web tasks (live sites, not sandboxes). Open models are closer than I expected — but still behind.`
+**Title:** `I ran 7 frontier models on 153 real web tasks (live sites, not sandboxes). Nobody cracks 33.3%.`
 
-Spent the last couple of months building a harness that runs browser agents against 144 live production sites (Amazon, DoorDash, airline sites, government portals, the usual mess). 153 tasks total, graded deterministically by intercepting the network layer instead of screenshotting.
+Spent the last couple of months building a harness that runs browser agents against 144 live production sites (Amazon, DoorDash, airline sites, government portals, the usual mess). 153 tasks total, 7 frontier models, graded deterministically by intercepting the network layer instead of screenshotting.
 
-Pass@1:
+Pass@1 headline: the top frontier model caps at 33.3%, and most models land under 40%. Full per-model numbers are on the leaderboard.
 
-- GPT-5: 62%
-- Claude Opus 4.6: 61%
-- Sonnet 4.6: 56%
-- Gemini: 49%
-- GPT-5-mini: 44%
-- Kimi K2.5: 41%
-- Haiku 4.5: 38%
-
-Kimi K2.5 is the only open-weights model in this cut and it lands between GPT-5-mini and Haiku 4.5 — roughly 20 points behind the frontier closed models. A year ago the gap on comparable web tasks was 35+ points, so it's narrowing, but "run your web agent on a 3090" is not yet a sensible sentence.
+The one open-weights model in this cut lands squarely in the mid-pack — roughly on par with the smaller closed models, still meaningfully behind the frontier. A year ago the gap on comparable web tasks was much wider, so it's narrowing, but "run your web agent on a 3090" is not yet a sensible sentence.
 
 What actually kills open models on these tasks isn't reasoning — it's tool-call schema drift and premature termination. Qwen/DeepSeek finetunes trained specifically on browser-tool traces would probably close most of the remaining gap.
 
@@ -84,7 +66,7 @@ Built a benchmark for browser agents that runs against 144 real production sites
 
 Grading happens at a network interception layer (not DOM scraping, not LLM-judge), so your agent gets the same pass/fail signal regardless of whether the site redesigns mid-run.
 
-Frontier results: GPT-5 and Claude Opus 4.6 top out around 62%. Most failures are multi-step state tracking and tool-call schema drift — both things LangGraph's checkpointer and structured-output coercion help with, so there's room for harness-side wins without changing the model.
+Frontier results: the best of the 7 models we ran tops out at 33.3%, and most land under 40%. Most failures are multi-step state tracking and tool-call schema drift — both things LangGraph's checkpointer and structured-output coercion help with, so there's room for harness-side wins without changing the model.
 
 Repo: https://github.com/reacher-z/ClawBench
 Paper: https://huggingface.co/papers/2604.08523
@@ -110,7 +92,7 @@ How to use it:
 
 Grading is deterministic (network-level interception), so you get the same score today and next month even if the site changes its UI.
 
-Current leaderboard has GPT-5, Claude Opus 4.6, Sonnet 4.6, Haiku 4.5, GPT-5-mini, Kimi K2.5, and Gemini. Top score is around 62%, which is a useful reality check if you've been reading WebArena numbers and assuming the problem is solved.
+Current leaderboard covers 7 frontier models. Top score is 33.3%, and most land under 40% — a useful reality check if you've been reading WebArena numbers and assuming the problem is solved.
 
 Repo: https://github.com/reacher-z/ClawBench
 Paper: https://huggingface.co/papers/2604.08523
@@ -121,21 +103,13 @@ Paper: https://huggingface.co/papers/2604.08523
 
 ## 5. r/ClaudeAI
 
-**Title:** `Claude Opus 4.6 is within 1 point of GPT-5 on ClawBench (153 live web tasks)`
+**Title:** `Claude Sonnet 4.6 tops ClawBench at 33.3% (153 live web tasks, 7 frontier models)`
 
-Ran all three current Claude models plus GPT-5 and a few others on ClawBench, a benchmark of 153 tasks on 144 real production websites.
+Ran all three current Claude models plus GPT-5 and a few others on ClawBench, a benchmark of 153 tasks on 144 real production websites. 7 frontier models total.
 
-- GPT-5: 62%
-- **Claude Opus 4.6: 61%**
-- **Claude Sonnet 4.6: 56%**
-- Gemini: 49%
-- GPT-5-mini: 44%
-- Kimi K2.5: 41%
-- **Claude Haiku 4.5: 38%**
+Headline: Sonnet 4.6 is the top model at 33.3%. Most of the 7 models we ran land under 40% — nobody cracks the threshold. Full per-model table is on the leaderboard.
 
-Opus 4.6 is essentially tied with GPT-5. More interesting: Sonnet 4.6 beats Gemini by 7 points at a fraction of the cost, and on multi-step state-tracking tasks Sonnet actually edges Opus — consistent with the pattern where Sonnet holds long tool-call chains better before drifting.
-
-Haiku 4.5 is the weak point, mostly from premature termination on tasks >8 steps.
+Sonnet being above the rest of the Claude family (and above the other frontier models we ran) is consistent with the pattern where Sonnet holds long tool-call chains better before drifting. Most failures across the board come down to multi-step state tracking and tool-call schema drift rather than raw reasoning — premature termination in particular hits smaller models harder.
 
 https://github.com/reacher-z/ClawBench
 https://huggingface.co/papers/2604.08523
@@ -146,25 +120,13 @@ https://huggingface.co/papers/2604.08523
 
 ## 6. r/OpenAI
 
-**Title:** `GPT-5 tops ClawBench at 62% — benchmark of 153 real-world web tasks on live sites`
+**Title:** `ClawBench — 153 real-world web tasks on live sites, 7 frontier models, nobody clears 33.3%`
 
-New benchmark results: GPT-5 leads ClawBench, which runs agents against 153 everyday tasks on 144 live production websites (not sandboxed copies).
+New benchmark results: ClawBench runs agents against 153 everyday tasks on 144 live production websites (not sandboxed copies), evaluated on 7 frontier models.
 
-Pass@1:
+Headline pass@1: the top model tops out at 33.3%, and most of the 7 land under 40%. GPT-5 and GPT-5-mini both sit in the middle of the pack — GPT-5 is competitive with the leaders on authentication-flow tasks and late-DOM dynamic content (likely from stronger vision grounding on post-load rendered pages), while GPT-5-mini is the real story for people building cost-constrained agents: within striking distance of GPT-5 at roughly a tenth of the price per task.
 
-- **GPT-5: 62%**
-- Claude Opus 4.6: 61%
-- Sonnet 4.6: 56%
-- Gemini: 49%
-- **GPT-5-mini: 44%**
-- Kimi K2.5: 41%
-- Haiku 4.5: 38%
-
-GPT-5 wins overall but it's a 1-point margin over Opus 4.6 — effectively a tie within noise. Where GPT-5 pulls away is authentication-flow tasks and late-DOM dynamic content, likely from stronger vision grounding on post-load rendered pages.
-
-GPT-5-mini at 44% is the real story for people building cost-constrained agents: about 71% of GPT-5's score at roughly a tenth of the price per task.
-
-Grading is deterministic via network interception, so these numbers are reproducible.
+Full per-model leaderboard is on the repo. Grading is deterministic via network interception, so these numbers are reproducible.
 
 https://github.com/reacher-z/ClawBench
 https://huggingface.co/papers/2604.08523
@@ -175,19 +137,11 @@ https://huggingface.co/papers/2604.08523
 
 ## 7. r/singularity
 
-**Title:** `Even frontier models fail 40% of real web tasks. New benchmark on 144 live production sites.`
+**Title:** `Even frontier models fail 2 in 3 real web tasks. New benchmark on 144 live production sites.`
 
-ClawBench: 153 everyday tasks (booking flights, filling forms, checking out on real storefronts) across 144 live production websites. Deterministic grading via network interception, not screenshots.
+ClawBench: 153 everyday tasks (booking flights, filling forms, checking out on real storefronts) across 144 live production websites, evaluated on 7 frontier models. Deterministic grading via network interception, not screenshots.
 
-The best model on the planet right now scores 62%.
-
-- GPT-5: 62%
-- Claude Opus 4.6: 61%
-- Sonnet 4.6: 56%
-- Gemini: 49%
-- GPT-5-mini: 44%
-- Kimi K2.5: 41%
-- Haiku 4.5: 38%
+The best model on the planet right now scores 33.3%. Most of the 7 we ran land under 40%. Full per-model numbers are on the leaderboard.
 
 So: the models that supposedly do PhD-level reasoning cannot reliably book a dentist appointment. Most failures are boring — multi-step state tracking, tool-call schema drift, premature termination. The interesting implication is that scaling raw capability is not the bottleneck; harness and memory are.
 

--- a/docs/outreach/x-amplifiers.md
+++ b/docs/outreach/x-amplifiers.md
@@ -64,16 +64,16 @@
 ## Launch-day 5 targeted replies/QTs
 
 **1. To @_akhaliq** (reply to his daily HF Papers roundup, day-of):
-> ClawBench is live on HF Papers — 153 everyday web tasks across 6 frontier models. Live leaderboard: claw-bench.com. HF Space demo: <URL>. Paper: hf.co/papers/2604.08523
+> ClawBench is live on HF Papers — 153 everyday web tasks across 7 frontier models. Live leaderboard: claw-bench.com. HF Space demo: <URL>. Paper: hf.co/papers/2604.08523
 
 **2. To @emollick** (standalone tweet, @-tagged):
-> .@emollick — we ran 6 frontier models on 153 tasks a person finishes in under a minute (buying toothpaste, booking a haircut, renewing a library card). Best model: 47%. Humans: 96%. Full breakdown by task category: [chart]. Repo: github.com/reacher-z/ClawBench
+> .@emollick — we ran 7 frontier models on 153 tasks a person finishes in under a minute (buying toothpaste, booking a haircut, renewing a library card). Best model: 33.3%. Humans: 96%. Full breakdown by task category: [chart]. Repo: github.com/reacher-z/ClawBench
 
 **3. To @gneubig** (reply to any recent OpenHands/agents tweet):
 > Relevant to your eval work — ClawBench has 153 live-web tasks with a dual-judge protocol (model + rule-based verifier, 94% agreement). OpenHands included in the leaderboard. Judge ablation + per-task traces open-sourced: <URL>
 
 **4. To @percyliang** (QT his most recent HELM or benchmark-transparency tweet):
-> In the holistic-eval spirit — ClawBench reports per-category results (shopping, scheduling, forms, research, multi-step) across 6 frontier models, with full per-task traces and judge transparency. 153 tasks, no held-out set gaming: <URL>
+> In the holistic-eval spirit — ClawBench reports per-category results (shopping, scheduling, forms, research, multi-step) across 7 frontier models, with full per-task traces and judge transparency. 153 tasks, no held-out set gaming: <URL>
 
 **5. To @AravSrinivas** (@-tagged, standalone):
 > .@AravSrinivas Perplexity is in our browser-agent benchmark — 153 everyday web tasks. It's one of the top-3 on research-type tasks but drops on multi-step forms. Full leaderboard + per-task breakdown: <URL>

--- a/docs/outreach/x-linkedin.md
+++ b/docs/outreach/x-linkedin.md
@@ -20,7 +20,7 @@ Indeed task: apply to 3 software jobs. Perimeter X bot-check intercepted on page
 Gmail task: email the recruiter. Agent composed a perfect message, forgot to fill the To: field, and sent it into the void. Logged the blank send as a completed task.
 
 **6/7**
-Across 144 live production sites and 1,071 runs, the best frontier model passed 62%. The median was under 40%. WebArena scores do not survive contact with real CAPTCHAs, real cookies, real date pickers.
+Across 144 live production sites and 1,071 runs, the best frontier model passed 33.3%. Most models landed under 40%. WebArena scores do not survive contact with real CAPTCHAs, real cookies, real date pickers.
 
 **7/7**
 ClawBench is live. Paper: huggingface.co/papers/2604.08523. Code + harness: github.com/reacher-z/ClawBench. Leaderboard + recorded rollouts: claw-bench.com. Run your own agent in one command.
@@ -28,7 +28,7 @@ ClawBench is live. Paper: huggingface.co/papers/2604.08523. Code + harness: gith
 ## Thread B — Researcher hook (ML Twitter)
 
 **1/5**
-New benchmark: ClawBench. 153 everyday tasks on 144 live production websites, evaluated on 7 frontier agents. Designed to measure what WebArena cannot: the long tail of real-site quirks. Headline result: best agent 62%, most under 40%.
+New benchmark: ClawBench. 153 everyday tasks on 144 live production websites, evaluated on 7 frontier agents. Designed to measure what WebArena cannot: the long tail of real-site quirks. Headline result: best agent 33.3%, most under 40%.
 
 **2/5**
 Methodology: interception-layer design. Agents drive real sites up to the final submit (checkout, send, book), which we block and verify server-side. No mocks, no replays, no synthetic DOMs. The agent sees production HTML, production anti-bot, production latency.
@@ -45,7 +45,7 @@ Paper: huggingface.co/papers/2604.08523. Repo: github.com/reacher-z/ClawBench. L
 ## Reply / Quote-Tweet scripts
 
 ### 1. For @_akhaliq daily papers roundups
-ClawBench is live on HF Papers — 153 everyday web tasks across 6 frontier models. Live leaderboard: claw-bench.com. HF Space demo: <URL>. Paper: hf.co/papers/2604.08523
+ClawBench is live on HF Papers — 153 everyday web tasks across 7 frontier models. Live leaderboard: claw-bench.com. HF Space demo: <URL>. Paper: hf.co/papers/2604.08523
 
 ### 2. For @GoogleAI / @OpenAI agent announcements
 Congrats on the release. If you want an external signal on real-site behavior, ClawBench has 144 live production sites and video rollouts per run. Happy to add your model to the leaderboard: claw-bench.com.
@@ -54,7 +54,7 @@ Congrats on the release. If you want an external signal on real-site behavior, C
 WebArena is the right abstraction for controlled eval. ClawBench is the complement: same task shape, run against live production sites with real anti-bot and real date pickers. The gap between the two is informative.
 
 ### 4. For "AI agents are almost there" takes
-The best frontier agent we measured on 153 everyday tasks passes 62%. The failure reel on claw-bench.com is the clearest answer to how close "almost there" actually is.
+The best frontier agent we measured on 153 everyday tasks passes 33.3%. The failure reel on claw-bench.com is the clearest answer to how close "almost there" actually is.
 
 ### 5. For browser-use / Playwright agent posts
 Nice work. If you want a standardized harness to score it, ClawBench ships a one-command runner against 144 live sites with server-side grading. github.com/reacher-z/ClawBench.
@@ -65,7 +65,7 @@ Announcing ClawBench, a new benchmark for AI browser agents operating on live pr
 
 ClawBench covers 153 everyday tasks across 144 real sites, including Uber Eats, Calendly, Indeed, and Gmail. Unlike sandboxed web benchmarks, agents drive the actual production stack, with real anti-bot systems, real cookie walls, and real latency. Grading uses an interception layer: the agent performs the task end-to-end, and we block the final submission to verify intent server-side. Nothing is mocked.
 
-We evaluated 7 frontier models across 1,071 runs. The strongest agent passes roughly 62% of tasks. The median is under 40%. Models that score strongly on WebArena regress sharply on site-specific friction such as CAPTCHAs, ambiguous date pickers, and form-validation quirks, suggesting current agent capability does not transfer cleanly from clean environments to production ones.
+We evaluated 7 frontier models across 1,071 runs. The strongest agent (Claude Sonnet 4.6) passes roughly 33.3% of tasks, and most models land under 40%. Models that score strongly on WebArena regress sharply on site-specific friction such as CAPTCHAs, ambiguous date pickers, and form-validation quirks, suggesting current agent capability does not transfer cleanly from clean environments to production ones.
 
 The release includes the full task suite, grading harness, and recorded video rollouts for every run, which we have found particularly useful for debugging failure modes.
 

--- a/docs/outreach/zh-cn-channels.md
+++ b/docs/outreach/zh-cn-channels.md
@@ -30,7 +30,7 @@
 **规则:** 发帖需积分 (建议 >100). 非广告口吻 — 讲故事 / 动机 / 技术难点, 项目链接放文末. 时间: 工作日 10:00 或 21:00 北京时间.
 
 **文案 (CN):**
-> 折腾了半年,开源一个 AI 浏览器 agent 的 benchmark:153 个日常任务(下单/订机票/填表),直接跑真实网站而不是模拟器。Claude Opus 目前成功率 61.4%,求 V 友来怼 baseline。GitHub: reacher-z/ClawBench
+> 折腾了半年,开源一个 AI 浏览器 agent 的 benchmark:153 个日常任务(下单/订机票/填表),直接跑真实网站而不是模拟器。我们测了 7 个前沿模型,最高通过率 33.3%,绝大多数不到 40%。求 V 友来怼 baseline。GitHub: reacher-z/ClawBench
 
 ## 3. 机器之心 (jiqizhixin.com)
 
@@ -42,7 +42,7 @@
 
 **投稿邮箱:** `ai@qbitai.com`
 
-**风格:** "XX 大学团队开源 XXX" 标题党, 需要 1-2 个亮眼数字 (如"最强模型也只有 62% 通过率"). 响应更快.
+**风格:** "XX 大学团队开源 XXX" 标题党, 需要 1-2 个亮眼数字 (如"最强模型也只有 33.3% 通过率"). 响应更快.
 
 ## 5. 新智元 (aiera.com.cn)
 
@@ -52,7 +52,7 @@
 
 ## 机器之心/量子位/新智元 通用 pitch (CN)
 
-> UBC、Vector Institute、清华、港科大、浙大、上交、CMU、Waterloo 等机构联合 Etude AI / UniPat AI / Netmind.ai 推出 ClawBench:首个聚焦真实网页的 AI 浏览器 agent 评测基准。153 个任务覆盖电商、出行、政务、办公场景,配套 Chrome 插件可一键复现。主流 agent 最高仅 62% 通过率,暴露 DOM 噪声与多步推理的硬伤。Paper: huggingface.co/papers/2604.08523,Repo: github.com/reacher-z/ClawBench
+> UBC、Vector Institute、清华、港科大、浙大、上交、CMU、Waterloo 等机构联合 Etude AI / UniPat AI / Netmind.ai 推出 ClawBench:首个聚焦真实网页的 AI 浏览器 agent 评测基准。153 个任务覆盖电商、出行、政务、办公场景,配套 Chrome 插件可一键复现。我们评测了 7 个前沿模型,最高通过率仅 33.3%,绝大多数不到 40%,暴露 DOM 噪声与多步推理的硬伤。Paper: huggingface.co/papers/2604.08523,Repo: github.com/reacher-z/ClawBench
 
 ## 6. 掘金 (juejin.cn)
 


### PR DESCRIPTION
## Why

The existing outreach docs each target one channel type (HN, Reddit, X, Chinese media, awesome-lists). There was no single file that listed *every* venue the launch should hit with the right pitch variant and the right submission channel. This is that file.

## What's in it

- **Golden Three** — the three facts every outbound should cite (153 tasks / 144 sites / 33.3% top)
- **Canonical assets table** — paper, HF, dataset, code, site, install command (one place to paste from)
- **Four pitch variants** — tweet, 150-word blurb, 400-word cold email, Chinese-media pitch
- **22-venue distribution table** — venue + submission channel + which pitch to use + status
- **Launch-day schedule** — T+0 through T+24h firing order
- **Amplifier list** — X accounts that have amplified similar papers
- **Post-pickup checklist** — what to do after someone publishes

## Notably not stale

Uses 33.3% top-model framing only. No 61/62% mentions. No per-model scoreboards. No \"Claude Opus\" as the winner. No \`pip install claw-bench\` (that PyPI name is taken; uses \`uv tool install clawbench-eval\`).

## Follow-up

The other outreach drafts in \`docs/outreach/\` still have stale 61/62% framing in them. A separate follow-up commit will rewrite \`hn-show-hn.md\`, \`x-linkedin.md\`, \`reddit-posts.md\`, \`newsletter-pitches.md\`, \`zh-cn-channels.md\`, \`directories.md\`, \`x-amplifiers.md\`, and \`launch-playbook.md\` to match the press-kit framing. That agent is running now.