### PR TITLE
chore: migrate package to clawbench-eval

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://test.pypi.org/project/clawbenchmark/${{ needs.build.outputs.version }}/
+      url: https://test.pypi.org/project/clawbench-eval/${{ needs.build.outputs.version }}/
     permissions:
       contents: read
       id-token: write
@@ -118,7 +118,7 @@ jobs:
           python -m pip install \
             --index-url https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple/ \
-            "clawbenchmark==${PACKAGE_VERSION}"
+            "clawbench-eval==${PACKAGE_VERSION}"
 
       - name: Verify console scripts
         run: |
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/clawbenchmark/${{ needs.build.outputs.version }}/
+      url: https://pypi.org/project/clawbench-eval/${{ needs.build.outputs.version }}/
     permissions:
       contents: read
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.2] - 2026-05-08
+### Changed
+- Migrated the PyPI package to `clawbench-eval` instead of `clawbenchmark`.
+
 ## [0.2.1] - 2026-05-08
 ### Fixed
 - Included the `static/` directory in the package distribution, ensuring markdowns render properly on PyPI.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/clawbench)
 [![Codespaces](https://img.shields.io/badge/Codespaces-Open-181717?style=flat-square&logo=github&logoColor=white)](https://codespaces.new/reacher-z/ClawBench?quickstart=1)
 
-[![PyPI downloads](https://img.shields.io/pypi/dm/clawbenchmark?style=flat-square&logo=pypi&color=3775A9&logoColor=white&label=PyPI%20downloads)](https://pypi.org/project/clawbenchmark/)
-[![PyPI version](https://img.shields.io/pypi/v/clawbenchmark?style=flat-square&logo=pypi&color=3775A9&logoColor=white)](https://pypi.org/project/clawbenchmark/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/clawbench-eval?style=flat-square&logo=pypi&color=3775A9&logoColor=white&label=PyPI%20downloads)](https://pypi.org/project/clawbench-eval/)
+[![PyPI version](https://img.shields.io/pypi/v/clawbench-eval?style=flat-square&logo=pypi&color=3775A9&logoColor=white)](https://pypi.org/project/clawbench-eval/)
 [![Last commit](https://img.shields.io/github/last-commit/reacher-z/ClawBench?style=flat-square&logo=github&logoColor=white)](https://github.com/reacher-z/ClawBench/commits/main)
 [![Contributors](https://img.shields.io/github/contributors/reacher-z/ClawBench?style=flat-square&logo=github&logoColor=white)](https://github.com/reacher-z/ClawBench/graphs/contributors)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/reacher-z/ClawBench?style=flat-square&logo=github&logoColor=white)](https://github.com/reacher-z/ClawBench/graphs/commit-activity)
@@ -134,10 +134,10 @@ Point your coding agent (Claude Code, Cursor, Copilot, etc.) at [`AGENTS.md`](AG
 Install ClawBench from PyPI for normal use:
 
 ```bash
-uv tool install clawbenchmark
+uv tool install clawbench-eval
 ```
 
-You can also use `pipx install clawbenchmark` or `python -m pip install clawbenchmark`.
+You can also use `pipx install clawbench-eval` or `python -m pip install clawbench-eval`.
 The installed commands are still `clawbench`, `clawbench-run`, and
 `clawbench-batch`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,8 +16,8 @@
 [![Discord](https://img.shields.io/badge/Discord-%E5%8A%A0%E5%85%A5-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/clawbench)
 [![Codespaces](https://img.shields.io/badge/Codespaces-%E4%B8%80%E9%94%AE%E6%89%93%E5%BC%80-181717?style=flat-square&logo=github&logoColor=white)](https://codespaces.new/reacher-z/ClawBench?quickstart=1)
 
-[![PyPI downloads](https://img.shields.io/pypi/dm/clawbenchmark?style=flat-square&logo=pypi&color=3775A9&logoColor=white&label=PyPI%20downloads)](https://pypi.org/project/clawbenchmark/)
-[![PyPI version](https://img.shields.io/pypi/v/clawbenchmark?style=flat-square&logo=pypi&color=3775A9&logoColor=white)](https://pypi.org/project/clawbenchmark/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/clawbench-eval?style=flat-square&logo=pypi&color=3775A9&logoColor=white&label=PyPI%20downloads)](https://pypi.org/project/clawbench-eval/)
+[![PyPI version](https://img.shields.io/pypi/v/clawbench-eval?style=flat-square&logo=pypi&color=3775A9&logoColor=white)](https://pypi.org/project/clawbench-eval/)
 [![Last commit](https://img.shields.io/github/last-commit/reacher-z/ClawBench?style=flat-square&logo=github&logoColor=white)](https://github.com/reacher-z/ClawBench/commits/main)
 [![Contributors](https://img.shields.io/github/contributors/reacher-z/ClawBench?style=flat-square&logo=github&logoColor=white)](https://github.com/reacher-z/ClawBench/graphs/contributors)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/reacher-z/ClawBench?style=flat-square&logo=github&logoColor=white)](https://github.com/reacher-z/ClawBench/graphs/commit-activity)
@@ -128,10 +128,10 @@ git clone https://github.com/reacher-z/ClawBench.git && cd ClawBench && ./run.sh
 日常使用建议直接从 PyPI 安装 ClawBench:
 
 ```bash
-uv tool install clawbenchmark
+uv tool install clawbench-eval
 ```
 
-也可以使用 `pipx install clawbenchmark` 或 `python -m pip install clawbenchmark`。
+也可以使用 `pipx install clawbench-eval` 或 `python -m pip install clawbench-eval`。
 安装后的命令仍然是 `clawbench`、`clawbench-run` 和 `clawbench-batch`。
 
 如果你想要更细粒度的控制或参与贡献，可以克隆仓库并运行根目录 `uv` 包入口:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
-name = "clawbenchmark"
-version = "0.2.1"
+name = "clawbench-eval"
+version = "0.2.2"
 description = "Benchmarking framework for evaluating AI web agents on real-world online tasks"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -57,8 +57,8 @@ wheels = [
 ]
 
 [[package]]
-name = "clawbenchmark"
-version = "0.2.1"
+name = "clawbench-eval"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fpdf2" },


### PR DESCRIPTION
- Migrate PyPI package from `clawbenchmark` to `clawbench-eval`. 