### PR TITLE
feat: inline LLM judge as second scoring stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ order food, book travel, apply for jobs, write reviews, manage projects.<br/>
 
 ## <img src="static/icons/bullhorn.svg" width="20" height="20"> News
 
+- **[2026.05.09]** <img src="static/icons/robot.svg" width="14" height="14"> &nbsp;Added an **inline LLM judge** as the second scoring stage. Pass = (1) the agent's final HTTP request is intercepted and matches the task's URL/method schema, AND (2) an LLM judge confirms the request body actually fulfills the natural-language instruction. Default judge: `deepseek-v4-pro`. Disable with `--no-judge`. This means **runs now produce a final pass/fail score automatically** — no separate trajectory inspection step.
 - **[2026.05.09]** <img src="static/icons/rocket.svg" width="14" height="14"> &nbsp;We have updated our release pipeline and published the package to PyPI under [**clawbench-eval**](https://pypi.org/project/clawbench-eval/) for easier usage.
 - **[2026.05.04]** <img src="static/icons/screwdriver-wrench.svg" width="14" height="14"> &nbsp;Refactored the codebase to improve project structure, streamline the CI/CD pipeline, make it easier to extend ClawBench to additional test suites, and deliver more stable builds across **V1**, **V1-Lite**, and **V2**. The FAQ section was also updated based on user feedback.
 - **[2026.05.01]** <img src="static/icons/rocket.svg" width="14" height="14"> &nbsp;Added the full **V2** 130-task corpus and one-command Hermes launch:

--- a/src/clawbench/runner/batch.py
+++ b/src/clawbench/runner/batch.py
@@ -227,6 +227,8 @@ async def run_job(
     batch_start: float,
     no_upload: bool = False,
     harness: str | None = None,
+    judge: str | None = None,
+    no_judge: bool = False,
 ) -> None:
     assert shutdown_event is not None
     try:
@@ -267,6 +269,10 @@ async def run_job(
                     cmd_parts.append("--no-upload")
                 if harness:
                     cmd_parts += ["--harness", harness]
+                if no_judge:
+                    cmd_parts.append("--no-judge")
+                elif judge:
+                    cmd_parts += ["--judge", judge]
                 proc = await asyncio.create_subprocess_exec(
                     *cmd_parts,
                     stdout=asyncio.subprocess.PIPE,
@@ -634,6 +640,8 @@ async def async_main(args: argparse.Namespace) -> int:
                 batch_start,
                 no_upload=args.no_upload,
                 harness=args.harness,
+                judge=args.judge,
+                no_judge=args.no_judge,
             )
         )
         for j in jobs
@@ -738,6 +746,21 @@ def main() -> None:
         choices=HARNESSES,
         default=DEFAULT_HARNESS,
         help=f"Coding-agent harness (default: {DEFAULT_HARNESS})",
+    )
+    p.add_argument(
+        "--judge",
+        default="deepseek-v4-pro",
+        help=(
+            "Model name (key in models/models.yaml) used as LLM judge over "
+            "intercepted HTTP requests. Pass = intercepted AND judge says match. "
+            "Default: deepseek-v4-pro. Use --no-judge to disable."
+        ),
+    )
+    p.add_argument(
+        "--no-judge",
+        dest="no_judge",
+        action="store_true",
+        help="Skip the LLM judge stage; pass = intercepted (stage 1 only)",
     )
     args = p.parse_args()
     if args.cases_dir is None:

