### PR TITLE
README: add News timeline section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ order food, book travel, apply for jobs, write reviews, manage projects.<br/>
 
 </div>
 
+## News
+
+- **[2026.04.16]** Featured in **5 curated awesome-lists**: [awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering), [Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents), [awesome-computer-use](https://github.com/ranpox/awesome-computer-use), [Awesome-GUI-Agents](https://github.com/ZJU-REAL/Awesome-GUI-Agents), and [LLM-Agent-Benchmark-List](https://github.com/zhangxjohn/LLM-Agent-Benchmark-List).
+- **[2026.04.15]** Sister project [**HarnessBench**](https://github.com/reacher-z/HarnessBench) launched — fixes the base model, varies the harness. Also on [PyPI](https://pypi.org/project/harness-bench/).
+- **[2026.04.14]** Project featured on [**DeepWiki**](https://deepwiki.com/reacher-z/ClawBench) — ask questions about ClawBench in natural language.
+- **[2026.04.11]** Honored to be [**#3 HuggingFace Paper of the Day**](https://huggingface.co/papers/2604.08523)!
+- **[2026.04.11]** Paper released on [arXiv (2604.08523)](https://arxiv.org/abs/2604.08523). Dataset published on [HuggingFace](https://huggingface.co/datasets/NAIL-Group/ClawBench).
+
 <br/>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,6 +71,14 @@ uv tool install clawbench-eval && clawbench
 
 </div>
 
+## 动态
+
+- **[2026.04.16]** 被 **5 个精选 awesome-list** 收录：[awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering)、[Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents)、[awesome-computer-use](https://github.com/ranpox/awesome-computer-use)、[Awesome-GUI-Agents](https://github.com/ZJU-REAL/Awesome-GUI-Agents)、[LLM-Agent-Benchmark-List](https://github.com/zhangxjohn/LLM-Agent-Benchmark-List)。
+- **[2026.04.15]** 姊妹项目 [**HarnessBench**](https://github.com/reacher-z/HarnessBench) 发布 — 固定模型、比较 Harness。已上架 [PyPI](https://pypi.org/project/harness-bench/)。
+- **[2026.04.14]** 项目被 [**DeepWiki**](https://deepwiki.com/reacher-z/ClawBench) 收录 — 可用自然语言提问 ClawBench 相关问题。
+- **[2026.04.11]** 荣获 [**HuggingFace 当日论文 #3**](https://huggingface.co/papers/2604.08523)!
+- **[2026.04.11]** 论文发布于 [arXiv (2604.08523)](https://arxiv.org/abs/2604.08523)。数据集上线 [HuggingFace](https://huggingface.co/datasets/NAIL-Group/ClawBench)。
+
 <br/>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Add an AgentFlow-style **News** timeline section to both READMEs, placed right after the hero/intro area and before the feature highlights. Lists project milestones with dates:

- #3 HuggingFace Paper of the Day (now visible as crawlable text, not just a badge image)
- 5 awesome-list features (with direct links)
- HarnessBench sister project launch + PyPI
- DeepWiki feature
- arXiv + HuggingFace dataset release

All achievements are now scannable text that LLM crawlers can extract, not just badge images. Bilingual parity maintained.

## Test plan
- [ ] News section renders correctly on GitHub (dark + light)
- [ ] All links resolve (5 awesome-lists, HarnessBench, DeepWiki, HF, arXiv, PyPI)
- [ ] Chinese parity: same items at same position in README.zh-CN.md