### PR TITLE
Document Claude for Chrome as a pairing integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ clawbench run 001-daily-life-food-uber-eats --human
 ```
 Open the noVNC URL the script prints, complete the task by hand, then close the tab. Port is auto-assigned if 6080 is busy.
 
+**(d) Pair with an external browser agent** — e.g. [Claude for Chrome](https://claude.com/claude-for-chrome) running in your own browser. See [`docs/integrations.md`](docs/integrations.md) for the flow and caveats.
+
 <details>
 <summary><b>Develop from source</b> &nbsp;— clone + ``./run.sh`` for contributors</summary>
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,55 @@
+# Integrations
+
+Supported pairings between ClawBench tasks and external browser-agent tools.
+
+## Claude for Chrome (Anthropic, beta)
+
+[Claude for Chrome](https://claude.com/claude-for-chrome) is Anthropic's Chrome
+extension that lets Claude navigate tabs, click, and fill forms directly in
+the user's browser. It is not a ClawBench harness in the automated sense —
+the extension runs in the user's local Chrome rather than inside our
+container — but it pairs cleanly with ClawBench task specs for a
+manual-but-realistic evaluation flow.
+
+### Try a ClawBench task with Claude for Chrome
+
+1. Install the extension from the Chrome Web Store (link on
+   [claude.com/claude-for-chrome](https://claude.com/claude-for-chrome)).
+2. Pick a task. The bundled suite is listed by `clawbench cases`; each case
+   directory holds a `task.json` with the starting URL and the natural-language
+   `instruction` the agent is expected to complete.
+3. Open the starting URL in the Chrome window where Claude for Chrome is
+   active. Paste the `instruction` into the Claude side-panel and let it
+   drive.
+4. When Claude reaches the final submit step, copy the outbound request from
+   Chrome DevTools → Network (or let it actually go through — ClawBench's
+   submission-interceptor only runs inside our container, so live runs in
+   your own browser will hit the real site).
+5. Score yourself against the per-task rubric in
+   [`eval/agentic_eval.md`](../eval/agentic_eval.md), or run the full judge
+   pipeline on a recording by hand.
+
+### What this flow is good for
+
+- Sanity-checking task reachability from an end-user perspective.
+- Generating additional human or agent reference runs without our container.
+- Comparing Anthropic's first-party browser agent against the harnesses we
+  already ship (`openclaw`, `opencode`).
+
+### What it is *not*
+
+- Not an automated leaderboard submission — scoring still requires the
+  full five-layer recording that our container produces (video + screenshots
+  + HTTP + browser actions + agent messages).
+- Not a safe way to run write-heavy tasks (checkout, job applications,
+  bookings) on your personal accounts. For the interception layer, run the
+  same task inside ClawBench's container with `clawbench run <case> --human`
+  instead.
+
+### Roadmap
+
+A first-class `--harness claude-for-chrome` entry is tracked as an open
+question: it requires either (a) Anthropic exposing a programmatic hook so
+the extension can drive a remote Chrome over CDP, or (b) running the
+extension itself inside our container image. Contributions welcome — open
+an issue tagged `harness:claude-for-chrome` if you want to help scope it.


### PR DESCRIPTION
## Summary

Adds a new `docs/integrations.md` that documents [Claude for Chrome](https://claude.com/claude-for-chrome) — Anthropic's browser extension — as a supported manual pairing flow for ClawBench tasks. Links from the Quick Start section of the README.

## Why

Users asking "can I try ClawBench tasks with Claude for Chrome?" should have a one-page answer. The extension isn't a ClawBench harness in the automated sense (it runs in the user's local Chrome rather than our container), but it pairs cleanly with our task specs for a manual evaluation flow. Documenting the pairing now — honestly, with the caveats — is cheap and saves FAQ noise as Claude for Chrome gains adoption.

## What changed

- `docs/integrations.md` (new, 55 lines): install steps, per-task flow using the bundled `task.json` starting URL + instruction, what the flow is good for, what it isn't (not an automated leaderboard submission; not safe for write-heavy tasks on personal accounts), and a roadmap note on a first-class `--harness claude-for-chrome` entry.
- `README.md`: one-line pointer under the Quick Start run examples.

## Out of scope

Automated harness integration. That requires either Anthropic exposing a programmatic hook so the extension can drive a remote Chrome over CDP, or packaging the extension inside our container image. Tracked in the roadmap note of `docs/integrations.md`.

## Test plan

- [x] `docs/integrations.md` renders correctly on GitHub
- [x] README link resolves to the new file
- [x] No changes to any code path, container build, or test-cases