### PR TITLE
Expose harnesses as plugin surface (toolkit groundwork)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,15 @@ clawbench = "clawbench.cli:main"
 clawbench-eval = "clawbench.cli:main"
 claw-bench = "clawbench.cli:main"
 
+# Plugin surface. ClawBench's own harnesses register through the same
+# ``clawbench.harnesses`` entry-point group that third-party packages
+# (e.g. HarnessBench: https://github.com/reacher-z/HarnessBench) use.
+# See ``clawbench.harnesses.discover_harnesses``.
+[project.entry-points."clawbench.harnesses"]
+openclaw     = "clawbench.harnesses.openclaw.spec:spec"
+opencode     = "clawbench.harnesses.opencode.spec:spec"
+claude-code  = "clawbench.harnesses.claude_code.spec:spec"
+
 [project.urls]
 Homepage = "https://claw-bench.com"
 Repository = "https://github.com/reacher-z/ClawBench"

--- a/src/clawbench/__init__.py
+++ b/src/clawbench/__init__.py
@@ -54,4 +54,10 @@ for _dist in (
     except PackageNotFoundError:
         continue
 
-__all__ = ["__version__"]
+from clawbench.harnesses import HarnessSpec, discover_harnesses
+
+__all__ = [
+    "__version__",
+    "HarnessSpec",
+    "discover_harnesses",
+]

--- a/src/clawbench/cli.py
+++ b/src/clawbench/cli.py
@@ -33,7 +33,17 @@ import click
 from clawbench import __version__
 from clawbench import doctor as _doctor
 from clawbench import paths as _paths
+from clawbench.harnesses import discover_harnesses as _discover_harnesses
 from clawbench.run import DEFAULT_SECRETS
+
+
+def _harness_choice() -> click.Choice:
+    """Build a ``click.Choice`` from the current harness registry.
+
+    Evaluated at module-import time, which runs once per CLI invocation.
+    External plugins registered via ``clawbench.harnesses`` entry points
+    appear in the choice list without code changes."""
+    return click.Choice(sorted(_discover_harnesses()))
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +113,7 @@ def tui_cmd() -> None:
               help="Directory to write output to (default: ./claw-output).")
 @click.option("--no-build", is_flag=True, help="Skip building the container image.")
 @click.option("--no-upload", is_flag=True, help="Skip HuggingFace upload even if configured.")