--- a/src/clawbench/runner/judge.py
+++ b/src/clawbench/runner/judge.py
@@ -1,0 +1,199 @@
+"""LLM judge for ClawBench: decide if an intercepted HTTP request fulfills the instruction.
+
+Stage 2 of the two-stage scoring rubric:
+  Stage 1 — request matches eval_schema regex+method (set by interceptor → run-meta.intercepted).
+  Stage 2 — judge: given task instruction + intercepted request body, does the request
+            actually do what the user asked?
+
+Final pass = stage1 AND stage2.
+
+Uses only stdlib (urllib.request) so no extra deps. Loads model config from models.yaml
+the same way run.py does, supports api_type in
+{openai-completions, openai-responses, anthropic-messages}.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+import urllib.error
+from typing import Any
+
+
+JUDGE_SYSTEM = """You are a strict evaluator for a web-agent benchmark.
+
+A user gave a natural-language INSTRUCTION to an autonomous browser agent.
+The agent navigated a real website and finally produced a single HTTP request
+(URL + method + body) that we INTERCEPTED before it was sent to the server.
+
+Decide whether this intercepted request, if it had been sent, would correctly
+fulfill the user's instruction.
+
+Rules:
+- Match = the request would do what the user asked (right item, right action,
+  right target, right quantity). Cosmetic differences (timestamps, session IDs,
+  affiliate codes, etc.) are OK.
+- Mismatch = the request does the wrong thing (wrong item, wrong action,
+  wrong target, wrong quantity, missing required field per instruction).
+- If the request is ambiguous or only partially correct, mark as mismatch.
+
+Reply with ONLY a single-line JSON object, no markdown fences, no extra prose:
+{"match": true|false, "reason": "<one short sentence>"}
+"""
+
+
+def _build_user_msg(instruction: str, intercept: dict[str, Any]) -> str:
+    req = intercept.get("request") or {}
+    body = req.get("body")
+    if isinstance(body, (dict, list)):
+        body_str = json.dumps(body, ensure_ascii=False, indent=2)[:6000]
+    else:
+        body_str = str(body)[:6000] if body is not None else "(empty)"
+    return (
+        f"INSTRUCTION:\n{instruction}\n\n"
+        f"INTERCEPTED REQUEST:\n"
+        f"  url: {req.get('url')}\n"
+        f"  method: {req.get('method')}\n"
+        f"  body:\n{body_str}\n"
+    )
+
+
+def _post_json(url: str, headers: dict[str, str], payload: dict[str, Any], timeout: int = 60) -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={**headers, "Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def _call_openai_chat(model_cfg: dict, model_name: str, system: str, user: str) -> str:
+    base = model_cfg["base_url"].rstrip("/")
+    url = f"{base}/chat/completions"
+    # Reasoning models (DeepSeek v4-pro, OpenAI o-series, etc.) silently burn
+    # max_tokens on hidden reasoning_content. Give the budget enough headroom
+    # that a few thousand reasoning tokens still leaves room for a JSON line.
+    payload = {
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": 4096,
+        "temperature": 0,
+    }
+    headers = {"Authorization": f"Bearer {model_cfg['api_key']}"}
+    resp = _post_json(url, headers, payload)
+    return resp["choices"][0]["message"].get("content") or ""
+
+
+def _call_openai_responses(model_cfg: dict, model_name: str, system: str, user: str) -> str:
+    base = model_cfg["base_url"].rstrip("/")
+    url = f"{base}/responses"
+    payload = {
+        "model": model_name,
+        "instructions": system,
+        "input": user,
+        "max_output_tokens": 4096,
+    }
+    headers = {"Authorization": f"Bearer {model_cfg['api_key']}"}
+    resp = _post_json(url, headers, payload)
+    # /v1/responses returns output[].content[].text
+    out = resp.get("output_text")
+    if out:
+        return out
+    pieces: list[str] = []
+    for item in resp.get("output", []):
+        for c in item.get("content", []):
+            if c.get("type") in ("output_text", "text"):
+                pieces.append(c.get("text", ""))
+    return "".join(pieces)
+
+
+def _call_anthropic_messages(model_cfg: dict, model_name: str, system: str, user: str) -> str:
+    base = model_cfg["base_url"].rstrip("/")
+    url = f"{base}/v1/messages"
+    payload = {
+        "model": model_name,
+        "max_tokens": 4096,
+        "system": system,
+        "messages": [{"role": "user", "content": user}],
+    }
+    headers = {
+        "x-api-key": model_cfg["api_key"],
+        "anthropic-version": "2023-06-01",
+    }
+    resp = _post_json(url, headers, payload)
+    return resp["content"][0]["text"]
+
+
+def _parse_verdict(text: str) -> tuple[bool | None, str]:
+    """Best-effort parse of the judge's reply into (match, reason)."""
+    text = (text or "").strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.startswith("json"):
+            text = text[4:].strip()
+    # Take first {...} block
+    try:
+        start = text.index("{")
+        end = text.rindex("}") + 1
+        obj = json.loads(text[start:end])
+        return bool(obj.get("match")), str(obj.get("reason", ""))
+    except (ValueError, json.JSONDecodeError):
+        # Heuristic fallback
+        low = text.lower()
+        if "match" in low and "true" in low and "false" not in low.split("true")[-1][:30]:
+            return True, text[:200]
+        if "match" in low and "false" in low:
+            return False, text[:200]
+        return None, text[:200] or "unparseable"
+
+
+def judge_request(
+    model_cfg: dict,
+    judge_model_name: str,
+    instruction: str,
+    intercept: dict[str, Any],
+    *,
+    retries: int = 2,
+) -> dict[str, Any]:
+    """Run a single judge call. Returns dict with keys match/reason/judge_model/raw/error."""
+    system = JUDGE_SYSTEM
+    user = _build_user_msg(instruction, intercept)
+    api_type = model_cfg.get("api_type", "openai-completions")
+
+    last_err: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            if api_type == "openai-completions":
+                raw = _call_openai_chat(model_cfg, judge_model_name, system, user)
+            elif api_type == "openai-responses":
+                raw = _call_openai_responses(model_cfg, judge_model_name, system, user)
+            elif api_type == "anthropic-messages":
+                raw = _call_anthropic_messages(model_cfg, judge_model_name, system, user)
+            else:
+                return {
+                    "match": None,
+                    "reason": f"unsupported judge api_type {api_type!r}",
+                    "judge_model": judge_model_name,
+                    "raw": None,
+                    "error": "unsupported_api_type",
+                }
+            match, reason = _parse_verdict(raw)
+            return {
+                "match": match,
+                "reason": reason,
+                "judge_model": judge_model_name,
+                "raw": raw,
+                "error": None,
+            }
+        except Exception as e:
+            last_err = e
+            if attempt < retries:
+                time.sleep(2 ** attempt)
+    return {
+        "match": None,
+        "reason": f"judge_call_failed: {last_err}",
+        "judge_model": judge_model_name,
+        "raw": None,
+        "error": str(last_err),
+    }

