### PR TITLE
fix: resolve #105 — FEAT: support steel browser

### DIFF
--- a/src/clawbench/runtime/harnesses/steel-browser/Dockerfile.steel-browser
+++ b/src/clawbench/runtime/harnesses/steel-browser/Dockerfile.steel-browser
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y \
+    chromium \
+    chromium-driver \
+    xvfb \
+    wget \
+    unzip \
+    curl \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHROME_BIN=/usr/bin/chromium \
+    CHROMEDRIVER_PATH=/usr/bin/chromedriver
+
+WORKDIR /app
+
+COPY setup.sh setup.sh
+COPY run-steel-browser.sh run-steel-browser.sh
+COPY agent.py agent.py
+
+RUN chmod +x setup.sh run-steel-browser.sh
+
+ENTRYPOINT ["./run-steel-browser.sh"]

--- a/src/clawbench/runtime/harnesses/steel-browser/run-steel-browser.sh
+++ b/src/clawbench/runtime/harnesses/steel-browser/run-steel-browser.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CLAW_TASK:?Missing CLAW_TASK}"
+: "${CLAW_START_URL:?Missing CLAW_START_URL}"
+: "${CLAW_OUTPUT_DIR:?Missing CLAW_OUTPUT_DIR}"
+
+mkdir -p "$CLAW_OUTPUT_DIR"
+
+XVFB_DISPLAY=${XVFB_DISPLAY:-99}
+Xvfb ":$XVFB_DISPLAY" -screen 0 1280x1024x24 &
+XVFB_PID=$!
+export DISPLAY=":$XVFB_DISPLAY"
+
+cleanup() {
+    kill "$XVFB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cd "$(dirname "$0")"
+
+python agent.py

--- a/src/clawbench/runtime/harnesses/steel-browser/setup-steel-browser.sh
+++ b/src/clawbench/runtime/harnesses/steel-browser/setup-steel-browser.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+pip install steel-browser openai beautifulsoup4 lxml


### PR DESCRIPTION
## Summary

fix: resolve #105 — FEAT: support steel browser

## Problem

**Severity**: `Medium` | **File**: `src/clawbench/runtime/harnesses/steel-browser/Dockerfile.steel-browser`

Creates a Dockerfile based on Python 3.11-slim with Chromium, ChromeDriver, Xvfb, and other dependencies required to run the steel-browser agent. It also copies the setup, run, and agent scripts, and sets the entrypoint to run-steel-browser.sh.

## Solution

Use the following content:

## Changes

- `src/clawbench/runtime/harnesses/steel-browser/Dockerfile.steel-browser` (new)
- `src/clawbench/runtime/harnesses/steel-browser/setup-steel-browser.sh` (new)
- `src/clawbench/runtime/harnesses/steel-browser/run-steel-browser.sh` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"