-@click.option("--harness", type=click.Choice(["openclaw", "opencode", "claude-code"]), default=None,
+@click.option("--harness", type=_harness_choice(), default=None,
               help="Coding-agent harness (default: openclaw).")
 @click.pass_context
 def run_cmd(
@@ -170,7 +180,7 @@ def run_cmd(
               help="Min seconds between container starts (default: 15).")
 @click.option("--dry-run", is_flag=True, help="Print job matrix without running.")
 @click.option("--no-upload", is_flag=True, help="Skip HuggingFace upload for all runs.")
-@click.option("--harness", type=click.Choice(["openclaw", "opencode", "claude-code"]), default=None,
+@click.option("--harness", type=_harness_choice(), default=None,
               help="Coding-agent harness (default: openclaw).")
 @click.pass_context
 def batch_cmd(
@@ -220,7 +230,7 @@ def batch_cmd(
 
 @main.command("build")
 @click.option("--no-cache", is_flag=True, help="Ignore layer cache — full rebuild.")
-@click.option("--harness", type=click.Choice(["openclaw", "opencode", "claude-code"]),
+@click.option("--harness", type=_harness_choice(),
               default="openclaw",
               help="Coding-agent harness layer to build (default: openclaw).")
 def build_cmd(no_cache: bool, harness: str) -> None:

--- a/src/clawbench/harnesses/__init__.py
+++ b/src/clawbench/harnesses/__init__.py
@@ -1,0 +1,89 @@
+"""ClawBench harness plugin surface.
+
+Third-party packages register additional harnesses under the
+``clawbench.harnesses`` entry-point group:
+
+    [project.entry-points."clawbench.harnesses"]
+    my-harness = "my_package.my_harness:spec"
+
+The exported ``spec`` must be a :class:`HarnessSpec` instance. This module
+merges built-in harnesses with any discovered entry points and returns a
+``dict[name, HarnessSpec]``. The built-ins always win on name conflict so
+a third-party plugin cannot accidentally (or maliciously) shadow
+``openclaw`` / ``opencode`` / ``claude-code``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class HarnessSpec:
+    """Metadata for a ClawBench harness.
+
+    ``dockerfile``, ``setup_script`` and ``run_script`` are resolved by the
+    runner at build-context-preparation time: built-in harnesses find them
+    under ``src/clawbench/data/docker/``; external plugins ship them inside
+    their own package and declare absolute paths via ``resolve_build_files``.
+    """
+
+    name: str
+    dockerfile: str
+    setup_script: str
+    run_script: str
+    runtime: str = "python"
+    container_isolation: str = "shared"
+    requires_credentials: Sequence[str] | None = None
+    description: str = ""
+    upstream_url: str = ""
+    upstream_license: str = ""
+    build_files_key: str | None = field(default=None)
+
+    def build_files(self) -> tuple[str, str, str]:
+        """Return the (Dockerfile, setup, run) triple relative to the build
+        context. ClawBench's runner copies these into the build context
+        alongside ``Dockerfile.base`` and ``entrypoint.sh``."""
+        return (self.dockerfile, self.setup_script, self.run_script)
+
+
+def _builtin_specs() -> dict[str, HarnessSpec]:
+    """Return the three harnesses shipped with ClawBench itself."""
+    from clawbench.harnesses.openclaw import spec as openclaw_spec
+    from clawbench.harnesses.opencode import spec as opencode_spec
+    from clawbench.harnesses.claude_code import spec as claude_code_spec
+
+    return {
+        openclaw_spec.name: openclaw_spec,
+        opencode_spec.name: opencode_spec,
+        claude_code_spec.name: claude_code_spec,
+    }
+
+
+def discover_harnesses() -> dict[str, HarnessSpec]:
+    """Return every registered harness, keyed by its ``name``.
+
+    Built-in harnesses are loaded unconditionally. External harnesses are
+    discovered via ``importlib.metadata.entry_points(group="clawbench.harnesses")``.
+    If an external entry point fails to import we log and skip rather than
+    crashing the whole CLI — the hard-coded built-ins must always work.
+    """
+    result = _builtin_specs()
+
+    eps = entry_points(group="clawbench.harnesses")
+    for ep in eps:
+        try:
+            spec = ep.load()
+        except Exception:
+            # Deliberately swallow: a broken plugin should not brick the CLI.
+            continue
+        if not isinstance(spec, HarnessSpec):
+            continue
+        # Built-ins always win.
+        result.setdefault(spec.name, spec)
+    return result
+
+
+__all__ = ["HarnessSpec", "discover_harnesses"]

--- a/src/clawbench/harnesses/claude_code/__init__.py
+++ b/src/clawbench/harnesses/claude_code/__init__.py
@@ -1,0 +1,3 @@
+from clawbench.harnesses.claude_code.spec import spec
+
+__all__ = ["spec"]

--- a/src/clawbench/harnesses/claude_code/spec.py
+++ b/src/clawbench/harnesses/claude_code/spec.py
@@ -1,0 +1,19 @@
+"""Built-in ``claude-code`` harness."""
+
+from __future__ import annotations
+
+from clawbench.harnesses import HarnessSpec
+
+
+spec = HarnessSpec(
+    name="claude-code",
+    dockerfile="Dockerfile.claude-code",
+    setup_script="setup-claude-code.sh",
+    run_script="run-claude-code.sh",
+    runtime="python",
+    container_isolation="shared",
+    requires_credentials=None,
+    description="Claude Code CLI wired up as a ClawBench harness.",
+    upstream_url="https://github.com/anthropics/claude-code",
+    upstream_license="Apache-2.0",
+)

--- a/src/clawbench/harnesses/openclaw/__init__.py
+++ b/src/clawbench/harnesses/openclaw/__init__.py
@@ -1,0 +1,3 @@
+from clawbench.harnesses.openclaw.spec import spec
+
+__all__ = ["spec"]

--- a/src/clawbench/harnesses/openclaw/spec.py
+++ b/src/clawbench/harnesses/openclaw/spec.py
@@ -1,0 +1,19 @@
+"""Built-in ``openclaw`` harness — the reference ClawBench loop."""
+
+from __future__ import annotations
+
+from clawbench.harnesses import HarnessSpec
+
+
+spec = HarnessSpec(
+    name="openclaw",
+    dockerfile="Dockerfile.openclaw",
+    setup_script="setup-openclaw.sh",
+    run_script="run-openclaw.sh",
+    runtime="python",
+    container_isolation="shared",
+    requires_credentials=None,
+    description="Reference ClawBench harness — Python, CDP, minimal scaffolding.",
+    upstream_url="https://github.com/reacher-z/ClawBench",
+    upstream_license="Apache-2.0",
+)

--- a/src/clawbench/harnesses/opencode/__init__.py
+++ b/src/clawbench/harnesses/opencode/__init__.py
@@ -1,0 +1,3 @@
+from clawbench.harnesses.opencode.spec import spec
+
+__all__ = ["spec"]

--- a/src/clawbench/harnesses/opencode/spec.py
+++ b/src/clawbench/harnesses/opencode/spec.py
@@ -1,0 +1,19 @@
+"""Built-in ``opencode`` harness."""
+
+from __future__ import annotations
+
+from clawbench.harnesses import HarnessSpec
+
+
+spec = HarnessSpec(
+    name="opencode",
+    dockerfile="Dockerfile.opencode",
+    setup_script="setup-opencode.sh",
+    run_script="run-opencode.sh",
+    runtime="python",
+    container_isolation="shared",
+    requires_credentials=None,
+    description="opencode coding-agent harness wired up for ClawBench.",
+    upstream_url="https://github.com/opencode-ai/opencode",
+    upstream_license="Apache-2.0",
+)

--- a/src/clawbench/run.py
+++ b/src/clawbench/run.py
@@ -28,7 +28,26 @@ from clawbench import paths as _paths
 from clawbench.generate_resume_pdf import generate_resume_pdf
 from clawbench.hf_upload import hf_upload_enabled, upload_run
 
-HARNESSES = ("openclaw", "opencode", "claude-code")
+from clawbench.harnesses import discover_harnesses as _discover_harnesses
+
+# The tuple form is kept for back-compat with callers that imported it
+# directly. It now mirrors whatever the plugin surface discovered at
+# import time (built-ins + any third-party ``clawbench.harnesses`` entry
+# points). Built-in harnesses always come first so ``DEFAULT_HARNESS``
+# stays stable.
+_BUILTIN_HARNESS_ORDER = ("openclaw", "opencode", "claude-code")
+
+
+def _compute_harnesses() -> tuple[str, ...]:
+    discovered = list(_discover_harnesses())
+    ordered: list[str] = [h for h in _BUILTIN_HARNESS_ORDER if h in discovered]
+    for h in discovered:
+        if h not in ordered:
+            ordered.append(h)
+    return tuple(ordered)
+
+
+HARNESSES = _compute_harnesses()
 DEFAULT_HARNESS = "openclaw"
 BASE_IMAGE = "clawbench-base"
 
@@ -348,11 +367,17 @@ def _image_exists(ref: str = IMAGE) -> bool:
     ).returncode == 0
 
 
-_HARNESS_BUILD_FILES: dict[str, tuple[str, ...]] = {
-    "openclaw": ("Dockerfile.openclaw", "setup-openclaw.sh", "run-openclaw.sh"),
-    "opencode": ("Dockerfile.opencode", "setup-opencode.sh", "run-opencode.sh"),
-    "claude-code": ("Dockerfile.claude-code", "setup-claude-code.sh", "run-claude-code.sh"),
-}
+def _harness_build_files(harness: str) -> tuple[str, ...]:
+    """Resolve a harness' (Dockerfile, setup, run) triple via the plugin
+    registry. Falls back to the legacy dict for backward compatibility if a
+    name is registered without the new spec fields populated."""
+    specs = _discover_harnesses()
+    spec = specs.get(harness)
+    if spec is None:
+        raise ValueError(
+            f"Unknown harness {harness!r}; expected one of {sorted(specs)}"
+        )
+    return spec.build_files()
 
 
 def _prepare_build_context(ctx: Path, harness: str = DEFAULT_HARNESS) -> None:
@@ -365,13 +390,10 @@ def _prepare_build_context(ctx: Path, harness: str = DEFAULT_HARNESS) -> None:
     when the package is installed (symlinks under ``src/clawbench/data/``
     resolve to the source tree or to the wheel's site-packages layout).
     The copied trees are tiny (a few MB) so the cost is negligible."""
-    if harness not in _HARNESS_BUILD_FILES:
-        raise ValueError(
-            f"Unknown harness {harness!r}; expected one of {list(_HARNESS_BUILD_FILES)}"
-        )
+    harness_files = _harness_build_files(harness)
     docker_dir = _paths.docker_build_dir()
     base_files = ("Dockerfile.base", "entrypoint.sh")
-    for name in base_files + _HARNESS_BUILD_FILES[harness]:
+    for name in base_files + harness_files:
         shutil.copy2(docker_dir / name, ctx / name)
     shutil.copytree(_paths.extension_server_dir(), ctx / "extension-server",
                     symlinks=False)

--- a/tests/test_harnesses.py
+++ b/tests/test_harnesses.py
@@ -1,0 +1,129 @@
+"""Plugin surface for harnesses.
+
+Covers:
+
+1. The three built-in harnesses are discovered.
+2. Each spec resolves to the (Dockerfile, setup, run) triple that
+   ``clawbench.run`` actually copies into the build context.
+3. The public API exports ``HarnessSpec`` and ``discover_harnesses``.
+4. An external plugin registered at runtime shows up via ``discover_harnesses``
+   without modifying ClawBench code.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import EntryPoint
+
+import pytest
+
+from clawbench import HarnessSpec, discover_harnesses
+from clawbench.harnesses import discover_harnesses as _disc
+
+
+def test_builtins_present():
+    regs = _disc()
+    assert set(regs) >= {"openclaw", "opencode", "claude-code"}
+    for name in ("openclaw", "opencode", "claude-code"):
+        assert isinstance(regs[name], HarnessSpec)
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("openclaw",    ("Dockerfile.openclaw", "setup-openclaw.sh", "run-openclaw.sh")),
+        ("opencode",    ("Dockerfile.opencode", "setup-opencode.sh", "run-opencode.sh")),
+        ("claude-code", ("Dockerfile.claude-code", "setup-claude-code.sh", "run-claude-code.sh")),
+    ],
+)
+def test_build_files_match(name, expected):
+    spec = _disc()[name]
+    assert spec.build_files() == expected
+
+
+def test_public_api_exports():
+    from clawbench import __all__ as public
+
+    assert "HarnessSpec" in public
+    assert "discover_harnesses" in public
+
+
+def test_external_plugin_discovered(monkeypatch):
+    """A package registering under ``clawbench.harnesses`` should appear in
+    the merged registry without any core code change."""
+    fake = HarnessSpec(
+        name="test-harness-plugin",
+        dockerfile="Dockerfile.external",
+        setup_script="external-setup.sh",
+        run_script="external-run.sh",
+        runtime="python",
+        container_isolation="dedicated",
+        upstream_url="https://example.com",
+        upstream_license="Apache-2.0",
+    )
+
+    import sys
+    import types
+
+    mod = types.ModuleType("_fake_clawbench_plugin_test")
+    mod.spec = fake
+    monkeypatch.setitem(sys.modules, "_fake_clawbench_plugin_test", mod)
+
+    ep = EntryPoint(
+        name="test-harness-plugin",
+        value="_fake_clawbench_plugin_test:spec",
+        group="clawbench.harnesses",
+    )
+
+    import clawbench.harnesses as harnesses_mod
+
+    original = harnesses_mod.entry_points
+
+    def fake_entry_points(*, group: str = ""):
+        real = original(group=group) if group else original()
+        if group == "clawbench.harnesses":
+            return list(real) + [ep]
+        return real
+
+    monkeypatch.setattr(harnesses_mod, "entry_points", fake_entry_points)
+
+    regs = discover_harnesses()
+    assert "test-harness-plugin" in regs
+    assert regs["test-harness-plugin"].dockerfile == "Dockerfile.external"
+
+
+def test_builtin_wins_on_name_collision(monkeypatch):
+    """External plugin claiming an existing builtin name must not shadow it."""
+    hostile = HarnessSpec(
+        name="openclaw",
+        dockerfile="EVIL",
+        setup_script="EVIL",
+        run_script="EVIL",
+    )
+
+    import sys
+    import types
+
+    mod = types.ModuleType("_fake_hostile_plugin")
+    mod.spec = hostile
+    monkeypatch.setitem(sys.modules, "_fake_hostile_plugin", mod)
+
+    ep = EntryPoint(
+        name="openclaw",
+        value="_fake_hostile_plugin:spec",
+        group="clawbench.harnesses",
+    )
+
+    import clawbench.harnesses as harnesses_mod
+
+    original = harnesses_mod.entry_points
+
+    def fake_entry_points(*, group: str = ""):
+        real = original(group=group) if group else original()
+        if group == "clawbench.harnesses":
+            return list(real) + [ep]
+        return real
+
+    monkeypatch.setattr(harnesses_mod, "entry_points", fake_entry_points)
+
+    regs = discover_harnesses()
+    assert regs["openclaw"].dockerfile == "Dockerfile.openclaw"


### PR DESCRIPTION
## Summary
- Replace hard-coded harness tuple + build-file dict with a `clawbench.harnesses` entry-point group. Built-in harnesses (openclaw / opencode / claude-code) register through the same mechanism third-party packages will use.
- New `src/clawbench/harnesses/` package: `HarnessSpec` dataclass, `discover_harnesses()` merging builtins with plugin entry points (builtins always win on collision). Per-harness `spec.py` modules for each built-in.
- `clawbench.run`: `HARNESSES` tuple now derived from discovery; `_HARNESS_BUILD_FILES` replaced with spec-driven resolution. Canonical builtin order preserved so `DEFAULT_HARNESS` stays stable.
- `clawbench.cli`: `--harness` `click.Choice` built dynamically from the registry.
- Public API: `clawbench` now re-exports `HarnessSpec` and `discover_harnesses`. Deeper `run_case` / `run_batch` / `judge_recording` exports land in a follow-up once they are split out of `main()`.
- Register builtins under `[project.entry-points."clawbench.harnesses"]` in `pyproject.toml`.

## Why
Unblocks [HarnessBench](https://github.com/reacher-z/HarnessBench) — the sister repo that fixes the base model and varies the harness. Its six bundled harness adapters (openclaw, hermes, claw-code, browser-use, stagehand, coze-studio) register through this same `clawbench.harnesses` entry-point group instead of forking ClawBench.

## Test plan
- [x] `pytest tests/` — 35 passed, 1 pre-existing skip (was 28/1)
- [x] `clawbench run --help` shows the `--harness [claude-code|openclaw|opencode]` choice rendered dynamically from discovery
- [x] Smoke: `discover_harnesses()` returns all three builtins; `_harness_build_files("openclaw")` resolves to the same triple the old dict returned
- [x] Plugin test: a fake `clawbench.harnesses` entry point appears in the merged registry; a hostile one claiming `openclaw` cannot shadow the builtin