### PR TITLE
style: ruff format judge.py and run.py (unblocks main + all open PRs)

### DIFF
--- a/src/clawbench/runner/judge.py
+++ b/src/clawbench/runner/judge.py
@@ -11,6 +11,7 @@ Uses only stdlib (urllib.request) so no extra deps. Loads model config from mode
 the same way run.py does, supports api_type in
 {openai-completions, openai-responses, anthropic-messages}.
 """
+
 from __future__ import annotations
 
 import json
@@ -58,9 +59,13 @@ def _build_user_msg(instruction: str, intercept: dict[str, Any]) -> str:
     )
 
 
-def _post_json(url: str, headers: dict[str, str], payload: dict[str, Any], timeout: int = 60) -> dict[str, Any]:
+def _post_json(
+    url: str, headers: dict[str, str], payload: dict[str, Any], timeout: int = 60
+) -> dict[str, Any]:
     data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=data, headers={**headers, "Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={**headers, "Content-Type": "application/json"}
+    )
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read())
 
@@ -85,7 +90,9 @@ def _call_openai_chat(model_cfg: dict, model_name: str, system: str, user: str) 
     return resp["choices"][0]["message"].get("content") or ""
 
 
-def _call_openai_responses(model_cfg: dict, model_name: str, system: str, user: str) -> str:
+def _call_openai_responses(
+    model_cfg: dict, model_name: str, system: str, user: str
+) -> str:
     base = model_cfg["base_url"].rstrip("/")
     url = f"{base}/responses"
     payload = {
@@ -108,7 +115,9 @@ def _call_openai_responses(model_cfg: dict, model_name: str, system: str, user: 
     return "".join(pieces)
 
 
-def _call_anthropic_messages(model_cfg: dict, model_name: str, system: str, user: str) -> str:
+def _call_anthropic_messages(
+    model_cfg: dict, model_name: str, system: str, user: str
+) -> str:
     base = model_cfg["base_url"].rstrip("/")
     url = f"{base}/v1/messages"
     payload = {
@@ -141,7 +150,11 @@ def _parse_verdict(text: str) -> tuple[bool | None, str]:
     except (ValueError, json.JSONDecodeError):
         # Heuristic fallback
         low = text.lower()
-        if "match" in low and "true" in low and "false" not in low.split("true")[-1][:30]:
+        if (
+            "match" in low
+            and "true" in low
+            and "false" not in low.split("true")[-1][:30]
+        ):
             return True, text[:200]
         if "match" in low and "false" in low:
             return False, text[:200]
@@ -169,7 +182,9 @@ def judge_request(
             elif api_type == "openai-responses":
                 raw = _call_openai_responses(model_cfg, judge_model_name, system, user)
             elif api_type == "anthropic-messages":
-                raw = _call_anthropic_messages(model_cfg, judge_model_name, system, user)
+                raw = _call_anthropic_messages(
+                    model_cfg, judge_model_name, system, user
+                )
             else:
                 return {
                     "match": None,
@@ -189,7 +204,7 @@ def judge_request(
         except Exception as e:
             last_err = e
             if attempt < retries:
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
     return {
         "match": None,
         "reason": f"judge_call_failed: {last_err}",

--- a/src/clawbench/runner/run.py
+++ b/src/clawbench/runner/run.py
@@ -1556,8 +1556,11 @@ def main():
             step("LLM judge")
             try:
                 from clawbench.runner.judge import judge_request
+
                 judge_cfg = load_model_config(args.judge)
-                instruction_text = (task.get("instruction") if isinstance(task, dict) else "") or ""
+                instruction_text = (
+                    task.get("instruction") if isinstance(task, dict) else ""
+                ) or ""
                 interception_path = output_dir / "data" / "interception.json"
                 if interception_path.exists():
                     intercept_blob = json.loads(interception_path.read_text())
@@ -1612,7 +1615,11 @@ def main():
             meta["judge_match"] = judge_result.get("match")
         meta["pass"] = bool(
             intercepted
-            and (args.no_judge or judge_result is None or judge_result.get("match") is True)
+            and (
+                args.no_judge
+                or judge_result is None
+                or judge_result.get("match") is True
+            )
         )
         write_run_meta(output_dir, meta)
 
@@ -1666,7 +1673,11 @@ def main():
     if not intercepted:
         print(f"\nNOT INTERCEPTED — results in {output_dir}")
         sys.exit(1)
-    if not args.no_judge and judge_result is not None and judge_result.get("match") is not True:
+    if (
+        not args.no_judge
+        and judge_result is not None
+        and judge_result.get("match") is not True
+    ):
         verdict = judge_result.get("match")
         reason = judge_result.get("reason", "")
         print(


### PR DESCRIPTION
## Summary

- Pure ruff-format whitespace fix for \`src/clawbench/runner/judge.py\` and \`src/clawbench/runner/run.py\`.
- These two files landed via #139 without \`ruff format\`, so \`static-check\` has been failing on \`main\` since that merge.
- Because every PR runs \`static-check\` against the whole tree, every open PR (notably #140) is being blocked even though their own diffs are clean.

## What this changes

\`\`\`
 src/clawbench/runner/judge.py | 29 ++++++++++++++++++++++-------
 src/clawbench/runner/run.py   | 17 ++++++++++++++---
 2 files changed, 36 insertions(+), 10 deletions(-)
\`\`\`

All changes are line-wrap / blank-line edits emitted by \`uv run --frozen ruff format\`. No behavior change.

## Test plan

- [x] \`uv run --frozen ruff format --check src/clawbench/runner/judge.py src/clawbench/runner/run.py\` -> "2 files already formatted"
- [ ] \`static-check\` CI passes on this PR
- [ ] After merge, re-run \`static-check\` on #140 to confirm it goes green