### PR TITLE
chore: corpus-aware issue + PR templates (default v2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,18 @@ body:
       description: What happened? What did you expect?
     validations:
       required: true
+  - type: dropdown
+    id: corpus
+    attributes:
+      label: Corpus
+      description: Which ClawBench corpus were you running? V2 is the current default.
+      default: 0
+      options:
+        - v2
+        - v1
+        - v1-lite
+        - claw-eval
+        - not applicable
   - type: input
     id: test-case
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_test_case.yml
+++ b/.github/ISSUE_TEMPLATE/new_test_case.yml
@@ -2,6 +2,17 @@ name: New Test Case Proposal
 description: Propose a new test case for ClawBench
 labels: ["new-test-case"]
 body:
+  - type: dropdown
+    id: corpus
+    attributes:
+      label: Target corpus
+      description: Which ClawBench corpus should this test case land in? V2 is the current default.
+      default: 0
+      options:
+        - v2
+        - v1
+    validations:
+      required: true
   - type: input
     id: platform
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,15 @@
 
 <!-- Brief description -->
 
+## Corpus
+
+<!-- Tick the corpus this change applies to. V2 is the current default. -->
+
+- [x] v2
+- [ ] v1
+- [ ] both
+- [ ] not applicable
+
 ## Test plan
 
 - [ ] <!-- How you verified this works -->


### PR DESCRIPTION
Adds corpus dropdown to `new_test_case.yml` and `bug_report.yml`, defaulting to v2. Adds corpus checkbox to `pull_request_template.md`.

Why: clawbench-batch now defaults to `--cases-suite v2`, the live leaderboard, README tables, and `TIGER-Lab/ClawBenchV2Trace` all target v2. Templates should reflect that so incoming issues/PRs declare their corpus scope up-front instead of forcing a back-and-forth.