### PR TITLE
fix: make token cost calculation available to all harnesses #211

### DIFF
--- a/.github/workflows/check-harness-build.yml
+++ b/.github/workflows/check-harness-build.yml
@@ -14,10 +14,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  harness-build:
+  validate-and-select:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILD_PARALLELISM: "3"
+    outputs:
+      count: ${{ steps.dockerfiles.outputs.count }}
+      matrix: ${{ steps.dockerfiles.outputs.matrix }}
 
     steps:
       - uses: actions/checkout@v6
@@ -67,37 +68,6 @@ jobs:
           load_harness_registry(registry_path)
           print(f"Validated {registry_path} against {schema_path}")
           PY
-
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v5.1.0
-        with:
-          daemon-config: |
-            {
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
-
-      - name: Restore harness build cache
-        id: docker-cache
-        uses: actions/cache@v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-harness-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-harness-buildx-
-
-      - name: Inspect restored harness build cache
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -d /tmp/.buildx-cache ]]; then
-            echo "Restored cache scopes:"
-            find /tmp/.buildx-cache -mindepth 1 -maxdepth 1 -type d -print | sort
-            du -sh /tmp/.buildx-cache || true
-          else
-            echo "No harness build cache restored."
-          fi
 
       - name: Select harness Dockerfiles
         id: dockerfiles
@@ -182,10 +152,13 @@ jobs:
             fi
           fi
 
+          matrix_json="$(
+            printf '%s\n' "${selected_dockerfiles[@]}" \
+              | python -c 'import json, pathlib, sys; dockerfiles=[line.strip() for line in sys.stdin if line.strip()]; print(json.dumps({"include":[{"harness":pathlib.Path(path).parent.name,"dockerfile":path,"image":"clawbench-" + pathlib.Path(path).parent.name} for path in dockerfiles]}, separators=(",", ":")))'
+          )"
+
           {
-            echo "dockerfiles<<EOF"
-            printf '%s\n' "${selected_dockerfiles[@]}"
-            echo "EOF"
+            echo "matrix=${matrix_json}"
             echo "count=${#selected_dockerfiles[@]}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -210,126 +183,102 @@ jobs:
             done
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Build harness Docker images
+  build-base:
+    runs-on: ubuntu-latest
+    needs: validate-and-select
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5.1.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Build base Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: src/clawbench/runtime
+          file: src/clawbench/runtime/harnesses/base/Dockerfile.base
+          tags: |
+            clawbench-base
+            clawbench-base:amd64
+          load: true
+          provenance: false
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=base,ignore-error=true
+
+      - name: Summarize base build
         shell: bash
         run: |
-          set -euo pipefail
-          runtime_root="src/clawbench/runtime"
-          harness_root="${runtime_root}/harnesses"
-          base_dockerfile="${harness_root}/base/Dockerfile.base"
-          cache_root="/tmp/.buildx-cache"
-          cache_update="/tmp/.buildx-cache-update"
-          status_root="/tmp/clawbench-harness-build-status"
-          parallelism="${DOCKER_BUILD_PARALLELISM:-3}"
-
-          rm -rf "${cache_update}" "${status_root}"
-          mkdir -p "${cache_root}" "${cache_update}" "${status_root}"
-
           {
-            echo
             echo "## Harness build results"
-            echo
-            echo "- Restored cache key: \`${{ steps.docker-cache.outputs.cache-matched-key || 'none' }}\`"
-            echo "- Exact cache hit: \`${{ steps.docker-cache.outputs.cache-hit || 'false' }}\`"
             echo
             echo "| Image | Status |"
             echo "| --- | --- |"
+            echo "| \`clawbench-base\`, \`clawbench-base:amd64\` | Passed |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-          build_with_cache() {
-            local dockerfile="$1"
-            local image="$2"
-            local scope="$3"
-            local cache_args=()
+  build-harness:
+    runs-on: ubuntu-latest
+    needs:
+      - validate-and-select
+      - build-base
+    if: needs.validate-and-select.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.validate-and-select.outputs.matrix) }}
 
-            if [[ -f "${cache_root}/${scope}/index.json" ]]; then
-              echo "[cache] ${scope}: hit at ${cache_root}/${scope}"
-              cache_args+=(--cache-from "type=local,src=${cache_root}/${scope}")
-            else
-              echo "[cache] ${scope}: miss"
-            fi
+    steps:
+      - uses: actions/checkout@v6
 
-            docker buildx build \
-              --load \
-              --progress=plain \
-              --provenance=false \
-              -f "${dockerfile}" \
-              -t "${image}" \
-              "${cache_args[@]}" \
-              --cache-to "type=local,dest=${cache_update}/${scope},mode=max" \
-              "${runtime_root}"
-          }
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5.1.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
 
-          if build_with_cache "${base_dockerfile}" "clawbench-base" "base"; then
-            docker tag clawbench-base clawbench-base:amd64
-            echo "| \`clawbench-base\`, \`clawbench-base:amd64\` | Passed |" >> "${GITHUB_STEP_SUMMARY}"
-          else
-            echo "| \`clawbench-base\`, \`clawbench-base:amd64\` | Failed |" >> "${GITHUB_STEP_SUMMARY}"
-            exit 1
-          fi
+      - name: Load base Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: src/clawbench/runtime
+          file: src/clawbench/runtime/harnesses/base/Dockerfile.base
+          tags: |
+            clawbench-base
+            clawbench-base:amd64
+          load: true
+          provenance: false
+          cache-from: type=gha,scope=base
 
-          build_harness() {
-            local dockerfile="$1"
-            local harness
-            local image
-            local status
+      - name: Build harness Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: src/clawbench/runtime
+          file: ${{ matrix.dockerfile }}
+          tags: ${{ matrix.image }}
+          load: true
+          provenance: false
+          cache-from: |
+            type=gha,scope=base
+            type=gha,scope=${{ matrix.harness }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.harness }},ignore-error=true
 
