### PR TITLE
CD: release to PyPI #132

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,151 @@
+name: publish-pypi
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-pypi-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.package-version.outputs.version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Read package version
+        id: package-version
+        run: |
+          version="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          with Path("pyproject.toml").open("rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify release tag matches package version
+        if: github.event_name == 'release'
+        env:
+          PACKAGE_VERSION: ${{ steps.package-version.outputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          expected="v${PACKAGE_VERSION}"
+          if [[ "${RELEASE_TAG}" != "${expected}" ]]; then
+            echo "::error title=Release tag mismatch::Expected ${expected}, got ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Build wheel and source distribution
+        env:
+          UV_FROZEN: "true"
+        run: uv build
+
+      - name: Check distribution metadata
+        env:
+          UV_FROZEN: "true"
+        run: uvx twine check dist/*
+
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/clawbenchmark/${{ needs.build.outputs.version }}/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  smoke-test-testpypi:
+    name: Smoke test TestPyPI install
+    needs:
+      - build
+      - publish-testpypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install package from TestPyPI
+        env:
+          PACKAGE_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            "clawbenchmark==${PACKAGE_VERSION}"
+
+      - name: Verify console scripts
+        run: |
+          clawbench --help
+          clawbench-run --help
+          clawbench-batch --help
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'release'
+    needs:
+      - build
+      - smoke-test-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/clawbenchmark/${{ needs.build.outputs.version }}/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -50,3 +50,14 @@ jobs:
         env:
           UV_FROZEN: "true"
         run: uv build
+
+      - name: Check distribution metadata
+        env:
+          UV_FROZEN: "true"
+        run: uvx twine check dist/*
+
+      - name: Verify console scripts
+        run: |
+          uv run --frozen clawbench --help
+          uv run --frozen clawbench-run --help
+          uv run --frozen clawbench-batch --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
-name = "clawbench"
+name = "clawbenchmark"
 version = "0.2.0"
 description = "Benchmarking framework for evaluating AI web agents on real-world online tasks"
 readme = "README.md"
@@ -15,6 +15,12 @@ dependencies = [
     "questionary>=2.0",
     "rich>=13.0",
 ]
+
+[project.urls]
+Homepage = "https://claw-bench.com"
+Repository = "https://github.com/reacher-z/ClawBench"
+Issues = "https://github.com/reacher-z/ClawBench/issues"
+Paper = "https://arxiv.org/abs/2604.08523"
 
 [project.scripts]
 clawbench = "clawbench.tui:main"

--- a/src/clawbench/tui.py
+++ b/src/clawbench/tui.py
@@ -1489,6 +1489,13 @@ def _fix_engine(engine: str, status: str, detail: str) -> bool:
 def main() -> None:
     global STYLE, ACCENT, ACCENT2
 
+    if any(arg in {"-h", "--help"} for arg in sys.argv[1:]):
+        console.print("Usage: clawbench")
+        console.print()
+        console.print("Launch the interactive ClawBench TUI.")
+        console.print("For non-interactive runs, use clawbench-run or clawbench-batch.")
+        return
+
     _require_tty()
     ensure_workspace_templates()
     os.chdir(WORKSPACE_ROOT)

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,7 @@ wheels = [
 ]
 
 [[package]]
-name = "clawbench"
+name = "clawbenchmark"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
Since the package name [`claw-bench`](https://pypi.org/project/claw-bench/) is already taken, I'm switching the package name to `clawbenchmark` to pass PyPI restriction (since `clawbench` is considered too similar and thus prohibited; and other names like `clawbench-eval` are polluted by previous buggy releases). 