### PR TITLE
Drop harness-bench from alias list (handed to HarnessBench)

### DIFF
--- a/scripts/build-aliases.py
+++ b/scripts/build-aliases.py
@@ -57,8 +57,10 @@ def root_version() -> str:
 
 # Alias distribution names successfully registered on PyPI.
 #
-# First wave (packaging PR): harness-bench, clawbench-eval, clawbench-cli,
-# openclawbench, clawbench-harness, claw-harness, nail-clawbench.
+# First wave (packaging PR): clawbench-eval, clawbench-cli, openclawbench,
+# clawbench-harness, claw-harness, nail-clawbench. ``harness-bench`` was
+# also in this wave but has since been handed over to the HarnessBench
+# project (its own repo; owns the name on PyPI going forward).
 #
 # Second wave (adjacent harness/agent names): harnessos, r2agent, claw-ai,
 # claw-agent, claw-eval.
@@ -80,7 +82,8 @@ def root_version() -> str:
 # distribution anyway — so ``pip install claw_ai`` still lands on our
 # package.
 ALIAS_NAMES = [
-    "harness-bench",
+    # "harness-bench" was split off into its own project (HarnessBench):
+    # https://github.com/reacher-z/HarnessBench — don't re-claim as an alias.
     "clawbench-eval",
     "clawbench-cli",
     "openclawbench",


### PR DESCRIPTION
## Summary

- Remove `harness-bench` from `ALIAS_NAMES` in `scripts/build-aliases.py`
- Update wave-1 provenance comment to explain the handoff

## Why

HarnessBench (https://github.com/reacher-z/HarnessBench) has claimed `harness-bench` as its real PyPI distribution (now at 0.1.6 on PyPI). Keeping it in ClawBench's defensive-alias list would clobber HarnessBench releases on every ClawBench tag push.

## Test plan

- [ ] `python scripts/build-aliases.py` runs without materializing a `harness-bench/` directory
- [ ] Next ClawBench release does not attempt to re-upload `harness-bench`