-            harness="$(basename "$(dirname "${dockerfile}")")"
-            image="clawbench-${harness}"
-            status="${status_root}/${harness}.status"
-
-            echo "[${harness}] Starting ${image}"
-            set -o pipefail
-            if build_with_cache "${dockerfile}" "${image}" "${harness}" 2>&1 | sed -u "s/^/[${harness}] /"; then
-              echo "passed" > "${status}"
-              echo "[${harness}] Finished ${image}"
-            else
-              echo "failed" > "${status}"
-              echo "[${harness}] Failed ${image}"
-              return 1
-            fi
-          }
-
-          export -f build_with_cache build_harness
-          export runtime_root cache_root cache_update status_root
-
-          mapfile -t selected_dockerfiles <<'EOF'
-          ${{ steps.dockerfiles.outputs.dockerfiles }}
-          EOF
-          filtered_dockerfiles=()
-          for dockerfile in "${selected_dockerfiles[@]}"; do
-            [[ -n "${dockerfile}" ]] && filtered_dockerfiles+=("${dockerfile}")
-          done
-          selected_dockerfiles=("${filtered_dockerfiles[@]}")
-
-          if (( ${#selected_dockerfiles[@]} > 0 )); then
-            echo "Building ${#selected_dockerfiles[@]} harness image(s) with parallelism=${parallelism}"
-            set +e
-            printf '%s\0' "${selected_dockerfiles[@]}" \
-              | xargs -0 -n 1 -P "${parallelism}" bash -c "build_harness \"\$1\"" _
-            harness_status=$?
-            set -e
-
-            for dockerfile in "${selected_dockerfiles[@]}"; do
-              [[ -n "${dockerfile}" ]] || continue
-              harness="$(basename "$(dirname "${dockerfile}")")"
-              image="clawbench-${harness}"
-              if [[ "$(cat "${status_root}/${harness}.status" 2>/dev/null || true)" == "passed" ]]; then
-                echo "| \`${image}\` | Passed |" >> "${GITHUB_STEP_SUMMARY}"
-              else
-                echo "| \`${image}\` | Failed |" >> "${GITHUB_STEP_SUMMARY}"
-              fi
-            done
-
-            if (( harness_status != 0 )); then
-              exit "${harness_status}"
-            fi
-          fi
-
-          for scope_dir in "${cache_update}"/*; do
-            [[ -d "${scope_dir}" ]] || continue
-            scope="$(basename "${scope_dir}")"
-            rm -rf "${cache_root:?}/${scope}"
-            mv "${scope_dir}" "${cache_root}/${scope}"
-          done
-          rm -rf "${cache_update}"
+      - name: Summarize harness build
+        shell: bash
+        run: |
+          {
+            echo "## Harness build results"
+            echo
+            echo "| Image | Status |"
+            echo "| --- | --- |"
+            echo "| \`${{ matrix.image }}\` | Passed |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Added display of live token cost estimation during the run.
 
+### Fixed
+- Fixed the issue that Claude Code Chrome Extension harness cannot be build due to upstream changes and pinned to a fixed version.
+
 ## [0.4.1] - 2026-05-23
 ### Fixed
 - Fixed several mismatches in task definitions and the provided extra information.

--- a/src/README.md
+++ b/src/README.md
@@ -58,12 +58,13 @@ src/
     setup.sh                     # Local extension launch helper
     README.md
   harnesses/
-    harnesses.yaml              # Central harness registry: images, Dockerfiles, scripts
+    harnesses.yaml              # Central harness registry: images, scripts, usage emitters
     harness.schema.json         # JSON Schema for harnesses.yaml
     base/
       Dockerfile.base            # Shared Chromium, Xvfb, noVNC, server, extension image
       entrypoint.sh              # Shared container startup logic
     openclaw/
+      usage-emitter.py           # Harness-local JSONL usage artifact emitter
     ...                          # other harnesses
 ```
 
@@ -143,8 +144,10 @@ Model entries are validated against `models/model.schema.json`.
 14. Removes the container, deletes the disposable email, and removes the temporary personal info directory.
 
 Check `clawbench/runtime/harnesses/harnesses.yaml` for the supported harnesses
-and their Dockerfile, setup script, run script, helper-file, and
-agent-message source mappings.
+and their Dockerfile, setup script, run script, `usage_emitter`, helper-file,
+and agent-message source mappings. `usage_emitter` is a dedicated registry
+field pointing to a harness-local emitter; `extra_files` is only for other
+harness-specific support files.
 
 Use `--harness <name>` to select one. The default is `openclaw`.
 

--- a/src/clawbench/runner/run.py
+++ b/src/clawbench/runner/run.py
@@ -44,6 +44,7 @@ from clawbench.runner.run_support.results import (
     classify_run,
     ensure_interception,
     print_results,
+    remove_transient_usage_artifact,
 )
 from clawbench.runner.run_support.task import (
     build_instruction,
@@ -453,6 +454,7 @@ def main():
             )
         )
         write_run_meta(output_dir, meta)
+        remove_transient_usage_artifact(output_dir)
 
         if do_upload:
             phase = "uploading"
@@ -496,6 +498,7 @@ def main():
             extra_info_warnings=extra_info_warnings,
         )
         write_run_meta(output_dir, meta)
+        remove_transient_usage_artifact(output_dir)
         print(f"ERROR: {phase} failed: {e}")
         sys.exit(2)
     finally:

--- a/src/clawbench/runner/run_support/docker.py
+++ b/src/clawbench/runner/run_support/docker.py
@@ -469,7 +469,7 @@ def _container_usage_summary(
                 name,
                 "sh",
                 "-c",
-                _agent_message_probe_script(harness),
+                "if [ -s /data/usage.jsonl ]; then cat /data/usage.jsonl; fi",
             ],
             capture_output=True,
             text=True,

--- a/src/clawbench/runner/run_support/harness_registry.py
+++ b/src/clawbench/runner/run_support/harness_registry.py
@@ -31,6 +31,7 @@ class HarnessRegistry:
     harness_dockerfiles: dict[str, Path]
     harness_setup_scripts: dict[str, Path]
     harness_run_scripts: dict[str, Path]
+    harness_usage_emitters: dict[str, Path]
     harness_extra_files: dict[str, tuple[Path, ...]]
     harness_agent_message_sources: dict[str, tuple[AgentMessageSource, ...]]
 
@@ -180,6 +181,7 @@ def load_harness_registry(path: Path = HARNESS_REGISTRY_YAML) -> HarnessRegistry
     dockerfiles: dict[str, Path] = {}
     setup_scripts: dict[str, Path] = {}
     run_scripts: dict[str, Path] = {}
+    usage_emitters: dict[str, Path] = {}
     extra_files: dict[str, tuple[Path, ...]] = {}
     agent_message_sources: dict[str, tuple[AgentMessageSource, ...]] = {}
     for index, entry in enumerate(entries):
@@ -207,6 +209,12 @@ def load_harness_registry(path: Path = HARNESS_REGISTRY_YAML) -> HarnessRegistry
             path,
             "run_script",
         )
+        usage_emitters[name] = _resolve_registry_file(
+            root,
+            _required_str(entry, "usage_emitter", path),
+            path,
+            "usage_emitter",
+        )
         extra_files[name] = tuple(
             _resolve_registry_file(root, rel_path, path, "extra_files")
             for rel_path in _optional_str_list(entry, "extra_files", path)
@@ -227,6 +235,7 @@ def load_harness_registry(path: Path = HARNESS_REGISTRY_YAML) -> HarnessRegistry
         harness_dockerfiles=dockerfiles,
         harness_setup_scripts=setup_scripts,
         harness_run_scripts=run_scripts,
+        harness_usage_emitters=usage_emitters,
         harness_extra_files=extra_files,
         harness_agent_message_sources=agent_message_sources,
     )

--- a/src/clawbench/runner/run_support/results.py
+++ b/src/clawbench/runner/run_support/results.py
@@ -94,6 +94,7 @@ def collect_run_metrics(
     actions_file = data_dir / "actions.jsonl"
     requests_file = data_dir / "requests.jsonl"
     messages_file = data_dir / "agent-messages.jsonl"
+    usage_file = data_dir / "usage.jsonl"
     screenshots_dir = data_dir / "screenshots"
     recording_file = data_dir / "recording.mp4"
     interception_file = data_dir / "interception.json"
@@ -204,7 +205,7 @@ def collect_run_metrics(
     elif browser_use_model_outputs:
         metrics["api_calls"] = browser_use_model_outputs
 
-    usage = summarize_usage_file(messages_file, model_cfg=model_cfg)
+    usage = summarize_usage_file(usage_file, model_cfg=model_cfg)
     if usage["api_calls"] > metrics["api_calls"]:
         metrics["api_calls"] = usage["api_calls"]
     metrics["usage"] = usage
@@ -362,6 +363,11 @@ def print_results(
         print(f"Request method: {result['request']['method']}")
         if result["request"].get("body"):
             print(f"Body: {json.dumps(result['request']['body'])[:300]}")
-    usage = summarize_usage_file(data_dir / "agent-messages.jsonl", model_cfg=model_cfg)
+    usage = summarize_usage_file(data_dir / "usage.jsonl", model_cfg=model_cfg)
     print(format_usage_summary(usage))
     return intercepted
+
+
+def remove_transient_usage_artifact(output_dir: Path) -> None:
+    """Remove the harness handoff artifact after run-meta.json has usage."""
+    (output_dir / "data" / "usage.jsonl").unlink(missing_ok=True)

--- a/src/clawbench/runner/run_support/usage.py
+++ b/src/clawbench/runner/run_support/usage.py
@@ -1,4 +1,4 @@
-"""Token and estimated-cost accounting for agent transcripts."""
+"""Token and estimated-cost aggregation for harness-generated usage rows."""
 
 from __future__ import annotations
 
@@ -50,10 +50,13 @@ def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
 def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
     input_details = raw.get("input_tokens_details")
     output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
     if not isinstance(input_details, dict):
         input_details = {}
     if not isinstance(output_details, dict):
         output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
 
     explicit_cache_read = _first_int(
         raw,
@@ -64,8 +67,12 @@ def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
             "cache_read_input_tokens",
         ),
     )
-    nested_cache_read = _first_int(
+    nested_input_cache_read = _first_int(
         input_details, ("cached_tokens", "cache_read_tokens")
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details,
+        ("read", "cache_read_tokens"),
     )
 
     usage = {
@@ -96,7 +103,8 @@ def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
                 "cache_write_tokens",
                 "cache_creation_input_tokens",
             ),
-        ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
         "reasoning_tokens": _first_int(
             raw,
             (
@@ -116,8 +124,11 @@ def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
             ),
         ),
     }
-    if nested_cache_read and not explicit_cache_read:
-        usage["input_tokens"] = max(usage["input_tokens"] - nested_cache_read, 0)
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
     usage["total_tokens"] = (
         usage["input_tokens"]
         + usage["output_tokens"]
@@ -197,12 +208,14 @@ def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None
     pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
     if not isinstance(pricing, dict):
         pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
     return {
         "input_tokens": _to_decimal(pricing.get("prompt")),
-        "output_tokens": _to_decimal(pricing.get("completion")),
+        "output_tokens": completion_rate,
         "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
         "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
-        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
     }
 
 
@@ -262,8 +275,10 @@ def _extract_usage_events(
     seen_keys: set[str] = set()
     observed_models: set[str] = set()
     api_calls = 0
-    session_aggregate: dict[str, int] | None = None
-    session_api_calls: int | None = None
+    estimated_cost = Decimal("0")
+    saw_cost = False
+    saw_price_unavailable = False
+    matched_models: set[str] = set()
 
     for line in lines:
         if not line.strip():
@@ -275,60 +290,50 @@ def _extract_usage_events(
         if not isinstance(event, dict):
             continue
 
-        for key in ("model", "model_id", "modelId"):
-            value = event.get(key)
-            if isinstance(value, str) and value:
-                observed_models.add(value.removeprefix("openrouter/"))
-
-        if event.get("type") == "session_meta":
-            for key in ("model", "model_id"):
-                value = event.get(key)
-                if isinstance(value, str) and value:
-                    observed_models.add(value.removeprefix("openrouter/"))
-            normalized = _normalize_usage(event)
-            if normalized["total_tokens"]:
-                session_aggregate = normalized
-            if isinstance(event.get("api_call_count"), int):
-                session_api_calls = event["api_call_count"]
+        if event.get("type") != "usage":
             continue
 
-        usage_owner: dict[str, Any] | None = None
-        raw_usage = event.get("usage")
-        if isinstance(raw_usage, dict):
-            usage_owner = event
-        else:
-            message = event.get("message")
-            if isinstance(message, dict):
-                for key in ("model", "model_id", "modelId"):
-                    value = message.get(key)
-                    if isinstance(value, str) and value:
-                        observed_models.add(value.removeprefix("openrouter/"))
-                raw_usage = message.get("usage")
-                if isinstance(raw_usage, dict):
-                    usage_owner = message
-
-        if not isinstance(raw_usage, dict) or usage_owner is None:
-            continue
-
-        usage_key = _event_usage_key(event, usage_owner)
+        call_id = event.get("call_id") or event.get("id")
+        usage_key = str(call_id) if call_id else None
         if usage_key and usage_key in seen_keys:
             continue
         if usage_key:
             seen_keys.add(usage_key)
 
-        normalized = _normalize_usage(raw_usage)
+        normalized = {
+            "input_tokens": _to_int(event.get("input_tokens")),
+            "output_tokens": _to_int(event.get("output_tokens")),
+            "cache_read_tokens": _to_int(event.get("cache_read_tokens")),
+            "cache_write_tokens": _to_int(event.get("cache_write_tokens")),
+            "reasoning_tokens": _to_int(event.get("reasoning_tokens")),
+            "reported_total_tokens": _to_int(event.get("reported_total_tokens")),
+            "total_tokens": _to_int(event.get("total_tokens")),
+        }
+        if normalized["total_tokens"] == 0:
+            normalized["total_tokens"] = (
+                normalized["input_tokens"]
+                + normalized["output_tokens"]
+                + normalized["cache_read_tokens"]
+                + normalized["cache_write_tokens"]
+                + normalized["reasoning_tokens"]
+            ) or normalized["reported_total_tokens"]
         if normalized["total_tokens"]:
             api_calls += 1
             _merge_usage(totals, normalized)
-
-    if session_aggregate is not None:
-        totals = session_aggregate
-        if session_api_calls is not None:
-            api_calls = session_api_calls
-        elif api_calls == 0:
-            api_calls = 1
-    elif session_api_calls is not None and api_calls == 0:
-        api_calls = session_api_calls
+            cost = event.get("estimated_cost_usd")
+            if isinstance(cost, (int, float, str)):
+                dec_cost = _to_decimal(cost)
+                if dec_cost is not None:
+                    estimated_cost += dec_cost
+                    saw_cost = True
+            if event.get("cost_status") == "price_unavailable":
+                saw_price_unavailable = True
+            model = event.get("model")
+            if isinstance(model, str) and model:
+                observed_models.add(model.removeprefix("openrouter/"))
+            matched = event.get("matched_model_id")
+            if isinstance(matched, str) and matched:
+                matched_models.add(matched)
 
     if totals["total_tokens"] == 0:
         totals["total_tokens"] = (
@@ -338,6 +343,11 @@ def _extract_usage_events(
             + totals["cache_write_tokens"]
             + totals["reasoning_tokens"]
         ) or totals["reported_total_tokens"]
+    totals["__estimated_cost_microusd"] = int(estimated_cost * Decimal("1000000"))
+    totals["__saw_cost"] = 1 if saw_cost else 0
+    totals["__saw_price_unavailable"] = 1 if saw_price_unavailable else 0
+    if len(matched_models) == 1:
+        totals["__matched_model"] = next(iter(matched_models))  # type: ignore[assignment]
 
     return totals, api_calls, observed_models, len(seen_keys)
 
@@ -349,22 +359,19 @@ def summarize_usage_lines(
     pricing_models: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     totals, api_calls, observed_models, usage_events = _extract_usage_events(lines)
-    configured_model = str(model_cfg.get("model", "")) if model_cfg else ""
-    base_url = str(model_cfg.get("base_url", "")) if model_cfg else ""
-    candidates = [configured_model, *sorted(observed_models)]
 
-    models = pricing_models
-    if models is None and "openrouter.ai" in base_url:
-        models = fetch_openrouter_pricing(base_url=base_url or None)
-    models = models or {}
-    model_row = resolve_openrouter_model(candidates, models)
-    cost, missing_rates = _estimate_cost_usd(totals, model_row)
-    if totals["total_tokens"] == 0:
-        cost = None
+    model_row = None
+    cost = None
+    missing_rates: list[str] = []
+    matched_model = totals.get("__matched_model")
+    if isinstance(matched_model, str):
+        model_row = {"id": matched_model}
+    if totals.get("__saw_cost"):
+        cost = totals.get("__estimated_cost_microusd", 0) / 1000000
 
     if totals["total_tokens"] == 0 and api_calls == 0:
         status = "usage_unavailable"
-    elif cost is None:
+    elif cost is None or totals.get("__saw_price_unavailable"):
         status = "price_unavailable"
     else:
         status = "estimated"
@@ -395,19 +402,24 @@ def summarize_usage_file(
     model_cfg: dict[str, Any] | None = None,
     pricing_models: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    usage_source = "transient_usage_jsonl" if path.name == "usage.jsonl" else path.name
     try:
         with path.open(encoding="utf-8", errors="replace") as f:
-            return summarize_usage_lines(
+            summary = summarize_usage_lines(
                 f,
                 model_cfg=model_cfg,
                 pricing_models=pricing_models,
             )
+            summary["usage_source"] = usage_source
+            return summary
     except OSError:
-        return summarize_usage_lines(
+        summary = summarize_usage_lines(
             (),
             model_cfg=model_cfg,
             pricing_models=pricing_models,
         )
+        summary["usage_source"] = usage_source
+        return summary
 
 
 def summarize_usage_text(

--- a/src/clawbench/runtime/harnesses/browser-use/Dockerfile.browser-use
+++ b/src/clawbench/runtime/harnesses/browser-use/Dockerfile.browser-use
@@ -6,4 +6,6 @@ RUN pip install --no-cache-dir 'litellm[proxy]==1.83.9'
 COPY harnesses/browser-use/setup-browser-use.sh /setup-browser-use.sh
 COPY harnesses/browser-use/run-browser-use.sh /run-harness.sh
 COPY harnesses/browser-use/run-browser-use-agent.py /run-browser-use-agent.py
-RUN chmod +x /setup-browser-use.sh /run-harness.sh
+COPY harnesses/browser-use/browser-use-usage-logger.py /tmp/browser_use_usage_logger.py
+COPY harnesses/browser-use/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-browser-use.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/browser-use/browser-use-usage-logger.py
+++ b/src/clawbench/runtime/harnesses/browser-use/browser-use-usage-logger.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""browser-use harness LiteLLM usage logger."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from litellm.integrations.custom_logger import CustomLogger
+
+OUT = Path("/data/usage.jsonl")
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _usage_dict(response_obj: Any) -> dict[str, Any]:
+    if isinstance(response_obj, dict):
+        usage = response_obj.get("usage") or response_obj.get("token_usage")
+        return usage if isinstance(usage, dict) else {}
+    usage = getattr(response_obj, "usage", None)
+    if isinstance(usage, dict):
+        return usage
+    try:
+        model_dump = response_obj.model_dump()
+    except Exception:
+        return {}
+    usage = model_dump.get("usage") or model_dump.get("token_usage")
+    return usage if isinstance(usage, dict) else {}
+
+
+def _hidden_params(response_obj: Any) -> dict[str, Any]:
+    if isinstance(response_obj, dict):
+        hidden = response_obj.get("_hidden_params")
+    else:
+        hidden = getattr(response_obj, "_hidden_params", None)
+    return hidden if isinstance(hidden, dict) else {}
+
+
+def _row(kwargs: dict[str, Any], response_obj: Any) -> dict[str, Any] | None:
+    usage = _usage_dict(response_obj)
+    prompt = _to_int(usage.get("prompt_tokens") or usage.get("input_tokens"))
+    completion = _to_int(usage.get("completion_tokens") or usage.get("output_tokens"))
+    cache_read = _to_int(
+        usage.get("cache_read_tokens") or usage.get("cache_read_input_tokens")
+    )
+    cache_write = _to_int(
+        usage.get("cache_write_tokens") or usage.get("cache_creation_input_tokens")
+    )
+    reasoning = _to_int(
+        usage.get("reasoning_tokens") or usage.get("internal_reasoning_tokens")
+    )
+    total = (prompt + completion + cache_read + cache_write + reasoning) or _to_int(
+        usage.get("total_tokens") or usage.get("totalTokens")
+    )
+    if total <= 0:
+        return None
+    model = str(kwargs.get("model") or getattr(response_obj, "model", "") or "")
+    hidden = _hidden_params(response_obj)
+    response_cost = hidden.get("response_cost")
+    cost = response_cost if isinstance(response_cost, (int, float)) else None
+    matched_model = hidden.get("model_id") or hidden.get("custom_llm_provider")
+    response_id = (
+        getattr(response_obj, "id", None)
+        or (response_obj.get("id") if isinstance(response_obj, dict) else None)
+        or f"browser-use:{model}:{time.time()}"
+    )
+    return {
+        "type": "usage",
+        "source_harness": "browser-use",
+        "call_id": f"response:{response_id}",
+        "timestamp": time.time(),
+        "model": model,
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "cache_read_tokens": cache_read,
+        "cache_write_tokens": cache_write,
+        "reasoning_tokens": reasoning,
+        "total_tokens": total,
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": "estimated" if cost is not None else "price_unavailable",
+        "pricing_source_url": "https://openrouter.ai/api/v1/models",
+        "matched_model_id": str(matched_model) if matched_model else None,
+    }
+
+
+class BrowserUseUsageLogger(CustomLogger):
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        row = _row(kwargs, response_obj)
+        if row is None:
+            return
+        OUT.parent.mkdir(parents=True, exist_ok=True)
+        with OUT.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+
+proxy_handler_instance = BrowserUseUsageLogger()

--- a/src/clawbench/runtime/harnesses/browser-use/run-browser-use-agent.py
+++ b/src/clawbench/runtime/harnesses/browser-use/run-browser-use-agent.py
@@ -11,12 +11,17 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
 from browser_use import Agent, Browser, ChatOpenAI, Tools
 
 OUT = Path("/data/agent-messages.jsonl")
+USAGE_OUT = Path("/data/usage.jsonl")
 STOP = Path("/data/.stop-requested")  # extension-server eval-match marker
 
 # Map our THINKING_LEVEL values onto browser-use's `reasoning_effort` levels.
@@ -28,6 +33,162 @@ _EFFORT_MAP = {
     "high": "high",
     "xhigh": "high",
 }
+_OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+_PRICING: dict[str, dict[str, Any]] | None = None
+_USAGE_CALLS = 0
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _pricing_models() -> dict[str, dict[str, Any]]:
+    global _PRICING
+    if _PRICING is not None:
+        return _PRICING
+    base_url = os.environ.get("BU_UPSTREAM_BASE_URL", "")
+    if "openrouter.ai" not in base_url:
+        _PRICING = {}
+        return _PRICING
+    try:
+        req = urllib.request.Request(
+            base_url.rstrip("/") + "/models",
+            headers={"User-Agent": "clawbench/browser-use-usage"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        _PRICING = {}
+        return _PRICING
+    _PRICING = {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    return _PRICING
+
+
+def _matched_model(model: str) -> dict[str, Any] | None:
+    models = _pricing_models()
+    candidates = [
+        os.environ.get("BU_UPSTREAM_MODEL_ID", ""),
+        model,
+        model.removeprefix("openrouter/"),
+    ]
+    for candidate in candidates:
+        if candidate in models:
+            return models[candidate]
+    for candidate in candidates:
+        suffix = f"/{candidate}"
+        matches = [row for key, row in models.items() if key.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _estimate_cost(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> float | None:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        return None
+    rates = {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": _to_decimal(pricing.get("completion")),
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+    }
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None
+        cost += Decimal(tokens) * rate
+    return float(cost)
+
+
+def _emit_usage(completion: Any, model: str) -> None:
+    usage = getattr(completion, "usage", None)
+    if usage is None:
+        return
+    raw = usage.model_dump() if hasattr(usage, "model_dump") else dict(usage)
+    cache_read = _to_int(raw.get("prompt_cached_tokens"))
+    cache_write = _to_int(raw.get("prompt_cache_creation_tokens"))
+    input_tokens = max(
+        _to_int(raw.get("prompt_tokens")) - cache_read - cache_write,
+        0,
+    )
+    row = {
+        "type": "usage",
+        "source_harness": "browser-use",
+        "call_id": "",
+        "timestamp": time.time(),
+        "model": model,
+        "input_tokens": input_tokens,
+        "output_tokens": _to_int(raw.get("completion_tokens")),
+        "cache_read_tokens": cache_read,
+        "cache_write_tokens": cache_write,
+        "reasoning_tokens": 0,
+        "total_tokens": _to_int(raw.get("total_tokens")),
+    }
+    if not row["total_tokens"]:
+        row["total_tokens"] = (
+            row["input_tokens"]
+            + row["output_tokens"]
+            + row["cache_read_tokens"]
+            + row["cache_write_tokens"]
+        )
+    if not row["total_tokens"]:
+        return
+    global _USAGE_CALLS
+    _USAGE_CALLS += 1
+    row["call_id"] = f"browser-use:{model}:{_USAGE_CALLS}:{row['timestamp']}"
+    model_row = _matched_model(model)
+    cost = _estimate_cost(row, model_row)
+    row["estimated_cost_usd"] = round(cost, 6) if cost is not None else None
+    row["cost_status"] = "estimated" if cost is not None else "price_unavailable"
+    row["pricing_source_url"] = _OPENROUTER_MODELS_URL
+    row["matched_model_id"] = (
+        model_row.get("id") if isinstance(model_row, dict) else None
+    )
+    USAGE_OUT.parent.mkdir(parents=True, exist_ok=True)
+    with USAGE_OUT.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+
+class UsageTrackingChatOpenAI(ChatOpenAI):
+    async def ainvoke(self, messages, output_format=None, **kwargs):
+        completion = await super().ainvoke(
+            messages,
+            output_format=output_format,
+            **kwargs,
+        )
+        _emit_usage(completion, self.model)
+        return completion
 
 
 def make_llm() -> ChatOpenAI:
@@ -48,7 +209,7 @@ def make_llm() -> ChatOpenAI:
     if effort:
         kw["reasoning_effort"] = effort
         kw["reasoning_models"] = [model]
-    return ChatOpenAI(**kw)
+    return UsageTrackingChatOpenAI(**kw)
 
 
 def dump_history(agent_obj) -> None:

--- a/src/clawbench/runtime/harnesses/browser-use/run-browser-use.sh
+++ b/src/clawbench/runtime/harnesses/browser-use/run-browser-use.sh
@@ -7,8 +7,9 @@ set -e
 source /tmp/browser-use-env.sh
 
 echo "Starting API translation proxy (litellm)..."
-litellm --config /tmp/litellm-config.yaml --port 4000 \
-  > /tmp/browser-use-litellm.log 2>&1 &
+PYTHONPATH="/tmp${PYTHONPATH:+:$PYTHONPATH}" \
+  litellm --config /tmp/litellm-config.yaml --port 4000 \
+  > /data/proxy.log 2>&1 &
 PROXY_PID=$!
 for i in $(seq 1 30); do
   if curl -sf http://localhost:4000/health/liveliness > /dev/null 2>&1; then
@@ -16,7 +17,7 @@ for i in $(seq 1 30); do
     break
   fi
   if [ "$i" -eq 30 ]; then
-    echo "API proxy not ready after 30s — check /tmp/browser-use-litellm.log"
+    echo "API proxy not ready after 30s — check /data/proxy.log"
     echo "proxy_failed" > /data/.stop-reason
     exit 1
   fi
@@ -60,6 +61,7 @@ ln -sf "$(command -v python3)" "$SAFE_BIN/python3"
 # /tmp so the post-run cleanup doesn't include them in the run output.
 cd "$WORKSPACE"
 echo "Starting browser-use agent (model=${BU_MODEL_NAME})..."
+: > /data/usage.jsonl
 PATH="$SAFE_BIN" python3 /run-browser-use-agent.py \
   > /tmp/browser-use-stdout.log 2> /tmp/browser-use-stderr.log &
 AGENT_PID=$!
@@ -119,6 +121,7 @@ pkill -f "browser_use"           2>/dev/null || true
 pkill -f "playwright"            2>/dev/null || true
 pkill -f "litellm"               2>/dev/null || true
 sleep 2
+python3 /usage-emitter.py --harness browser-use --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 
 curl -sf -X POST http://localhost:7878/api/stop || true
 

--- a/src/clawbench/runtime/harnesses/browser-use/setup-browser-use.sh
+++ b/src/clawbench/runtime/harnesses/browser-use/setup-browser-use.sh
@@ -86,7 +86,10 @@ proxy_config = {
     }],
     # drop_params: silently ignore fields the upstream doesn't accept
     # instead of erroring out (e.g. service_tier for non-OpenAI).
-    "litellm_settings": {"drop_params": True},
+    "litellm_settings": {
+        "drop_params": True,
+        "success_callback": ["browser_use_usage_logger.proxy_handler_instance"],
+    },
 }
 Path("/tmp/litellm-config.yaml").write_text(
     yaml.dump(proxy_config, default_flow_style=False))
@@ -98,6 +101,8 @@ os.chmod("/tmp/litellm-config.yaml", 0o600)
 env_path = Path("/tmp/browser-use-env.sh")
 env_path.write_text(
     f'export BU_MODEL_NAME="{model_name}"\n'
+    f'export BU_UPSTREAM_BASE_URL="{base_url}"\n'
+    f'export BU_UPSTREAM_MODEL_ID="{resolved_model}"\n'
     f'export BU_BASE_URL="http://localhost:4000"\n'
     f'export BU_API_KEY="sk-proxy-placeholder"\n'
     f'export BU_TEMPERATURE="{os.environ.get("TEMPERATURE", "0.0")}"\n'

--- a/src/clawbench/runtime/harnesses/browser-use/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/browser-use/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/claude-code-chrome-extension/Dockerfile.claude-code-chrome-extension
+++ b/src/clawbench/runtime/harnesses/claude-code-chrome-extension/Dockerfile.claude-code-chrome-extension
@@ -553,4 +553,5 @@ ENV EXTRA_LOAD_EXTENSIONS=/app/claude-in-chrome
 # --- Harness scripts --------------------------------------------------------
 COPY harnesses/claude-code-chrome-extension/setup-claude-code-chrome-extension.sh /setup-claude-code-chrome-extension.sh
 COPY harnesses/claude-code-chrome-extension/run-claude-code-chrome-extension.sh /run-harness.sh
-RUN chmod +x /setup-claude-code-chrome-extension.sh /run-harness.sh
+COPY harnesses/claude-code-chrome-extension/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-claude-code-chrome-extension.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/claude-code-chrome-extension/Dockerfile.claude-code-chrome-extension
+++ b/src/clawbench/runtime/harnesses/claude-code-chrome-extension/Dockerfile.claude-code-chrome-extension
@@ -235,16 +235,21 @@ RUN chmod +x /usr/local/bin/fake-anthropic-bridge.py
 
 # --- Unpack the Claude in Chrome extension from the Web Store ---------------
 # Download the .crx once at build time so the container has no outbound
-# dependency at run time. The inlined Python script strips the CRX3 header,
+# dependency at run time. This URL is the versioned blob currently returned by
+# the Chrome Web Store update endpoint for extension version 1.0.72.
+# The inlined Python script strips the CRX3 header,
 # unzips the payload, and injects the extension's original public key into
 # manifest.json so Chrome loads it under the original extension id
 # (fcoeoabgfenejglbffodgkkbkcdhcgfn) — that id is what the Claude Code CLI's
 # native-messaging allow-list expects.
+ARG CLAUDE_IN_CHROME_CRX_URL="https://clients2.googleusercontent.com/crx/blobs/AXJDbcCe7Rt2vHvMkvZou5r3pa1doh0i2ovwYyZVkkGgj0nX0bMP-zkeHiMeofTpH4AM9wr23dfwyXf5E9tpib-PvpGDcjChlD0Z3AU4tuAOwQFKU2Yjy4VVrUhrg9RbwkQpAMZSmuWyQpl_555JbFGxSQceKle50ryw9g/FCOEOABGFENEJGLBFFODGKKBKCDHCGFN_1_0_72_0.crx"
+ARG CLAUDE_IN_CHROME_CRX_SHA256="a22375eea12ab077d82a7a2210bb02a45f55740c61091bf61e97dd473dcc9b79"
+ARG CLAUDE_IN_CHROME_VERSION="1.0.72"
 RUN mkdir -p /app/claude-in-chrome \
-    && CRX_ID=fcoeoabgfenejglbffodgkkbkcdhcgfn \
     && wget --tries=3 -qO /tmp/claude.crx \
-    "https://clients2.google.com/service/update2/crx?response=redirect&prodversion=131.0.0.0&acceptformat=crx2,crx3&x=id%3D${CRX_ID}%26installsource%3Dondemand%26uc" \
-    && python3 - /tmp/claude.crx /app/claude-in-chrome <<'PYEOF' \
+    "$CLAUDE_IN_CHROME_CRX_URL" \
+    && printf '%s  /tmp/claude.crx\n' "$CLAUDE_IN_CHROME_CRX_SHA256" | sha256sum -c - \
+    && python3 - /tmp/claude.crx /app/claude-in-chrome "$CLAUDE_IN_CHROME_VERSION" <<'PYEOF' \
     && rm /tmp/claude.crx \
     && ls /app/claude-in-chrome/manifest.json
 import base64, hashlib, io, json, struct, sys, zipfile
@@ -252,6 +257,7 @@ from pathlib import Path
 
 crx_path = Path(sys.argv[1])
 out_dir = Path(sys.argv[2])
+expected_version = sys.argv[3]
 data = crx_path.read_bytes()
 assert data[:4] == b"Cr24", f"Not a CRX file: {data[:4]!r}"
 version = struct.unpack("<I", data[4:8])[0]
@@ -329,9 +335,15 @@ else:
 out_dir.mkdir(parents=True, exist_ok=True)
 zipfile.ZipFile(io.BytesIO(data[zip_start:])).extractall(out_dir)
 
+manifest_path = out_dir / "manifest.json"
+manifest = json.loads(manifest_path.read_text())
+actual_version = manifest.get("version")
+if actual_version != expected_version:
+    raise SystemExit(
+        f"ERROR: Claude in Chrome CRX version drifted: "
+        f"expected {expected_version}, got {actual_version}")
+
 if public_key:
-    manifest_path = out_dir / "manifest.json"
-    manifest = json.loads(manifest_path.read_text())
     manifest["key"] = base64.b64encode(public_key).decode()
     manifest_path.write_text(json.dumps(manifest, indent=2))
     digest = hashlib.sha256(public_key).digest()[:16]
@@ -376,9 +388,11 @@ def patch_file(path):
         text = text.replace('"wss://api.anthropic.com"',
                             '"ws://127.0.0.1:4001"', 1)
         patches.append(f"{path.name}: wsApiBaseUrl")
-    # 3. Bypass OAuth null-returns inside the bridge connector. Older builds
-    # used Na/nn in PermissionManager; newer 1.0.70 builds use Ba/un in
-    # mcpPermissions. Patch both shapes so extension updates fail less often.
+    # 3. Bypass OAuth null-returns inside the bridge connector. Extension
+    # updates regularly rename the minified helpers:
+    #   1.0.70-ish: u()/h() with Na/nn or Ba/un state helpers
+    #   1.0.72-ish: h()/p() with Ba/un state helpers
+    # Patch all known shapes so Web Store updates fail less often.
     oauth_null = 'if(o=await u(),!o)return Na=!1,nn(),!1;'
     oauth_fix = 'if(o=await u(),!o)o="fake-oauth-token";'
     if oauth_null in text:
@@ -399,48 +413,85 @@ def patch_file(path):
     if userid_null in text:
         text = text.replace(userid_null, userid_fix, 1)
         patches.append(f"{path.name}: userId null-return")
+    oauth_null = 'if(o=await h(),!o)return Ba=!1,un(),!1;'
+    oauth_fix = 'if(o=await h(),!o)o="fake-oauth-token";'
+    if oauth_null in text:
+        text = text.replace(oauth_null, oauth_fix, 1)
+        patches.append(f"{path.name}: OAuth null-return")
+    userid_null = 'if(t=await p(o),!t)return Ba=!1,un(),!1;'
+    userid_fix = 'if(t=await p(o),!t)t="clawbench-user";'
+    if userid_null in text:
+        text = text.replace(userid_null, userid_fix, 1)
+        patches.append(f"{path.name}: userId null-return")
     # 4. Make the extension's auth helpers local-only. This prevents both the
     # visible OAuth launcher and the non-interactive silent reauth path from
     # opening claude.ai tabs while still satisfying side panel/native-host
     # status checks that expect auth to be valid.
-    text, count = re.subn(
+    text, count_old = re.subn(
         r'async function Te\(\)\{.*?\}const xe=',
         'async function Te(){return"success"}const xe=',
         text,
         count=1,
         flags=re.S,
     )
-    if count:
+    text, count_new = re.subn(
+        r'async function Ae\(\)\{.*?\}const Oe=',
+        'async function Ae(){return"success"}const Oe=',
+        text,
+        count=1,
+        flags=re.S,
+    )
+    if count_old or count_new:
         patches.append(f"{path.name}: silent OAuth no-op")
-    text, count = re.subn(
+    text, count_old = re.subn(
         r'let Ae=null;const Oe=\(\)=>Ae\|\|.*?\),Ae\);const Ce=async\(\)=>\{if\(!\(await Oe\(\)\)\.isValid\)return;return await j\(F\.ACCESS_TOKEN\)\|\|void 0\}',
         'let Ae=null;const Oe=()=>Promise.resolve({isValid:!0,isRefreshed:!1});const Ce=async()=>await j(F.ACCESS_TOKEN)||"fake-oauth-token"',
         text,
         count=1,
         flags=re.S,
     )
-    if count:
+    text, count_new = re.subn(
+        r'let Ce=null;const Pe=\(\)=>Ce\|\|.*?\),Ce\);const ke=async',
+        'let Ce=null;const Pe=()=>Promise.resolve({isValid:!0,isRefreshed:!1});const ke=async',
+        text,
+        count=1,
+        flags=re.S,
+    )
+    if count_old or count_new:
         patches.append(f"{path.name}: auth valid")
-    text, count = re.subn(
+    text, count_old = re.subn(
         r'Re=async t=>\{const e=t\?\?await Ce\(\);.*?\},Ie=async',
         'Re=async t=>"clawbench-user",Ie=async',
         text,
         count=1,
         flags=re.S,
     )
-    if count:
+    text, count_new = re.subn(
+        r'Re=async t=>\{const e=t\?\?await ke\(\);.*?\},Le=async',
+        'Re=async t=>"clawbench-user",Le=async',
+        text,
+        count=1,
+        flags=re.S,
+    )
+    if count_old or count_new:
         patches.append(f"{path.name}: userId helper")
 
     # 5. Stop the extension from opening a visible claude.ai OAuth tab during
     # startup. The bridge gets fake credentials above; this keeps benchmark
     # action logs focused on the task page instead of the auth splash.
-    text, count = re.subn(
+    text, count_old = re.subn(
         r'Le=async\(\)=>\{const t=E\(\),e=ve\(32\).*?chrome\.tabs\.create\(\{url:o\}\)\}',
         'Le=async()=>{await G({[F.ACCESS_TOKEN]:"fake-oauth-token",[F.REFRESH_TOKEN]:"fake-refresh-token",[F.TOKEN_EXPIRY]:Date.now()+31536e6,[F.ACCOUNT_UUID]:"clawbench-user"})}',
         text,
         count=1,
     )
-    if count:
+    text, count_new = re.subn(
+        r'Ne=async\(\)=>\{const t=P\(\),e=we\(32\).*?chrome\.tabs\.create\(\{url:s\}\)\}',
+        'Ne=async()=>{await J({[W.ACCESS_TOKEN]:"fake-oauth-token",[W.REFRESH_TOKEN]:"fake-refresh-token",[W.TOKEN_EXPIRY]:Date.now()+31536e6,[W.ACCOUNT_UUID]:"clawbench-user"})}',
+        text,
+        count=1,
+    )
+    if count_old or count_new:
         patches.append(f"{path.name}: OAuth launch no-op")
     if text != original:
         path.write_text(text)

--- a/src/clawbench/runtime/harnesses/claude-code-chrome-extension/run-claude-code-chrome-extension.sh
+++ b/src/clawbench/runtime/harnesses/claude-code-chrome-extension/run-claude-code-chrome-extension.sh
@@ -426,9 +426,12 @@ case "${THINKING_LEVEL:-off}" in
 esac
 CLAUDE_ARGS+=(-- "$INSTRUCTION")
 
+: > /data/usage.jsonl
 PATH="$SAFE_BIN" claude "${CLAUDE_ARGS[@]}" \
   > /data/agent-messages.jsonl 2> /data/agent.log &
 AGENT_PID=$!
+python3 /usage-emitter.py --harness claude-code-chrome-extension --input /data/agent-messages.jsonl --output /data/usage.jsonl --watch &
+USAGE_PID=$!
 sleep 3
 
 # --- Watchdog ---------------------------------------------------------------
@@ -484,6 +487,7 @@ echo "$STOP_REASON" > /data/.stop-reason
 # subprocess is parented to the agent; both need an explicit pkill after we
 # take down the direct children.
 kill "$AGENT_PID"  2>/dev/null || true
+kill "$USAGE_PID" 2>/dev/null || true
 kill "$RETRY_PROXY_PID" 2>/dev/null || true
 kill "$PROXY_PID"  2>/dev/null || true
 kill "$MOCK_PID"   2>/dev/null || true
@@ -495,6 +499,7 @@ pkill -f "litellm"                    2>/dev/null || true
 pkill -f "mock-anthropic-api"         2>/dev/null || true
 pkill -f "fake-anthropic-bridge"      2>/dev/null || true
 sleep 2
+python3 /usage-emitter.py --harness claude-code-chrome-extension --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 
 curl -sf -X POST http://localhost:7878/api/stop || true
 rm -f /data/.stop-requested

--- a/src/clawbench/runtime/harnesses/claude-code-chrome-extension/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/claude-code-chrome-extension/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/claude-code/Dockerfile.claude-code
+++ b/src/clawbench/runtime/harnesses/claude-code/Dockerfile.claude-code
@@ -18,4 +18,5 @@ RUN pip install --no-cache-dir 'litellm[proxy]==1.83.9'
 
 COPY harnesses/claude-code/setup-claude-code.sh /setup-claude-code.sh
 COPY harnesses/claude-code/run-claude-code.sh /run-harness.sh
-RUN chmod +x /setup-claude-code.sh /run-harness.sh
+COPY harnesses/claude-code/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-claude-code.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/claude-code/run-claude-code.sh
+++ b/src/clawbench/runtime/harnesses/claude-code/run-claude-code.sh
@@ -77,9 +77,12 @@ case "${THINKING_LEVEL:-off}" in
 esac
 # --mcp-config is variadic; use -- to stop it consuming the prompt.
 CLAUDE_ARGS+=(--mcp-config /tmp/claude-mcp.json -- "$INSTRUCTION")
+: > /data/usage.jsonl
 PATH="$SAFE_BIN" claude "${CLAUDE_ARGS[@]}" \
   > /data/agent-messages.jsonl 2> /data/agent.log &
 AGENT_PID=$!
+python3 /usage-emitter.py --harness claude-code --input /data/agent-messages.jsonl --output /data/usage.jsonl --watch &
+USAGE_PID=$!
 sleep 3
 
 # Watchdog: detect agent no action for 300s
@@ -130,11 +133,13 @@ echo "$STOP_REASON" > /data/.stop-reason
 
 # Kill Claude Code, MCP, and proxy processes
 kill $AGENT_PID 2>/dev/null || true
+kill $USAGE_PID 2>/dev/null || true
 kill $PROXY_PID 2>/dev/null || true
 pkill -f "@anthropic-ai/claude-code" 2>/dev/null || true
 pkill -f "@playwright/mcp" 2>/dev/null || true
 pkill -f "litellm" 2>/dev/null || true
 sleep 2
+python3 /usage-emitter.py --harness claude-code --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 
 curl -sf -X POST http://localhost:7878/api/stop || true
 

--- a/src/clawbench/runtime/harnesses/claude-code/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/claude-code/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/claw-code/Dockerfile.claw-code
+++ b/src/clawbench/runtime/harnesses/claw-code/Dockerfile.claw-code
@@ -46,4 +46,5 @@ COPY --from=claw-builder /out/claw /usr/local/bin/claw
 
 COPY harnesses/claw-code/setup-claw-code.sh /setup-claw-code.sh
 COPY harnesses/claw-code/run-claw-code.sh   /run-harness.sh
-RUN chmod +x /setup-claw-code.sh /run-harness.sh
+COPY harnesses/claw-code/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-claw-code.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/claw-code/run-claw-code.sh
+++ b/src/clawbench/runtime/harnesses/claw-code/run-claw-code.sh
@@ -81,6 +81,7 @@ case "${THINKING_LEVEL:-off}" in
 esac
 
 CLAW_ARGS+=(prompt "$INSTRUCTION")
+: > /data/usage.jsonl
 PATH="$SAFE_BIN" claw "${CLAW_ARGS[@]}" \
   > /data/agent.log 2>&1 &
 AGENT_PID=$!
@@ -146,6 +147,7 @@ sleep 2
 LATEST_SESSION=$(ls -t "$WORKSPACE"/.claw/sessions/*/*.jsonl 2>/dev/null | head -n 1)
 if [ -n "$LATEST_SESSION" ]; then
   cp "$LATEST_SESSION" /data/agent-messages.jsonl
+  python3 /usage-emitter.py --harness claw-code --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 else
   echo "WARN: no .claw/sessions file produced"
   : > /data/agent-messages.jsonl

--- a/src/clawbench/runtime/harnesses/claw-code/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/claw-code/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/codex/Dockerfile.codex
+++ b/src/clawbench/runtime/harnesses/codex/Dockerfile.codex
@@ -24,4 +24,5 @@ RUN pip install --no-cache-dir 'litellm[proxy]==1.83.9'
 
 COPY harnesses/codex/setup-codex.sh /setup-codex.sh
 COPY harnesses/codex/run-codex.sh /run-harness.sh
-RUN chmod +x /setup-codex.sh /run-harness.sh
+COPY harnesses/codex/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-codex.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/codex/run-codex.sh
+++ b/src/clawbench/runtime/harnesses/codex/run-codex.sh
@@ -72,9 +72,12 @@ CODEX_ARGS=(exec
   --skip-git-repo-check
   --dangerously-bypass-approvals-and-sandbox
   -- "$INSTRUCTION")
+: > /data/usage.jsonl
 PATH="$SAFE_BIN" codex "${CODEX_ARGS[@]}" \
   > /tmp/codex-stdout.jsonl 2> /tmp/codex-agent.log &
 AGENT_PID=$!
+python3 /usage-emitter.py --harness codex --input /tmp/codex-stdout.jsonl --output /data/usage.jsonl --watch &
+USAGE_PID=$!
 sleep 3
 
 # Watchdog: detect agent no action for 300s
@@ -125,6 +128,7 @@ echo "$STOP_REASON" > /data/.stop-reason
 
 # Kill Codex, MCP, and LiteLLM proxy processes
 kill $AGENT_PID 2>/dev/null || true
+kill $USAGE_PID 2>/dev/null || true
 kill $PROXY_PID 2>/dev/null || true
 pkill -f "@openai/codex"      2>/dev/null || true
 pkill -f "@playwright/mcp"    2>/dev/null || true
@@ -137,9 +141,11 @@ LATEST_ROLLOUT=$(find /root/.codex/sessions -name "rollout-*.jsonl" -type f \
 if [ -n "$LATEST_ROLLOUT" ]; then
   cp "$LATEST_ROLLOUT" /data/agent-messages.jsonl
   echo "Promoted session rollout to /data/agent-messages.jsonl"
+  python3 /usage-emitter.py --harness codex --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 elif [ -s /tmp/codex-stdout.jsonl ]; then
   cp /tmp/codex-stdout.jsonl /data/agent-messages.jsonl
   echo "WARN: no rollout found; fell back to stdout capture"
+  python3 /usage-emitter.py --harness codex --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 fi
 
 curl -sf -X POST http://localhost:7878/api/stop || true

--- a/src/clawbench/runtime/harnesses/codex/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/codex/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/harness.schema.json
+++ b/src/clawbench/runtime/harnesses/harness.schema.json
@@ -116,6 +116,7 @@
         "dockerfile",
         "setup_script",
         "run_script",
+        "usage_emitter",
         "agent_message_sources"
       ],
       "properties": {
@@ -134,6 +135,9 @@
           "$ref": "#/$defs/relativePath"
         },
         "run_script": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "usage_emitter": {
           "$ref": "#/$defs/relativePath"
         },
         "extra_files": {

--- a/src/clawbench/runtime/harnesses/harnesses.yaml
+++ b/src/clawbench/runtime/harnesses/harnesses.yaml
@@ -12,6 +12,7 @@ harnesses:
     dockerfile: openclaw/Dockerfile.openclaw
     setup_script: openclaw/setup-openclaw.sh
     run_script: openclaw/run-openclaw.sh
+    usage_emitter: openclaw/usage-emitter.py
     agent_message_sources:
       - type: file
         path: /data/agent-messages.jsonl
@@ -22,6 +23,7 @@ harnesses:
     dockerfile: opencode/Dockerfile.opencode
     setup_script: opencode/setup-opencode.sh
     run_script: opencode/run-opencode.sh
+    usage_emitter: opencode/usage-emitter.py
     agent_message_sources:
       - type: file
         path: /data/agent-messages.jsonl
@@ -30,6 +32,7 @@ harnesses:
     dockerfile: claude-code/Dockerfile.claude-code
     setup_script: claude-code/setup-claude-code.sh
     run_script: claude-code/run-claude-code.sh
+    usage_emitter: claude-code/usage-emitter.py
     agent_message_sources:
       - type: file
         path: /data/agent-messages.jsonl
@@ -38,6 +41,7 @@ harnesses:
     dockerfile: claude-code-chrome-extension/Dockerfile.claude-code-chrome-extension
     setup_script: claude-code-chrome-extension/setup-claude-code-chrome-extension.sh
     run_script: claude-code-chrome-extension/run-claude-code-chrome-extension.sh
+    usage_emitter: claude-code-chrome-extension/usage-emitter.py
     extra_files:
       - claude-code-chrome-extension/mock-anthropic-api.py
     agent_message_sources:
@@ -48,6 +52,7 @@ harnesses:
     dockerfile: codex/Dockerfile.codex
     setup_script: codex/setup-codex.sh
     run_script: codex/run-codex.sh
+    usage_emitter: codex/usage-emitter.py
     agent_message_sources:
       - type: file
         path: /data/agent-messages.jsonl
@@ -61,8 +66,10 @@ harnesses:
     dockerfile: browser-use/Dockerfile.browser-use
     setup_script: browser-use/setup-browser-use.sh
     run_script: browser-use/run-browser-use.sh
+    usage_emitter: browser-use/usage-emitter.py
     extra_files:
       - browser-use/run-browser-use-agent.py
+      - browser-use/browser-use-usage-logger.py
     agent_message_sources:
       - type: file
         path: /data/agent-messages.jsonl
@@ -71,6 +78,7 @@ harnesses:
     dockerfile: claw-code/Dockerfile.claw-code
     setup_script: claw-code/setup-claw-code.sh
     run_script: claw-code/run-claw-code.sh
+    usage_emitter: claw-code/usage-emitter.py
     extra_files:
       - claw-code/claw-code-ndjson.patch.py
     agent_message_sources:
@@ -83,6 +91,7 @@ harnesses:
     dockerfile: hermes/Dockerfile.hermes
     setup_script: hermes/setup-hermes.sh
     run_script: hermes/run-hermes.sh
+    usage_emitter: hermes/usage-emitter.py
     extra_files:
       - hermes/hermes-capture.py
     agent_message_sources:
@@ -95,6 +104,9 @@ harnesses:
     dockerfile: pi/Dockerfile.pi
     setup_script: pi/setup-pi.sh
     run_script: pi/run-pi.sh
+    usage_emitter: pi/usage-emitter.py
+    extra_files:
+      - pi/pi-usage-logger.py
     agent_message_sources:
       - type: file
         path: /data/agent-messages.jsonl

--- a/src/clawbench/runtime/harnesses/hermes/Dockerfile.hermes
+++ b/src/clawbench/runtime/harnesses/hermes/Dockerfile.hermes
@@ -16,4 +16,5 @@ RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install -g agent-browser@0.26.0
 COPY harnesses/hermes/setup-hermes.sh /setup-hermes.sh
 COPY harnesses/hermes/run-hermes.sh /run-harness.sh
 COPY harnesses/hermes/hermes-capture.py /hermes-capture.py
-RUN chmod +x /setup-hermes.sh /run-harness.sh /hermes-capture.py
+COPY harnesses/hermes/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-hermes.sh /run-harness.sh /hermes-capture.py /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/hermes/run-hermes.sh
+++ b/src/clawbench/runtime/harnesses/hermes/run-hermes.sh
@@ -249,8 +249,11 @@ HERMES_ARGS=(chat
   --model "$HERMES_MODEL_NAME"
   --provider "$HERMES_PROVIDER"
   -q "$HERMES_INSTRUCTION")
+: > /data/usage.jsonl
 python3 /hermes-capture.py "${HERMES_ARGS[@]}" > /tmp/hermes-stdout.log 2> /tmp/hermes-stderr.log &
 AGENT_PID=$!
+python3 /usage-emitter.py --harness hermes --input /tmp/hermes-live-agent-messages.jsonl --output /data/usage.jsonl --watch &
+USAGE_PID=$!
 sleep 3
 
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -315,10 +318,12 @@ echo "$STOP_REASON" > /data/.stop-reason
 # Terminate Hermes first so it can flush its session, then clean up the native
 # browser helper process if it is still alive.
 terminate_hermes "$AGENT_PID"
+kill "$USAGE_PID" 2>/dev/null || true
 pkill -f "agent-browser" 2>/dev/null || true
 sleep 2
 
 promote_hermes_transcript
+python3 /usage-emitter.py --harness hermes --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 cp /tmp/hermes-stdout.log /data/agent-stdout.log 2>/dev/null || true
 cp /tmp/hermes-stderr.log /data/agent-stderr.log 2>/dev/null || true
 cp /tmp/hermes-export.log /data/hermes-export.log 2>/dev/null || true

--- a/src/clawbench/runtime/harnesses/hermes/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/hermes/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/openclaw/Dockerfile.openclaw
+++ b/src/clawbench/runtime/harnesses/openclaw/Dockerfile.openclaw
@@ -17,4 +17,5 @@ RUN find /usr/local/lib/node_modules/openclaw/dist -name '*.js' -exec \
 
 COPY harnesses/openclaw/setup-openclaw.sh /setup-openclaw.sh
 COPY harnesses/openclaw/run-openclaw.sh /run-harness.sh
-RUN chmod +x /setup-openclaw.sh /run-harness.sh
+COPY harnesses/openclaw/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-openclaw.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/openclaw/run-openclaw.sh
+++ b/src/clawbench/runtime/harnesses/openclaw/run-openclaw.sh
@@ -63,8 +63,11 @@ if [ -n "$MAX_TOKENS" ]; then
   AGENT_CMD+=(--max-tokens "$MAX_TOKENS")
 fi
 cd "$WORKSPACE"
+: > /data/usage.jsonl
 "${AGENT_CMD[@]}" > /data/agent.log 2>&1 &
 AGENT_PID=$!
+python3 /usage-emitter.py --harness openclaw --input /root/.openclaw/agents/main/sessions/clawbench.jsonl --output /data/usage.jsonl --watch &
+USAGE_PID=$!
 
 # Watchdog: wait for agent activity, then detect idle (no new actions for 300s)
 IDLE_THRESHOLD=300
@@ -114,12 +117,14 @@ echo "$STOP_REASON" > /data/.stop-reason
 
 # Kill all openclaw processes
 kill $AGENT_PID 2>/dev/null || true
+kill $USAGE_PID 2>/dev/null || true
 kill $GATEWAY_PID 2>/dev/null || true
 pkill -f "openclaw" 2>/dev/null || true
 sleep 2
 
 # Copy OpenClaw session transcript to /data
 cp /root/.openclaw/agents/main/sessions/clawbench.jsonl /data/agent-messages.jsonl 2>/dev/null || true
+python3 /usage-emitter.py --harness openclaw --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 
 # Finalize bookkeeping (eval promotion, etc.) — recording keeps running
 curl -sf -X POST http://localhost:7878/api/stop || true

--- a/src/clawbench/runtime/harnesses/openclaw/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/openclaw/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/opencode/Dockerfile.opencode
+++ b/src/clawbench/runtime/harnesses/opencode/Dockerfile.opencode
@@ -15,4 +15,5 @@ RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install -g \
 
 COPY harnesses/opencode/setup-opencode.sh /setup-opencode.sh
 COPY harnesses/opencode/run-opencode.sh /run-harness.sh
-RUN chmod +x /setup-opencode.sh /run-harness.sh
+COPY harnesses/opencode/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-opencode.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/opencode/run-opencode.sh
+++ b/src/clawbench/runtime/harnesses/opencode/run-opencode.sh
@@ -52,9 +52,12 @@ case "${THINKING_LEVEL:-medium}" in
   *) OPENCODE_ARGS+=(--thinking) ;;
 esac
 OPENCODE_ARGS+=("$INSTRUCTION")
+: > /data/usage.jsonl
 opencode "${OPENCODE_ARGS[@]}" \
   > /data/agent-messages.jsonl 2> /data/agent.log &
 AGENT_PID=$!
+python3 /usage-emitter.py --harness opencode --input /data/agent-messages.jsonl --output /data/usage.jsonl --watch &
+USAGE_PID=$!
 sleep 3
 
 # Watchdog: detect agent no action for 300s
@@ -105,9 +108,11 @@ echo "$STOP_REASON" > /data/.stop-reason
 
 # Kill opencode and any MCP child processes
 kill $AGENT_PID 2>/dev/null || true
+kill $USAGE_PID 2>/dev/null || true
 pkill -f "opencode" 2>/dev/null || true
 pkill -f "@playwright/mcp" 2>/dev/null || true
 sleep 2
+python3 /usage-emitter.py --harness opencode --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 
 curl -sf -X POST http://localhost:7878/api/stop || true
 

--- a/src/clawbench/runtime/harnesses/opencode/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/opencode/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clawbench/runtime/harnesses/pi/Dockerfile.pi
+++ b/src/clawbench/runtime/harnesses/pi/Dockerfile.pi
@@ -18,4 +18,6 @@ RUN pip install --no-cache-dir 'litellm[proxy]==1.83.9'
 
 COPY harnesses/pi/setup-pi.sh /setup-pi.sh
 COPY harnesses/pi/run-pi.sh /run-harness.sh
-RUN chmod +x /setup-pi.sh /run-harness.sh
+COPY harnesses/pi/pi-usage-logger.py /tmp/pi_usage_logger.py
+COPY harnesses/pi/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-pi.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/pi/pi-usage-logger.py
+++ b/src/clawbench/runtime/harnesses/pi/pi-usage-logger.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Pi harness LiteLLM usage logger."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from litellm.integrations.custom_logger import CustomLogger
+
+OUT = Path("/data/usage.jsonl")
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+class PiUsageLogger(CustomLogger):
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        if isinstance(response_obj, dict):
+            usage = response_obj.get("usage") or {}
+            response_id = response_obj.get("id")
+            model = response_obj.get("model") or kwargs.get("model") or ""
+            hidden = response_obj.get("_hidden_params")
+        else:
+            usage = getattr(response_obj, "usage", None) or {}
+            response_id = getattr(response_obj, "id", None)
+            model = getattr(response_obj, "model", None) or kwargs.get("model") or ""
+            hidden = getattr(response_obj, "_hidden_params", None)
+        if not isinstance(usage, dict):
+            return
+        prompt = _to_int(usage.get("prompt_tokens") or usage.get("input_tokens"))
+        completion = _to_int(
+            usage.get("completion_tokens") or usage.get("output_tokens")
+        )
+        cache_read = _to_int(
+            usage.get("cache_read_tokens") or usage.get("cache_read_input_tokens")
+        )
+        cache_write = _to_int(
+            usage.get("cache_write_tokens") or usage.get("cache_creation_input_tokens")
+        )
+        reasoning = _to_int(
+            usage.get("reasoning_tokens") or usage.get("internal_reasoning_tokens")
+        )
+        total = prompt + completion + cache_read + cache_write + reasoning
+        total = total or _to_int(usage.get("total_tokens") or usage.get("totalTokens"))
+        if total <= 0:
+            return
+        hidden = hidden if isinstance(hidden, dict) else {}
+        response_cost = hidden.get("response_cost")
+        cost = response_cost if isinstance(response_cost, (int, float)) else None
+        matched_model = hidden.get("model_id") or hidden.get("custom_llm_provider")
+        row = {
+            "type": "usage",
+            "source_harness": "pi",
+            "call_id": f"response:{response_id or time.time()}",
+            "timestamp": time.time(),
+            "model": str(model),
+            "input_tokens": prompt,
+            "output_tokens": completion,
+            "cache_read_tokens": cache_read,
+            "cache_write_tokens": cache_write,
+            "reasoning_tokens": reasoning,
+            "total_tokens": total,
+            "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+            "cost_status": "estimated" if cost is not None else "price_unavailable",
+            "pricing_source_url": "https://openrouter.ai/api/v1/models",
+            "matched_model_id": str(matched_model) if matched_model else None,
+        }
+        OUT.parent.mkdir(parents=True, exist_ok=True)
+        with OUT.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+
+proxy_handler_instance = PiUsageLogger()

--- a/src/clawbench/runtime/harnesses/pi/run-pi.sh
+++ b/src/clawbench/runtime/harnesses/pi/run-pi.sh
@@ -8,7 +8,8 @@ source /tmp/pi-env.sh
 
 # Start LiteLLM translation proxy.
 echo "Starting API translation proxy (litellm)..."
-litellm --config /tmp/litellm-config.yaml --port 4000 \
+PYTHONPATH="/tmp${PYTHONPATH:+:$PYTHONPATH}" \
+  litellm --config /tmp/litellm-config.yaml --port 4000 \
   > /data/proxy.log 2>&1 &
 PROXY_PID=$!
 for i in $(seq 1 30); do
@@ -79,6 +80,7 @@ PI_BROWSER_PROMPT="Complete the task using the browser_* tools attached to the e
 cd "$WORKSPACE"
 echo "Starting Pi agent (model=${PI_PROVIDER}/${PI_MODEL_ID}, thinking=${PI_THINKING})..."
 PI_RAW_MESSAGES=/data/agent-messages.raw.jsonl
+: > /data/usage.jsonl
 PATH="$SAFE_BIN" pi \
   --mode json \
   --print \
@@ -97,6 +99,8 @@ PATH="$SAFE_BIN" pi \
   "$INSTRUCTION" \
   > "$PI_RAW_MESSAGES" 2> /data/agent.log &
 AGENT_PID=$!
+python3 /usage-emitter.py --harness pi --input "$PI_RAW_MESSAGES" --output /data/usage.jsonl --watch &
+USAGE_PID=$!
 sleep 3
 
 # Watchdog: detect agent no action for 300s
@@ -147,6 +151,7 @@ echo "$STOP_REASON" > /data/.stop-reason
 
 # Kill Pi and proxy processes
 kill $AGENT_PID 2>/dev/null || true
+kill $USAGE_PID 2>/dev/null || true
 kill $PROXY_PID 2>/dev/null || true
 pkill -f "@earendil-works/pi-coding-agent" 2>/dev/null || true
 pkill -f "litellm" 2>/dev/null || true
@@ -177,6 +182,7 @@ PYEOF
 else
   : > /data/agent-messages.jsonl
 fi
+python3 /usage-emitter.py --harness pi --input /data/agent-messages.jsonl --output /data/usage.jsonl || true
 
 rm -f /data/agent.log /data/proxy.log
 

--- a/src/clawbench/runtime/harnesses/pi/setup-pi.sh
+++ b/src/clawbench/runtime/harnesses/pi/setup-pi.sh
@@ -86,7 +86,10 @@ proxy_config = {
         "model_name": model_name,
         "litellm_params": litellm_params,
     }],
-    "litellm_settings": {"drop_params": True},
+    "litellm_settings": {
+        "drop_params": True,
+        "success_callback": ["pi_usage_logger.proxy_handler_instance"],
+    },
 }
 proxy_path = Path("/tmp/litellm-config.yaml")
 proxy_path.write_text(yaml.dump(proxy_config, default_flow_style=False))

