### PR TITLE
README: drop duplicate emoji News section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,6 @@
   <a href="https://deepwiki.com/reacher-z/ClawBench"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg" /></a>
 </p>
 
-</div>
-
-## 📣 News
-
-- [2026.04.17] 🚀 Added support for the **Codex** harness
-- [2026.04.16] 🦾 Added support for the **Claude Code** harness
-- [2026.04.14] 🛠️ Added support for the **OpenCode** harness
-
-<div align="center">
-
 <p align="center">
   <b>New:</b> Check out our sister project <a href="https://github.com/reacher-z/HarnessBench"><b>HarnessBench</b></a> &mdash;
   fixes the base model, varies the harness. Same scoring pipeline, orthogonal axis.


### PR DESCRIPTION
## What happened

PR #89 (emoji News) and PR #90 (FA-icon News) both merged without a conflict because they landed at different line ranges. Main now renders two News sections — the emoji one near the top (what you see in the screenshot), the FA-icon one further down.

## Fix

Remove the #89 emoji block; keep the FA-icon section from #90 as the canonical one.

- README.md: -10 lines (the duplicate emoji section + the stray `</div>` / `<div align="center">` wrapper it introduced)
- No change to README.zh-CN.md (zh-CN never had the duplicate).

## Test plan

- [ ] Only one `## ... News` heading in README.md on GitHub
- [ ] FA icons render (rocket / bolt / screwdriver-wrench / bullhorn)
- [ ] No orphaned `</div>` / `<div align=center>`; page layout intact