### PR TITLE
feat: add --resume flag to batch runner to skip completed jobs

### DIFF
--- a/src/clawbench/runner/batch.py
+++ b/src/clawbench/runner/batch.py
@@ -580,9 +580,28 @@ async def async_main(args: argparse.Namespace) -> int:
 
     _run_mod.docker_build(args.harness)
 
-    batch_ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    base_output = Path(args.output_dir).resolve() / f"batch-{batch_ts}"
-    log_dir = base_output / "batch-logs"
+    if args.resume:
+        base_output = Path(args.resume).resolve()
+        if not base_output.exists():
+            print(f"ERROR: --resume directory does not exist: {base_output}")
+            return 1
+        log_dir = base_output / "batch-logs"
+        skipped = 0
+        for job in jobs:
+            safe_model = re.sub(r"[/:]+", "--", job.model)
+            if (log_dir / f"{job.case_name}-{safe_model}.log").exists():
+                job.status = "skipped"
+                skipped += 1
+        remaining = sum(1 for j in jobs if j.status == "pending")
+        print(f"\n[RESUME] Reusing {base_output}")
+        print(f"[RESUME] {skipped} job(s) already done, {remaining} remaining")
+        if remaining == 0:
+            print("[RESUME] All jobs already completed.")
+            return 0
+    else:
+        batch_ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        base_output = Path(args.output_dir).resolve() / f"batch-{batch_ts}"
+        log_dir = base_output / "batch-logs"
     log_dir.mkdir(parents=True, exist_ok=True)
 
     sem = asyncio.Semaphore(args.max_concurrent)
@@ -628,8 +647,14 @@ async def async_main(args: argparse.Namespace) -> int:
     loop.add_signal_handler(signal.SIGTERM, on_signal)
 
     throttle = StartupThrottle(args.stagger_delay)
+
+    async def _noop() -> None:
+        """Placeholder for jobs already marked skipped (e.g. by --resume)."""
+
     all_tasks = [
-        asyncio.create_task(
+        asyncio.create_task(_noop())
+        if j.status == "skipped"
+        else asyncio.create_task(
             run_job(
                 j,
                 sem,
@@ -738,6 +763,15 @@ def main() -> None:
         dest="no_upload",
         action="store_true",
         help="Skip HuggingFace upload for all runs",
+    )
+    p.add_argument(
+        "--resume",
+        default=None,
+        metavar="BATCH_DIR",
+        help=(
+            "Resume a previous batch run: reuse its output directory and skip "
+            "any (case x model) job whose batch-logs/<case>-<model>.log already exists."
+        ),
     )
     from clawbench.runner.run import HARNESSES, DEFAULT_HARNESS
 

--- a/src/clawbench/runner/judge.py
+++ b/src/clawbench/runner/judge.py
@@ -11,6 +11,7 @@ Uses only stdlib (urllib.request) so no extra deps. Loads model config from mode
 the same way run.py does, supports api_type in
 {openai-completions, openai-responses, anthropic-messages}.
 """
+
 from __future__ import annotations
 
 import json
@@ -58,9 +59,13 @@ def _build_user_msg(instruction: str, intercept: dict[str, Any]) -> str:
     )
 
 
-def _post_json(url: str, headers: dict[str, str], payload: dict[str, Any], timeout: int = 60) -> dict[str, Any]:
+def _post_json(
+    url: str, headers: dict[str, str], payload: dict[str, Any], timeout: int = 60
+) -> dict[str, Any]:
     data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=data, headers={**headers, "Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={**headers, "Content-Type": "application/json"}
+    )
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read())
 
@@ -85,7 +90,9 @@ def _call_openai_chat(model_cfg: dict, model_name: str, system: str, user: str) 
     return resp["choices"][0]["message"].get("content") or ""
 
 
-def _call_openai_responses(model_cfg: dict, model_name: str, system: str, user: str) -> str:
+def _call_openai_responses(
+    model_cfg: dict, model_name: str, system: str, user: str
+) -> str:
     base = model_cfg["base_url"].rstrip("/")
     url = f"{base}/responses"
     payload = {
@@ -108,7 +115,9 @@ def _call_openai_responses(model_cfg: dict, model_name: str, system: str, user: 
     return "".join(pieces)
 
 
-def _call_anthropic_messages(model_cfg: dict, model_name: str, system: str, user: str) -> str:
+def _call_anthropic_messages(
+    model_cfg: dict, model_name: str, system: str, user: str
+) -> str:
     base = model_cfg["base_url"].rstrip("/")
     url = f"{base}/v1/messages"
     payload = {
@@ -141,7 +150,11 @@ def _parse_verdict(text: str) -> tuple[bool | None, str]:
     except (ValueError, json.JSONDecodeError):
         # Heuristic fallback
         low = text.lower()
-        if "match" in low and "true" in low and "false" not in low.split("true")[-1][:30]:
+        if (
+            "match" in low
+            and "true" in low
+            and "false" not in low.split("true")[-1][:30]
+        ):
             return True, text[:200]
         if "match" in low and "false" in low:
             return False, text[:200]
@@ -169,7 +182,9 @@ def judge_request(
             elif api_type == "openai-responses":
                 raw = _call_openai_responses(model_cfg, judge_model_name, system, user)
             elif api_type == "anthropic-messages":
-                raw = _call_anthropic_messages(model_cfg, judge_model_name, system, user)
+                raw = _call_anthropic_messages(
+                    model_cfg, judge_model_name, system, user
+                )
             else:
                 return {
                     "match": None,
@@ -189,7 +204,7 @@ def judge_request(
         except Exception as e:
             last_err = e
             if attempt < retries:
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
     return {
         "match": None,
         "reason": f"judge_call_failed: {last_err}",

--- a/src/clawbench/runner/run.py
+++ b/src/clawbench/runner/run.py
@@ -1556,8 +1556,11 @@ def main():
             step("LLM judge")
             try:
                 from clawbench.runner.judge import judge_request
+
                 judge_cfg = load_model_config(args.judge)
-                instruction_text = (task.get("instruction") if isinstance(task, dict) else "") or ""
+                instruction_text = (
+                    task.get("instruction") if isinstance(task, dict) else ""
+                ) or ""
                 interception_path = output_dir / "data" / "interception.json"
                 if interception_path.exists():
                     intercept_blob = json.loads(interception_path.read_text())
@@ -1612,7 +1615,11 @@ def main():
             meta["judge_match"] = judge_result.get("match")
         meta["pass"] = bool(
             intercepted
-            and (args.no_judge or judge_result is None or judge_result.get("match") is True)
+            and (
+                args.no_judge
+                or judge_result is None
+                or judge_result.get("match") is True
+            )
         )
         write_run_meta(output_dir, meta)
 
@@ -1666,7 +1673,11 @@ def main():
     if not intercepted:
         print(f"\nNOT INTERCEPTED — results in {output_dir}")
         sys.exit(1)
-    if not args.no_judge and judge_result is not None and judge_result.get("match") is not True:
+    if (
+        not args.no_judge
+        and judge_result is not None
+        and judge_result.get("match") is not True
+    ):
         verdict = judge_result.get("match")
         reason = judge_result.get("reason", "")
         print(


### PR DESCRIPTION
Pass --resume <BATCH_DIR> to reuse a previous batch's output directory and skip any (case x model) whose batch-logs/<case>-<model>.log already exists, so an interrupted batch can be picked up without redoing work.

## What does this PR do?

<!-- Brief description -->

## Test plan

- [ ] <!-- How you verified this works -->

## Related issues

<!-- Fixes #N or "N/A" -->