--- a/src/clawbench/runtime/harnesses/pi/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/pi/usage-emitter.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Harness-local usage emitter.
+
+Each harness runs this inside its own container to translate that harness's
+native transcript stream into /data/usage.jsonl. The host runner consumes only
+the generated usage artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _first_int(data: dict[str, Any], keys: Iterable[str]) -> int:
+    for key in keys:
+        value = _to_int(data.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
+    input_details = raw.get("input_tokens_details")
+    output_details = raw.get("output_tokens_details")
+    cache_details = raw.get("cache")
+    if not isinstance(input_details, dict):
+        input_details = {}
+    if not isinstance(output_details, dict):
+        output_details = {}
+    if not isinstance(cache_details, dict):
+        cache_details = {}
+
+    explicit_cache_read = _first_int(
+        raw,
+        (
+            "cacheRead",
+            "cache_read",
+            "cache_read_tokens",
+            "cache_read_input_tokens",
+        ),
+    )
+    nested_input_cache_read = _first_int(
+        input_details,
+        ("cached_tokens", "cache_read_tokens", "cache_read_input_tokens"),
+    )
+    nested_cache_read = nested_input_cache_read or _first_int(
+        cache_details, ("read", "cache_read_tokens")
+    )
+
+    usage = {
+        "input_tokens": _first_int(
+            raw,
+            ("input", "prompt", "prompt_tokens", "input_tokens"),
+        ),
+        "output_tokens": _first_int(
+            raw,
+            ("output", "completion", "completion_tokens", "output_tokens"),
+        ),
+        "cache_read_tokens": explicit_cache_read or nested_cache_read,
+        "cache_write_tokens": _first_int(
+            raw,
+            (
+                "cacheWrite",
+                "cache_write",
+                "cache_write_tokens",
+                "cache_creation_input_tokens",
+            ),
+        )
+        or _first_int(cache_details, ("write", "cache_write_tokens")),
+        "reasoning_tokens": _first_int(
+            raw,
+            (
+                "reasoning",
+                "reasoning_tokens",
+                "internal_reasoning",
+                "internal_reasoning_tokens",
+            ),
+        )
+        or _first_int(output_details, ("reasoning_tokens",)),
+        "reported_total_tokens": _first_int(
+            raw,
+            ("totalTokens", "total_tokens", "total"),
+        ),
+    }
+    if nested_input_cache_read and not explicit_cache_read:
+        usage["input_tokens"] = max(
+            usage["input_tokens"] - nested_input_cache_read,
+            0,
+        )
+    usage["total_tokens"] = (
+        usage["input_tokens"]
+        + usage["output_tokens"]
+        + usage["cache_read_tokens"]
+        + usage["cache_write_tokens"]
+        + usage["reasoning_tokens"]
+    ) or usage["reported_total_tokens"]
+    return usage
+
+
+def _fetch_pricing(
+    base_url: str | None, api_key: str | None
+) -> dict[str, dict[str, Any]]:
+    if not base_url or "openrouter.ai" not in base_url:
+        return {}
+    url = base_url.rstrip("/") + "/models"
+    headers = {"User-Agent": "clawbench/usage-emitter"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return {}
+    return {
+        row["id"]: row
+        for row in payload.get("data", [])
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def _resolve_model(
+    candidates: Iterable[str], models: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    normalized = [c.removeprefix("openrouter/").strip() for c in candidates if c]
+    for candidate in normalized:
+        if candidate in models:
+            return models[candidate]
+    for candidate in normalized:
+        suffix = f"/{candidate}"
+        matches = [row for model_id, row in models.items() if model_id.endswith(suffix)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
+def _pricing_rates(model_row: dict[str, Any] | None) -> dict[str, Decimal | None]:
+    pricing = model_row.get("pricing") if isinstance(model_row, dict) else None
+    if not isinstance(pricing, dict):
+        pricing = {}
+    completion_rate = _to_decimal(pricing.get("completion"))
+    return {
+        "input_tokens": _to_decimal(pricing.get("prompt")),
+        "output_tokens": completion_rate,
+        "cache_read_tokens": _to_decimal(pricing.get("input_cache_read")),
+        "cache_write_tokens": _to_decimal(pricing.get("input_cache_write")),
+        "reasoning_tokens": _to_decimal(pricing.get("internal_reasoning"))
+        or completion_rate,
+    }
+
+
+def _estimate(
+    row: dict[str, Any], model_row: dict[str, Any] | None
+) -> tuple[float | None, str]:
+    rates = _pricing_rates(model_row)
+    if rates["input_tokens"] is None and rates["output_tokens"] is None:
+        return None, "price_unavailable"
+    cost = Decimal("0")
+    for key, rate in rates.items():
+        tokens = _to_int(row.get(key))
+        if not tokens:
+            continue
+        if rate is None:
+            return None, "price_unavailable"
+        cost += Decimal(tokens) * rate
+    return float(cost), "estimated"
+
+
+def _event_usage_key(event: dict[str, Any], owner: dict[str, Any]) -> str | None:
+    for key in ("id", "message_id"):
+        value = owner.get(key)
+        if value:
+            return f"message:{value}"
+    response_id = owner.get("responseId") or owner.get("response_id")
+    if response_id:
+        return f"response:{response_id}"
+    if event.get("id"):
+        return f"event:{event['id']}"
+    if event.get("uuid"):
+        return f"uuid:{event['uuid']}"
+    timestamp = owner.get("timestamp") or event.get("timestamp")
+    model = owner.get("model") or event.get("model")
+    if timestamp and model:
+        return f"{model}:{timestamp}"
+    return None
+
+
+def _usage_candidates(
+    event: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    candidates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    raw_usage = event.get("usage")
+    if isinstance(raw_usage, dict):
+        candidates.append((raw_usage, event))
+
+    message = event.get("message")
+    if isinstance(message, dict):
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, message))
+
+    part = event.get("part")
+    if isinstance(part, dict):
+        for key in ("usage", "tokens"):
+            raw_usage = part.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, part))
+
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("usage", "usage_metadata", "token_usage"):
+            raw_usage = metadata.get(key)
+            if isinstance(raw_usage, dict):
+                candidates.append((raw_usage, metadata))
+
+    response_metadata = event.get("response_metadata")
+    if isinstance(response_metadata, dict):
+        raw_usage = response_metadata.get("token_usage")
+        if isinstance(raw_usage, dict):
+            candidates.append((raw_usage, response_metadata))
+
+    if event.get("type") == "session_meta":
+        normalized = _normalize_usage(event)
+        if normalized["total_tokens"]:
+            candidates.append((event, event))
+    return candidates
+
+
+def _row_from_event(
+    event: dict[str, Any],
+    raw_usage: dict[str, Any],
+    owner: dict[str, Any],
+    *,
+    harness: str,
+    default_model: str,
+    pricing_models: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    usage = _normalize_usage(raw_usage)
+    if not usage["total_tokens"]:
+        return None
+
+    model = (
+        owner.get("model")
+        or owner.get("model_id")
+        or owner.get("modelId")
+        or event.get("model")
+        or event.get("model_id")
+        or event.get("modelId")
+        or default_model
+    )
+    model = str(model).removeprefix("openrouter/") if model else default_model
+    model_row = _resolve_model((model, default_model), pricing_models)
+    cost, status = _estimate(usage, model_row)
+    call_id = _event_usage_key(event, owner)
+    if call_id is None:
+        call_id = f"{harness}:{model}:{event.get('timestamp') or time.time()}"
+
+    return {
+        "type": "usage",
+        "source_harness": harness,
+        "call_id": call_id,
+        "timestamp": owner.get("timestamp") or event.get("timestamp") or time.time(),
+        "model": model,
+        "input_tokens": usage["input_tokens"],
+        "output_tokens": usage["output_tokens"],
+        "cache_read_tokens": usage["cache_read_tokens"],
+        "cache_write_tokens": usage["cache_write_tokens"],
+        "reasoning_tokens": usage["reasoning_tokens"],
+        "total_tokens": usage["total_tokens"],
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "cost_status": status,
+        "pricing_source_url": OPENROUTER_MODELS_URL,
+        "matched_model_id": (
+            model_row.get("id") if isinstance(model_row, dict) else None
+        ),
+    }
+
+
+def _load_seen(path: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and row.get("call_id"):
+                    seen.add(str(row["call_id"]))
+    except OSError:
+        pass
+    return seen
+
+
+def emit_once(args: argparse.Namespace, seen: set[str] | None = None) -> set[str]:
+    seen = set(seen or ())
+    pricing = getattr(args, "_pricing_models", None)
+    if pricing is None:
+        pricing = _fetch_pricing(args.base_url, args.api_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.output.exists():
+        args.output.write_text("")
+    try:
+        lines = args.input.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return seen
+    with args.output.open("a", encoding="utf-8") as out:
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            for raw_usage, owner in _usage_candidates(event):
+                row = _row_from_event(
+                    event,
+                    raw_usage,
+                    owner,
+                    harness=args.harness,
+                    default_model=args.model,
+                    pricing_models=pricing,
+                )
+                if row is None:
+                    continue
+                call_id = str(row["call_id"])
+                if call_id in seen:
+                    continue
+                seen.add(call_id)
+                out.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                out.write("\n")
+                out.flush()
+    return seen
+
+
+def watch(args: argparse.Namespace) -> None:
+    seen = _load_seen(args.output)
+    args._pricing_models = _fetch_pricing(args.base_url, args.api_key)
+    deadline = time.time() + args.max_seconds
+    while time.time() < deadline:
+        seen = emit_once(args, seen)
+        time.sleep(args.interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("/data/usage.jsonl"))
+    parser.add_argument("--model", default=os.environ.get("MODEL_NAME", ""))
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("API_KEY", ""))
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(os.environ.get("TIME_LIMIT_S", "1800")) + 60,
+    )
+    args = parser.parse_args()
+    if args.watch:
+        watch(args)
+    else:
+        emit_once(args, _load_seen(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_harness_registry.py
+++ b/tests/test_harness_registry.py
@@ -41,9 +41,17 @@ EXPECTED_EXTRA_FILES = {
     "claude-code-chrome-extension": (
         "claude-code-chrome-extension/mock-anthropic-api.py",
     ),
-    "browser-use": ("browser-use/run-browser-use-agent.py",),
+    "browser-use": (
+        "browser-use/run-browser-use-agent.py",
+        "browser-use/browser-use-usage-logger.py",
+    ),
     "claw-code": ("claw-code/claw-code-ndjson.patch.py",),
     "hermes": ("hermes/hermes-capture.py",),
+    "pi": ("pi/pi-usage-logger.py",),
+}
+
+EXPECTED_USAGE_EMITTERS = {
+    harness: f"{harness}/usage-emitter.py" for harness in EXPECTED_HARNESSES
 }
 
 EXPECTED_AGENT_MESSAGE_SOURCES = {
@@ -122,6 +130,13 @@ def test_harness_registry_matches_current_harness_contract() -> None:
             .as_posix()
             == run_script
         )
+        usage_emitter = HARNESS_REGISTRY.harness_usage_emitters[harness]
+        assert (
+            usage_emitter.relative_to(
+                HARNESS_REGISTRY.base_dockerfile.parents[1]
+            ).as_posix()
+            == EXPECTED_USAGE_EMITTERS[harness]
+        )
         assert all(
             extra_file.is_file()
             for extra_file in HARNESS_REGISTRY.harness_extra_files[harness]
@@ -161,6 +176,8 @@ def test_harness_registry_tracks_all_dockerfile_harness_copies() -> None:
             HARNESS_REGISTRY.harness_run_scripts[harness],
             *HARNESS_REGISTRY.harness_extra_files[harness],
         }
+        usage_emitter = HARNESS_REGISTRY.harness_usage_emitters[harness]
+        copied_sources[HARNESS_REGISTRY.harness_dockerfiles[harness]].add(usage_emitter)
 
     copy_re = re.compile(r"^\s*COPY\s+harnesses/(\S+)")
     for dockerfile, expected_sources in copied_sources.items():
@@ -179,9 +196,11 @@ def _write_registry_fixture(tmp_path: Path, harnesses_yaml: str) -> Path:
         "alpha/Dockerfile.alpha",
         "alpha/setup-alpha.sh",
         "alpha/run-alpha.sh",
+        "alpha/usage-emitter.py",
         "beta/Dockerfile.beta",
         "beta/setup-beta.sh",
         "beta/run-beta.sh",
+        "beta/usage-emitter.py",
     ):
         path = tmp_path / rel_path
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -209,11 +228,13 @@ harnesses:
     dockerfile: alpha/Dockerfile.alpha
     setup_script: alpha/setup-alpha.sh
     run_script: alpha/run-alpha.sh
+    usage_emitter: alpha/usage-emitter.py
   - name: alpha
     image: clawbench-alpha-2
     dockerfile: beta/Dockerfile.beta
     setup_script: beta/setup-beta.sh
     run_script: beta/run-beta.sh
+    usage_emitter: beta/usage-emitter.py
 """,
     )
 
@@ -236,11 +257,13 @@ harnesses:
     dockerfile: alpha/Dockerfile.alpha
     setup_script: alpha/setup-alpha.sh
     run_script: alpha/run-alpha.sh
+    usage_emitter: alpha/usage-emitter.py
   - name: beta
     image: clawbench-beta
     dockerfile: beta/Dockerfile.beta
     setup_script: beta/setup-beta.sh
     run_script: beta/run-beta.sh
+    usage_emitter: beta/usage-emitter.py
 """,
     )
 
@@ -263,6 +286,7 @@ harnesses:
     dockerfile: alpha/Dockerfile.alpha
     setup_script: alpha/setup-alpha.sh
     run_script: alpha/run-alpha.sh
+    usage_emitter: alpha/usage-emitter.py
     extra_files:
       - alpha/missing-helper.py
 """,
@@ -287,6 +311,7 @@ harnesses:
     dockerfile: alpha/Dockerfile.alpha
     setup_script: alpha/missing-setup.sh
     run_script: alpha/run-alpha.sh
+    usage_emitter: alpha/usage-emitter.py
 """,
     )
 
@@ -311,6 +336,7 @@ harnesses:
     dockerfile: alpha/Dockerfile.alpha
     setup_script: alpha/setup-alpha.sh
     run_script: alpha/run-alpha.sh
+    usage_emitter: alpha/usage-emitter.py
     agent_message_sources:
       - type: latest_glob
         pattern: /tmp/safe/*.jsonl;rm

--- a/tests/test_results_and_metadata.py
+++ b/tests/test_results_and_metadata.py
@@ -36,6 +36,7 @@ def test_classify_run_success_from_synthetic_output(tmp_path: Path) -> None:
     assert result["failure_category"] is None
     assert result["infra_failure"] is False
     assert result["metrics"]["actions"] == 1
+    assert "data/usage.jsonl" not in result["metrics"]["missing_files"]
 
 
 def test_classify_run_flags_missing_recording(tmp_path: Path) -> None:
@@ -105,6 +106,18 @@ def test_print_results_includes_usage_summary(
     out = capsys.readouterr().out
     assert "Usage: 123 total" in out
     assert "estimated cost $0.004200" in out
+
+
+def test_remove_transient_usage_artifact(tmp_path: Path) -> None:
+    from clawbench.runner.run_support.results import remove_transient_usage_artifact
+
+    usage = tmp_path / "data" / "usage.jsonl"
+    usage.parent.mkdir()
+    usage.write_text("{}\n")
+
+    remove_transient_usage_artifact(tmp_path)
+
+    assert not usage.exists()
 
 
 def test_run_metadata_redacts_model_and_judge_secrets(

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import importlib.util
+import argparse
 from pathlib import Path
+
+import pytest
 
 from clawbench.runner.run_support.usage import (
     format_usage_status,
@@ -35,6 +39,36 @@ def _line(row: dict) -> str:
     return json.dumps(row)
 
 
+EMITTER_HARNESSES = (
+    "openclaw",
+    "opencode",
+    "claude-code",
+    "claude-code-chrome-extension",
+    "codex",
+    "browser-use",
+    "claw-code",
+    "hermes",
+    "pi",
+)
+
+
+def _load_usage_emitter(harness: str):
+    path = (
+        Path(__file__).parents[1]
+        / "src/clawbench/runtime/harnesses"
+        / harness
+        / "usage-emitter.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        f"{harness.replace('-', '_')}_usage_emitter",
+        path,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_resolve_openrouter_model_exact_then_suffix() -> None:
     exact = resolve_openrouter_model(["provider/test-model"], PRICING)
     assert exact is not None
@@ -47,34 +81,36 @@ def test_resolve_openrouter_model_exact_then_suffix() -> None:
     assert resolve_openrouter_model(["missing"], PRICING) is None
 
 
-def test_openclaw_usage_and_cost_math() -> None:
+def test_usage_jsonl_rows_and_cost_math() -> None:
     lines = [
         _line(
             {
-                "type": "message",
-                "id": "a1",
-                "message": {
-                    "role": "assistant",
-                    "model": "test-model",
-                    "usage": {
-                        "input": 100,
-                        "output": 20,
-                        "cacheRead": 50,
-                        "cacheWrite": 10,
-                        "totalTokens": 180,
-                    },
-                },
+                "type": "usage",
+                "source_harness": "openclaw",
+                "call_id": "a1",
+                "model": "test-model",
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_tokens": 50,
+                "cache_write_tokens": 10,
+                "total_tokens": 180,
+                "estimated_cost_usd": 0.17,
+                "cost_status": "estimated",
+                "matched_model_id": "provider/test-model",
             }
         ),
         _line(
             {
-                "type": "message",
-                "id": "a2",
-                "message": {
-                    "role": "assistant",
-                    "model": "test-model",
-                    "usage": {"input": 10, "output": 5, "totalTokens": 15},
-                },
+                "type": "usage",
+                "source_harness": "openclaw",
+                "call_id": "a2",
+                "model": "test-model",
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "estimated_cost_usd": 0.0,
+                "cost_status": "estimated",
+                "matched_model_id": "provider/test-model",
             }
         ),
     ]
@@ -96,22 +132,20 @@ def test_openclaw_usage_and_cost_math() -> None:
     assert "195 tok" in format_usage_status(summary)
 
 
-def test_claude_code_duplicate_stream_rows_count_once() -> None:
+def test_duplicate_usage_rows_count_once() -> None:
     row = {
-        "type": "assistant",
-        "message": {
-            "id": "gen-1",
-            "role": "assistant",
-            "model": "test-model",
-            "usage": {
-                "input_tokens": 100,
-                "output_tokens": 30,
-                "cache_read_input_tokens": 70,
-                "total_tokens": 130,
-            },
-        },
+        "type": "usage",
+        "source_harness": "claude-code",
+        "call_id": "gen-1",
+        "model": "test-model",
+        "input_tokens": 100,
+        "output_tokens": 30,
+        "cache_read_tokens": 70,
+        "total_tokens": 200,
+        "estimated_cost_usd": 0.173,
+        "cost_status": "estimated",
     }
-    lines = [_line(row), _line(row), _line({**row, "uuid": "different-fragment"})]
+    lines = [_line(row), _line(row), _line({**row, "timestamp": 2})]
 
     summary = summarize_usage_lines(
         lines,
@@ -126,15 +160,20 @@ def test_claude_code_duplicate_stream_rows_count_once() -> None:
     assert summary["total_tokens"] == 200
 
 
-def test_openai_nested_cached_tokens_are_not_double_counted() -> None:
+def test_price_unavailable_rows_keep_tokens() -> None:
     lines = [
         _line(
             {
-                "usage": {
-                    "input_tokens": 100,
-                    "output_tokens": 10,
-                    "input_tokens_details": {"cached_tokens": 40},
-                }
+                "type": "usage",
+                "source_harness": "browser-use",
+                "call_id": "b1",
+                "model": "test-model",
+                "input_tokens": 60,
+                "output_tokens": 10,
+                "cache_read_tokens": 40,
+                "total_tokens": 110,
+                "estimated_cost_usd": None,
+                "cost_status": "price_unavailable",
             }
         )
     ]
@@ -145,34 +184,24 @@ def test_openai_nested_cached_tokens_are_not_double_counted() -> None:
         pricing_models=PRICING,
     )
 
+    assert summary["status"] == "price_unavailable"
     assert summary["input_tokens"] == 60
     assert summary["cache_read_tokens"] == 40
     assert summary["total_tokens"] == 110
 
 
-def test_hermes_session_meta_usage_wins_over_message_rows() -> None:
+def test_agent_messages_without_usage_json_contract_are_unavailable() -> None:
     lines = [
-        _line(
-            {
-                "type": "session_meta",
-                "model": "provider/test-model",
-                "input_tokens": 300,
-                "output_tokens": 40,
-                "cache_read_tokens": 500,
-                "api_call_count": 7,
-            }
-        ),
         _line(
             {
                 "type": "message",
                 "message": {
-                    "id": "m1",
                     "role": "assistant",
                     "model": "provider/test-model",
-                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                    "usage": {"input_tokens": 300, "output_tokens": 40},
                 },
             }
-        ),
+        )
     ]
 
     summary = summarize_usage_lines(
@@ -184,11 +213,9 @@ def test_hermes_session_meta_usage_wins_over_message_rows() -> None:
         pricing_models=PRICING,
     )
 
-    assert summary["api_calls"] == 7
-    assert summary["input_tokens"] == 300
-    assert summary["output_tokens"] == 40
-    assert summary["cache_read_tokens"] == 500
-    assert summary["total_tokens"] == 840
+    assert summary["status"] == "usage_unavailable"
+    assert summary["api_calls"] == 0
+    assert summary["total_tokens"] == 0
 
 
 def test_summarize_usage_file_handles_missing_file(tmp_path: Path) -> None:
@@ -196,3 +223,94 @@ def test_summarize_usage_file_handles_missing_file(tmp_path: Path) -> None:
 
     assert summary["status"] == "usage_unavailable"
     assert summary["total_tokens"] == 0
+
+
+def test_usage_jsonl_source_is_marked_transient(tmp_path: Path) -> None:
+    path = tmp_path / "usage.jsonl"
+    path.write_text("")
+
+    summary = summarize_usage_file(path)
+
+    assert summary["usage_source"] == "transient_usage_jsonl"
+
+
+@pytest.mark.parametrize("harness", EMITTER_HARNESSES)
+def test_harness_usage_emitter_writes_contract_rows(
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    emitter = _load_usage_emitter(harness)
+    src = tmp_path / "agent-messages.jsonl"
+    dst = tmp_path / "usage.jsonl"
+    src.write_text(
+        "\n".join(
+            [
+                _line(
+                    {
+                        "type": "message",
+                        "id": "openclaw-1",
+                        "message": {
+                            "role": "assistant",
+                            "model": "test-model",
+                            "usage": {"input": 10, "output": 3},
+                        },
+                    }
+                ),
+                _line(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "id": "claude-1",
+                            "model": "test-model",
+                            "usage": {
+                                "input_tokens": 20,
+                                "output_tokens": 4,
+                                "cache_read_input_tokens": 6,
+                            },
+                        },
+                    }
+                ),
+                _line(
+                    {
+                        "type": "session_meta",
+                        "model": "test-model",
+                        "input_tokens": 30,
+                        "output_tokens": 5,
+                    }
+                ),
+                _line(
+                    {
+                        "type": "step_finish",
+                        "part": {
+                            "id": "opencode-part-1",
+                            "model": "test-model",
+                            "tokens": {
+                                "input": 100,
+                                "output": 7,
+                                "reasoning": 2,
+                                "cache": {"read": 11, "write": 0},
+                            },
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    args = argparse.Namespace(
+        harness="fixture-harness",
+        input=src,
+        output=dst,
+        model="test-model",
+        base_url="https://api.example.test",
+        api_key="",
+    )
+
+    emitter.emit_once(args)
+
+    rows = [json.loads(line) for line in dst.read_text().splitlines()]
+    assert [row["source_harness"] for row in rows] == ["fixture-harness"] * 4
+    assert [row["total_tokens"] for row in rows] == [13, 30, 35, 120]
+    assert rows[-1]["cache_read_tokens"] == 11
+    assert rows[-1]["reasoning_tokens"] == 2
+    assert all(row["type"] == "usage" for row in rows)


### PR DESCRIPTION
- Makes token cost calculation available to all harnesses.
- Adds `usage-emitter.py` to each harness image layer to generate `usage.jsonl` files in a standard format and displayed on the host.
