### PR TITLE
docs(models): ship default judge in models.example.yaml (fixes #240)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,15 @@ cp models/models.example.yaml models/models.yaml
 $EDITOR models/models.yaml
 ```
 
+For task correctness judgement, an api key for the `deepseek-v4-pro` model is required for consistent behavior. Please fill in the new the API setups in the `models.yaml` before making any judgements.
+
+```
+deepseek-v4-pro:
+  api_key: "sk-..."
+  base_url: <api_base_url>
+  api_type: openai-completions
+```
+
 PurelyMail credentials for disposable run emails are provided in the committed `.env`.
 You only need to edit `.env` if you want to use your own PurelyMail account or enable optional HuggingFace upload.
 

--- a/models/models.example.yaml
+++ b/models/models.example.yaml
@@ -14,7 +14,7 @@ qwen3.5-397b-a17b:
 # openai-completions / openai-responses / anthropic-messages api_type.
 deepseek-v4-pro:
   api_key: "sk-..."
-  base_url: https://api.deepseek.com
+  base_url: <api_base_url>
   api_type: openai-completions
 
 # For multiple API keys (round-robin), use api_keys instead of api_key:

--- a/models/models.example.yaml
+++ b/models/models.example.yaml
@@ -7,6 +7,16 @@ qwen3.5-397b-a17b:
   api_type: openai-completions
   thinking_level: medium             # optional
 
+# LLM JUDGE (Stage-2 scoring). clawbench-run/clawbench-batch default to
+# `--judge deepseek-v4-pro`, so it must exist here or the scoring stage fails
+# with "model not found". Fill in a key below, point --judge at another entry,
+# or pass --no-judge to skip Stage-2 (interception-only). The judge must be an
+# openai-completions / openai-responses / anthropic-messages api_type.
+deepseek-v4-pro:
+  api_key: "sk-..."
+  base_url: https://api.deepseek.com
+  api_type: openai-completions
+
 # For multiple API keys (round-robin), use api_keys instead of api_key:
 # some-model:
 #   api_keys:


### PR DESCRIPTION
## Ship the default judge in `models.example.yaml` (fixes #240)

`clawbench-run` / `clawbench-batch` default to `--judge deepseek-v4-pro` (`run.py:142`), but `models/models.example.yaml` never contained it. A fresh clone that copies the example, fills in one agent key, and runs with defaults fails at the **scoring stage** with `ERROR: model 'deepseek-v4-pro' not found`.

**Fix:** add a commented `deepseek-v4-pro` entry to the example (with `base_url`/`api_type`), plus a note that you can point `--judge` at another entry or pass `--no-judge` for interception-only scoring. No code change; unblocks the out-of-box path.

Closes #240.