--- a/src/clawbench/runner/run.py
+++ b/src/clawbench/runner/run.py
@@ -1318,6 +1318,21 @@ def main():
         default=DEFAULT_HARNESS,
         help=f"Coding-agent harness (default: {DEFAULT_HARNESS})",
     )
+    parser.add_argument(
+        "--judge",
+        default="deepseek-v4-pro",
+        help=(
+            "Model name (key in models/models.yaml) used as LLM judge over the "
+            "intercepted HTTP request. Pass = intercepted AND judge says match. "
+            "Default: deepseek-v4-pro. Use --no-judge to disable."
+        ),
+    )
+    parser.add_argument(
+        "--no-judge",
+        dest="no_judge",
+        action="store_true",
+        help="Skip the LLM judge stage; pass = intercepted (stage 1 only)",
+    )
     args = parser.parse_args()
 
     if not args.human and args.model is None:
@@ -1532,6 +1547,49 @@ def main():
         step("Results")
         intercepted = print_results(output_dir)
 
+        # Stage 2 — LLM judge (default on, --no-judge to skip).
+        # Only invoked when stage 1 (intercepted) succeeded; otherwise the
+        # task already fails at stage 1 and there's nothing to judge.
+        judge_result: dict[str, Any] | None = None
+        if intercepted and not args.no_judge and args.judge:
+            phase = "running_judge"
+            step("LLM judge")
+            try:
+                from clawbench.runner.judge import judge_request
+                judge_cfg = load_model_config(args.judge)
+                instruction_text = (task.get("instruction") if isinstance(task, dict) else "") or ""
+                interception_path = output_dir / "data" / "interception.json"
+                if interception_path.exists():
+                    intercept_blob = json.loads(interception_path.read_text())
+                else:
+                    intercept_blob = {}
+                judge_result = judge_request(
+                    judge_cfg,
+                    judge_cfg.get("model", args.judge),
+                    instruction_text,
+                    intercept_blob,
+                )
+                (output_dir / "judge.json").write_text(
+                    json.dumps(judge_result, indent=2, ensure_ascii=False)
+                )
+                print(
+                    f"Judge ({args.judge}): "
+                    f"match={judge_result.get('match')}  "
+                    f"reason={judge_result.get('reason', '')[:160]}"
+                )
+            except Exception as e:
+                judge_result = {
+                    "match": None,
+                    "reason": f"judge_setup_failed: {e}",
+                    "judge_model": args.judge,
+                    "raw": None,
+                    "error": str(e),
+                }
+                (output_dir / "judge.json").write_text(
+                    json.dumps(judge_result, indent=2, ensure_ascii=False)
+                )
+                print(f"Judge skipped due to error: {e}")
+
         # Write run metadata
         phase = "writing_run_meta"
         duration = time.time() - start_time
