### PR TITLE
ci: add 3 sec delay before download from testpypi for it to refresh

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Wait for TestPyPI index
+        run: sleep 3
+
       - name: Install package from TestPyPI
         env:
           PACKAGE_VERSION: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
- Add a 3-second delay after uploading to testpypi and before downloading it for validation. Since testpypi needs a bit of time to refresh its index, otherwise it may return version not found if going too fast. 