### PR TITLE
docs: add 'What are you looking for?' audience-targeted entry grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,71 @@ order food, book travel, apply for jobs, write reviews, manage projects.<br/>
 
 </div>
 
+## <img src="static/icons/circle-question.svg" width="20" height="20"> What are you looking for?
+
+<table>
+<tr>
+<td width="25%" align="center" valign="top">
+
+🏆 **See scores**<br/>
+[Live leaderboard](https://huggingface.co/spaces/NAIL-Group/clawbench-leaderboard)<br/>
+<sub>Pick a corpus (v1 / v2)</sub>
+
+</td>
+<td width="25%" align="center" valign="top">
+
+🚀 **Run it on your model**<br/>
+[Quick start ↓](#-human-quick-start)<br/>
+<sub><code>pip install clawbench-eval</code></sub>
+
+</td>
+<td width="25%" align="center" valign="top">
+
+📊 **Browse 283 tasks**<br/>
+[Task explorer](https://claw-bench.com/v2)<br/>
+<sub>Search · filter · category</sub>
+
+</td>
+<td width="25%" align="center" valign="top">
+
+📄 **Read the paper**<br/>
+[arXiv:2604.08523](https://arxiv.org/abs/2604.08523)<br/>
+<sub>Methodology · evaluator · results</sub>
+
+</td>
+</tr>
+<tr>
+<td align="center" valign="top">
+
+🎬 **Re-grade old runs**<br/>
+[V1 raw traces](https://huggingface.co/datasets/NAIL-Group/ClawBenchV1Trace)<br/>
+<sub>5 layers per (task × model)</sub>
+
+</td>
+<td align="center" valign="top">
+
+📦 **Download the data**<br/>
+[`hf download NAIL-Group/ClawBench`](https://huggingface.co/datasets/NAIL-Group/ClawBench)<br/>
+<sub>Tasks · rubrics · metadata</sub>
+
+</td>
+<td align="center" valign="top">
+
+🌱 **Add a task / model**<br/>
+[How to contribute](#contributing)<br/>
+<sub>YAML spec + rubric</sub>
+
+</td>
+<td align="center" valign="top">
+
+❓ **Have a question**<br/>
+[FAQ](#frequently-asked-questions) · [Discord](https://discord.gg/clawbench)<br/>
+<sub>Or open an issue</sub>
+
+</td>
+</tr>
+</table>
+
 ## <img src="static/icons/bullhorn.svg" width="20" height="20"> News
 
 - **[2026.05.09]** <img src="static/icons/globe.svg" width="14" height="14"> Added support for the **pi** harness — Pi coding agent + `pi-browser-harness`.


### PR DESCRIPTION
## Summary

Add an 8-cell audience-targeted entry grid right after the hero, before News, so a reader landing on the README finds the right path in <5 seconds:

| | | | |
|---|---|---|---|
| 🏆 See scores | 🚀 Run it | 📊 Browse 283 tasks | 📄 Read the paper |
| 🎬 Re-grade old runs | 📦 Download data | 🌱 Add task/model | ❓ Have a question |

Mirrors the same pattern we just shipped on https://claw-bench.com (4 audience CTA cards in the hero) so the README and the website tell the same story.

## Test plan

- [ ] All 8 anchors / external links resolve
- [ ] Renders correctly on github.com
- [ ] Mobile-readable (table cells stack OK on narrow viewports)