@@ -1548,6 +1606,13 @@ def main():
             intercepted=intercepted,
             classification=classification,
             extra_info_warnings=extra_info_warnings,
+        )
+        if judge_result is not None:
+            meta["judge"] = judge_result
+            meta["judge_match"] = judge_result.get("match")
+        meta["pass"] = bool(
+            intercepted
+            and (args.no_judge or judge_result is None or judge_result.get("match") is True)
         )
         write_run_meta(output_dir, meta)
 
@@ -1596,11 +1661,23 @@ def main():
             shutil.rmtree(personal_info_tmp, ignore_errors=True)
         (output_dir / "eval-schema.json").unlink(missing_ok=True)
 
-    if intercepted:
-        print(f"\nINTERCEPTED — results in {output_dir}")
-    else:
+    # Final pass status: stage 1 (intercepted) AND stage 2 (judge match), unless --no-judge.
+    final_pass = bool(meta.get("pass"))
+    if not intercepted:
         print(f"\nNOT INTERCEPTED — results in {output_dir}")
         sys.exit(1)
+    if not args.no_judge and judge_result is not None and judge_result.get("match") is not True:
+        verdict = judge_result.get("match")
+        reason = judge_result.get("reason", "")
+        print(
+            f"\nINTERCEPTED but JUDGE {'MISMATCH' if verdict is False else 'INCONCLUSIVE'} "
+            f"— results in {output_dir}\n  reason: {reason[:200]}"
+        )
+        sys.exit(1)
+    if final_pass:
+        print(f"\nINTERCEPTED + JUDGE MATCH — results in {output_dir}")
+    else:
+        print(f"\nINTERCEPTED — results in {output_dir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a two-stage pass criterion to `clawbench-run` / `clawbench-batch`:

- **Stage 1 — interceptor** (existing): the agent's final HTTP request must match the task's `eval_schema` URL pattern + method.
- **Stage 2 — LLM judge** (new): given the natural-language `instruction` and the intercepted request body, a judge LLM decides whether the request actually fulfills the user's intent.

**Final pass = stage 1 AND stage 2.** Runs now produce a final pass/fail score automatically — no separate trajectory inspection step.

## Why

Previously the runner emitted `intercepted=true|false` and downstream scoring was manual. Two failure modes were silently classified as pass: (a) wrong-target requests that happened to hit the right endpoint, (b) malformed payloads that satisfied the regex but didn't do the user's task. The judge stage closes both gaps.

## What's added

- `src/clawbench/runner/judge.py` — stdlib-only `judge_request()` helper supporting `openai-completions`, `openai-responses`, and `anthropic-messages` api_types. Reads the model config from `models/models.yaml` like the agent does.
- `clawbench-run` and `clawbench-batch`: new `--judge MODEL` (default: `deepseek-v4-pro`) and `--no-judge` flags. After interception, the runner calls the judge, writes `judge.json` next to `run-meta.json`, embeds the verdict into `run-meta.json` (`judge`, `judge_match`, `pass`), and returns exit 1 unless both stages pass.
- `batch-summary.json` `passed` totals automatically reflect the new metric via subprocess return-code propagation — no extra aggregation needed.

## Default judge: `deepseek-v4-pro`

Cheap, capable, OpenAI-compatible API. Override with `--judge claude-sonnet-4-6` etc. Use `--no-judge` to fall back to stage-1-only scoring (legacy behavior).

## Test plan

- [x] `judge.py` smoke test against an existing intercepted v2 case (eventbrite free-event registration) — judge returns `{"match": true, "reason": "..."}` correctly via DeepSeek API.
- [ ] End-to-end: launch `clawbench-batch --cases-suite v2 --models <model>` and verify `batch-summary.json` `passed` count matches `run-meta.pass=true` count across all per-task dirs.
- [ ] `--no-judge` passthrough preserves legacy `intercepted`-only scoring.
- [ ] Judge errors (network/API) → `match=null`, exit 1, surfaced in `run-meta.json`.