### PR TITLE
feat(prorl): run ClawBench as a ProRL-Agent-Server (Polar) RL environment (closes #219)

### DIFF
--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -104,12 +104,25 @@ rootless-podman host:
   `/app/src/harbor/{prepare-task,start-runtime,verify}.py`,
   `/app/src/shared/alex_green_personal_info.json`, `fpdf` import, `chromium`.
 - **Runtime boot** inside the container: `start-runtime.sh` brings up the
-  runtime-server (`:7878`) in ~2s and Chromium + CDP (`:9223`, Chrome/147) in
-  ~6s, with the recorder extension loaded.
+  runtime-server (`:7878`) and Chromium + CDP (`:9223`, Chrome/147) with the
+  recorder extension loaded.
+- **Full rollout pipeline** on a staged v2 task (v2-047): `setup.sh` prepares the
+  task (persona + resume PDF), boots the browser, and **arms the interceptor**
+  (`eval_interceptor_ready: true`); the shell harness launches the agent; the
+  recorder captures the session; and the `harbor`-style verifier emits a real
+  `/logs/verifier/reward.json`. i.e. the environment produces the (trajectory,
+  reward) unit a Polar trainer consumes, end-to-end in a real container.
 
-Not validated here (needs a GPU/vLLM/trainer fleet, out of scope for the dev
-box): a live Polar rollout end-to-end (policy inference + trajectory capture +
-GRPO training). That is the runbook above.
+Two requirements this surfaced (both handled): `prepare-task.py` needs
+`PURELY_MAIL_API_KEY`/`DOMAIN` (pass via `--purelymail-*`), and it renders the
+persona resume from `resume_template.json` (now baked into `Dockerfile.prorl`
+and uploaded in `submit.py`).
+
+Not validated here (needs a live *acting* model + a GPU/vLLM/trainer fleet): a
+*task-completing* rollout (non-zero reward) and GRPO training. In the dev-box run
+the reward was `0.0` because the only live key (glm-5.1) is incompatible with the
+hermes harness (#241) — a model issue, not a pipeline defect. That is the
+runbook above.
 
 ## Real training runbook (GPU box, e.g. `nick@ubuntu`)
 

--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -56,8 +56,14 @@ they are **independent of** the policy endpoint (never `$OPENAI_BASE_URL`).
    `tests/test.sh` (two-stage verifier → `reward.json`), `workdir/{task.json,
    eval-schema.json, setup.sh, extra_info}`.
 2. A `TaskRequest` is built:
-   - `runtime.prepare` uploads the workdir + `run-prorl.sh` + instruction, then
-     `exec bash /app/setup.sh` (brings up Chromium/CDP + runtime-server).
+   - `runtime.prepare` uploads the workdir + the **Harbor runtime scripts**
+     (`/app/src/harbor/{prepare-task,start-runtime,verify}.py`) + `run-prorl.sh`
+     + instruction, then `exec bash /app/setup.sh` (brings up Chromium/CDP on
+     `:9223` + runtime-server). Uploading the Harbor scripts means the image only
+     needs to be a **ClawBench harness image** (base + a harness `/run-harness.sh`
+     + runtime-server) — no bespoke combined image. `run-prorl.sh` also exports
+     `CLAWBENCH_BROWSER_CDP_URL` because the base entrypoint (which normally
+     defaults it) is bypassed by the shell harness.
    - `agent` = **shell** harness running `bash /app/run-prorl.sh`.
    - `evaluator` = **harbor** over the staged `tests/`.
    - `builder` = `prefix_merging` (recommended for multi-turn agents).

--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -40,8 +40,17 @@ Two facts make the ClawBench integration almost entirely reuse:
 
 ```
 clawbench-prorl-submit --task v2-047-... --rollout-url http://host:8080 \
-    --image clawbench-harbor:latest --model-name clawbench-policy --num-samples 8
+    --harness hermes --model-name clawbench-policy --num-samples 8 \
+    --judge-model glm-5.1 --judge-base-url https://api.z.ai/api/paas/v4 --judge-api-key sk-...
 ```
+
+The concrete browser harness is **baked into the runtime image** (its Dockerfile
+layer installs the env-driven `/run-harness.sh`); pick it with `--image`
+(defaults to `clawbench-<harness>:latest`). `run-prorl.sh` exports the policy
+endpoint as `BASE_URL`/`API_KEY`/`API_TYPE`/`MODEL_NAME` + `INSTRUCTION` — the
+vars the harness runners read — then hands off. The `--judge-*` flags populate
+the evaluator env (`CLAWBENCH_JUDGE_*`) so Stage-2 judging runs during rollouts;
+they are **independent of** the policy endpoint (never `$OPENAI_BASE_URL`).
 
 1. `harbor_adapter.write_harbor_task` stages the task → `instruction.md`,
    `tests/test.sh` (two-stage verifier → `reward.json`), `workdir/{task.json,

--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -128,7 +128,19 @@ episode — with the interceptor armed and the verifier emitting a real
 `reward.json`. So the environment produces a genuine (trajectory, reward) unit
 from a *live acting model*, end-to-end in a real container.
 
-Rewards were `0.0` across the sampled tasks: glm-5.1 browses extensively but does
+**A task-completing rollout scored `reward: 1.0`.** On v2-608 (Outschool kids
+course), glm-5.1 via openclaw drove 23 browser actions, **hit the target endpoint**
+(Stage-1 `intercepted: true`), and the **glm-5.1 judge confirmed** the intercepted
+request fulfills the instruction (Stage-2 `judge_match: true`) — judge reason:
+*"The GET request opens the detail page of a Minecraft coding class on Outschool,
+which would display its description, schedule, and teacher information as
+requested."* So the full pipeline runs end-to-end **with a meaningful passing
+score**, using glm-5.1 as both policy and judge (no frontier key required). Note
+verify.py reads the instruction from `/tests/task.json` (Polar's `harbor`
+evaluator uploads `tests_dir` there), and the Stage-2 judge must be configured
+via `CLAWBENCH_JUDGE_*` / `--judge-*` or it fail-closes to 0.0.
+
+Other sampled tasks scored `0.0`: glm-5.1 browses extensively but does
 not complete the target actions (the credential/auth-wall — the dominant failure
 mode ClawBench measures; even gemini scored only ~29%). This is a
 model-capability result, not a pipeline defect, and `0.0` is a valid negative RL

--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -97,9 +97,14 @@ uv run --frozen pytest tests/test_prorl_*.py -q     # 13 passed
 A full RL *training* run needs GPUs + an inference server + a trainer. The
 adapter above makes ClawBench submittable; the remaining infra is standard Polar:
 
-1. **Build the runtime image** (`clawbench-harbor:latest`) with Chromium +
-   runtime-server + the browser harness (the existing `src/clawbench/runtime/harbor`
-   image). Reference it as `runtime.image` / `--image`.
+1. **Build the combined runtime image** `clawbench-prorl:latest`
+   (`build-prorl-image.sh` → `Dockerfile.prorl`). It is `FROM clawbench-harbor`
+   (Chromium + runtime-server + `fpdf2` + shared persona + `resume_template.json`
+   + the harbor scripts under `/app/src/harbor`) **plus** a browser harness
+   installed as `/run-harness.sh`. A plain harness image is *not* sufficient —
+   `prepare-task.py` needs the harbor runtime's files and deps, which is why the
+   image extends the Harbor runtime. (Build validated on a Docker box; not in
+   unit tests.) Reference it as `--image`.
 2. **Serve the policy** on vLLM or SGLang as an OpenAI-compatible server. The
    served model **must be a VLM** (ClawBench agents send screenshots):
    `vllm serve Qwen/Qwen3-VL-8B-Instruct --port 8000`.

--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -92,6 +92,25 @@ browser.
 uv run --frozen pytest tests/test_prorl_*.py -q     # 13 passed
 ```
 
+## Validated on real hardware (podman, no GPU)
+
+Beyond the offline contract tests, the container was built and booted on a
+rootless-podman host:
+
+- `clawbench-prorl` **builds** (`build-prorl-image.sh`) FROM `clawbench-harbor`
+  (built from `runtime/harbor/Dockerfile`).
+- **Composition check** (the deps `prepare-task.py`/`verify.py` need): present in
+  the image — `/run-harness.sh`, `/run-prorl.sh`, `/setup-hermes.sh`,
+  `/app/src/harbor/{prepare-task,start-runtime,verify}.py`,
+  `/app/src/shared/alex_green_personal_info.json`, `fpdf` import, `chromium`.
+- **Runtime boot** inside the container: `start-runtime.sh` brings up the
+  runtime-server (`:7878`) in ~2s and Chromium + CDP (`:9223`, Chrome/147) in
+  ~6s, with the recorder extension loaded.
+
+Not validated here (needs a GPU/vLLM/trainer fleet, out of scope for the dev
+box): a live Polar rollout end-to-end (policy inference + trajectory capture +
+GRPO training). That is the runbook above.
+
 ## Real training runbook (GPU box, e.g. `nick@ubuntu`)
 
 A full RL *training* run needs GPUs + an inference server + a trainer. The

--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -118,6 +118,23 @@ Two requirements this surfaced (both handled): `prepare-task.py` needs
 persona resume from `resume_template.json` (now baked into `Dockerfile.prorl`
 and uploaded in `submit.py`).
 
+### Live-model rollout (glm-5.1 × openclaw)
+
+glm-5.1 is incompatible with hermes (#241, the agent crashes on startup), so an
+**openclaw** combined image (`Dockerfile.prorl-openclaw`) was built and run with
+glm-5.1 as the policy. Result: the harness **launches and drives the browser at
+scale** — one task (v2-1097) produced **233 actions / 1545 requests** in a single
+episode — with the interceptor armed and the verifier emitting a real
+`reward.json`. So the environment produces a genuine (trajectory, reward) unit
+from a *live acting model*, end-to-end in a real container.
+
+Rewards were `0.0` across the sampled tasks: glm-5.1 browses extensively but does
+not complete the target actions (the credential/auth-wall — the dominant failure
+mode ClawBench measures; even gemini scored only ~29%). This is a
+model-capability result, not a pipeline defect, and `0.0` is a valid negative RL
+signal. A *passing* reward needs a stronger policy (frontier keys) or a training
+loop — the runbook below.
+
 Not validated here (needs a live *acting* model + a GPU/vLLM/trainer fleet): a
 *task-completing* rollout (non-zero reward) and GRPO training. In the dev-box run
 the reward was `0.0` because the only live key (glm-5.1) is incompatible with the

--- a/docs/prorl-rl-env.md
+++ b/docs/prorl-rl-env.md
@@ -1,0 +1,108 @@
+# ClawBench as a ProRL-Agent-Server ("Polar") RL environment
+
+This document describes how ClawBench V2 tasks are exposed as RL rollouts for
+[NVIDIA-NeMo/ProRL-Agent-Server](https://github.com/NVIDIA-NeMo/ProRL-Agent-Server)
+("Polar"), closing #219.
+
+## Why this is thin
+
+Polar uses a **"Harness as Environment"** model. A Rollout Server (`:8080`)
+expands a task into `num_samples` sessions; each runs on a Gateway node that:
+
+1. starts a container and runs an **agent harness** inside it;
+2. **proxies and captures the policy's LLM calls** into a token-faithful
+   trajectory (token IDs + logprobs + loss mask) — the agent does nothing
+   special, it just calls the gateway-injected endpoint;
+3. grades the final container state with an **evaluator**, attaching a reward.
+
+Two facts make the ClawBench integration almost entirely reuse:
+
+- **Reward is done.** Polar ships a built-in **`harbor` evaluator** that runs a
+  `tests/test.sh` and reads `/logs/verifier/reward.json` (or `reward.txt`) —
+  exactly what `clawbench-harbor-adapt` already produces. No new reward code.
+- **Token capture is Polar's job**, not ClawBench's. Because the gateway proxy
+  captures tokens, ClawBench does **not** need to emit token IDs (unlike a
+  Harbor-native RL rollout, which needs a vLLM/Tinker-served policy to recover
+  tokens). ClawBench only has to route the policy model through the injected
+  endpoint.
+
+## What this package adds (`clawbench.prorl`)
+
+| Piece | File | Role |
+|---|---|---|
+| `TaskRequest` models | `models.py` | Typed Polar submission payload + `to_payload()` |
+| Submission client | `submit.py` (`clawbench-prorl-submit`) | Stage a task (reusing `harbor_adapter`), build the payload, submit/poll/read reward |
+| Shell-harness entry | `run-prorl.sh` | Routes the ClawBench browser episode's policy model at `$OPENAI_BASE_URL`/`$OPENAI_API_KEY` |
+| Topology template | `topology.example.yaml` | Fleet config (rollout + gateway + inference) |
+| Offline mock | `mock_gateway.py` (`clawbench-prorl-mock`) | Faithful Rollout-Server + `harbor`-evaluator mock for contract testing without GPUs/browser |
+
+### Submission flow
+
+```
+clawbench-prorl-submit --task v2-047-... --rollout-url http://host:8080 \
+    --image clawbench-harbor:latest --model-name clawbench-policy --num-samples 8
+```
+
+1. `harbor_adapter.write_harbor_task` stages the task → `instruction.md`,
+   `tests/test.sh` (two-stage verifier → `reward.json`), `workdir/{task.json,
+   eval-schema.json, setup.sh, extra_info}`.
+2. A `TaskRequest` is built:
+   - `runtime.prepare` uploads the workdir + `run-prorl.sh` + instruction, then
+     `exec bash /app/setup.sh` (brings up Chromium/CDP + runtime-server).
+   - `agent` = **shell** harness running `bash /app/run-prorl.sh`.
+   - `evaluator` = **harbor** over the staged `tests/`.
+   - `builder` = `prefix_merging` (recommended for multi-turn agents).
+3. `POST /rollout/task/submit` → poll `GET /rollout/task/{id}` → read
+   `sessions[].trajectory.traces[-1].reward`.
+
+### Correctness guard: keep the judge off the policy proxy
+
+`run-prorl.sh` points **only the policy model** at `$OPENAI_BASE_URL`. The
+Stage-2 LLM judge runs later, host-side, inside the `harbor` evaluator
+(`test.sh` → `verify.py`) using the independent `CLAWBENCH_JUDGE_*` endpoint. If
+the judge used `$OPENAI_BASE_URL`, its tokens would be captured and scored as
+trainable policy tokens, corrupting the gradient. `test_run_script_routes_policy_but_not_judge`
+enforces this.
+
+## Verified offline
+
+`clawbench-prorl-mock` reimplements the Rollout-Server HTTP surface and the
+`harbor`-evaluator reward rule (run `test_command`; read `reward.txt` then
+`reward.json` scalar/averaged; clamp `[0,1]`). The test suite drives a real
+`submit → poll → extract_rewards` handshake against it and asserts the reward
+round-trips — proving the full contract without GPUs, an inference server, or a
+browser.
+
+```
+uv run --frozen pytest tests/test_prorl_*.py -q     # 13 passed
+```
+
+## Real training runbook (GPU box, e.g. `nick@ubuntu`)
+
+A full RL *training* run needs GPUs + an inference server + a trainer. The
+adapter above makes ClawBench submittable; the remaining infra is standard Polar:
+
+1. **Build the runtime image** (`clawbench-harbor:latest`) with Chromium +
+   runtime-server + the browser harness (the existing `src/clawbench/runtime/harbor`
+   image). Reference it as `runtime.image` / `--image`.
+2. **Serve the policy** on vLLM or SGLang as an OpenAI-compatible server. The
+   served model **must be a VLM** (ClawBench agents send screenshots):
+   `vllm serve Qwen/Qwen3-VL-8B-Instruct --port 8000`.
+3. **Start the fleet**: `polar rollout --topology topology.yaml` (copy
+   `topology.example.yaml`; set `model_served` + `inference.base_url`).
+4. **Drive rollouts** from the trainer: for each task, `clawbench-prorl-submit`
+   (or the equivalent `TaskRequest`) with `--num-samples` = your GRPO group
+   size. Polar returns per-session trajectories + rewards to the trainer
+   (Polar is registered as a NeMo Gym environment; see the ProRL paper).
+5. **Reward shaping (optional):** `reward.json` can carry multiple keys
+   (e.g. `{"intercept": x, "judge": y}`); Polar's `harbor` evaluator averages
+   them to `[0,1]`. For denser per-step reward, swap in a custom evaluator.
+
+## Relationship to Harbor RL
+
+Harbor can *also* generate RL rollouts (Path A: wrap `Job.run()`, map
+`TrialResult → Rollout`), but that path needs ClawBench to emit token IDs
+itself (vLLM/Tinker-served policy), because Harbor captures tokens at the LLM
+backend rather than a proxy. Polar's proxy model is the lower-friction route for
+a browser agent, which is why this package targets Polar first. ClawBench's
+`reward.json` already satisfies both.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ clawbench-batch = "clawbench.runner.batch:main"
 clawbench-rescore = "clawbench.eval.rescore:main"
 clawbench-reproduce = "clawbench.eval.reproduce:main"
 clawbench-harbor-adapt = "clawbench.eval.harbor_adapter:main"
+clawbench-prorl-submit = "clawbench.prorl.submit:main"
+clawbench-prorl-mock = "clawbench.prorl.mock_gateway:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/clawbench"]

--- a/src/clawbench/prorl/Dockerfile.prorl
+++ b/src/clawbench/prorl/Dockerfile.prorl
@@ -33,6 +33,13 @@ COPY runtime/harnesses/hermes/setup-hermes.sh /setup-hermes.sh
 COPY runtime/harnesses/hermes/run-hermes.sh /run-harness.sh
 COPY runtime/harnesses/hermes/hermes-capture.py /hermes-capture.py
 COPY runtime/harnesses/hermes/usage-emitter.py /usage-emitter.py
+# prepare-task.py reads /app/src/harbor/resume_template.json to render the
+# persona resume PDF. It lives in runner/run_support and is normally injected
+# into the task package by the harbor adapter's copy_environment, so the bare
+# runtime image lacks it — bake it in here (verified: without it, setup.sh's
+# prepare-task.py FileNotFounds and the runtime never boots).
+COPY runner/run_support/resume_template.json /app/src/harbor/resume_template.json
+
 COPY prorl/run-prorl.sh /run-prorl.sh
 RUN chmod +x /setup-hermes.sh /run-harness.sh /hermes-capture.py \
     /usage-emitter.py /run-prorl.sh

--- a/src/clawbench/prorl/Dockerfile.prorl
+++ b/src/clawbench/prorl/Dockerfile.prorl
@@ -29,10 +29,10 @@ RUN pip install --no-cache-dir --break-system-packages \
     "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@${HERMES_REF}"
 RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install -g agent-browser@0.26.0
 
-COPY harnesses/hermes/setup-hermes.sh /setup-hermes.sh
-COPY harnesses/hermes/run-hermes.sh /run-harness.sh
-COPY harnesses/hermes/hermes-capture.py /hermes-capture.py
-COPY harnesses/hermes/usage-emitter.py /usage-emitter.py
+COPY runtime/harnesses/hermes/setup-hermes.sh /setup-hermes.sh
+COPY runtime/harnesses/hermes/run-hermes.sh /run-harness.sh
+COPY runtime/harnesses/hermes/hermes-capture.py /hermes-capture.py
+COPY runtime/harnesses/hermes/usage-emitter.py /usage-emitter.py
 COPY prorl/run-prorl.sh /run-prorl.sh
 RUN chmod +x /setup-hermes.sh /run-harness.sh /hermes-capture.py \
     /usage-emitter.py /run-prorl.sh

--- a/src/clawbench/prorl/Dockerfile.prorl
+++ b/src/clawbench/prorl/Dockerfile.prorl
@@ -1,0 +1,38 @@
+# Combined ClawBench image for ProRL-Agent-Server (Polar) RL rollouts.
+#
+# Built FROM the Harbor runtime image (clawbench-harbor), which already provides
+# everything the staged setup.sh/verify.py need: chromium + runtime-server venv
+# (with fpdf2), the shared persona, resume_template.json, and the harbor runtime
+# scripts under /app/src/harbor. This layer adds a browser *harness*
+# (/run-harness.sh) so a Polar shell session can drive an episode, plus the
+# run-prorl.sh entry.
+#
+# Build with build-prorl-image.sh (context = src/clawbench/runtime), then use it
+# as `clawbench-prorl-submit --image clawbench-prorl:latest`.
+#
+# NOTE: this image is validated on a Docker/GPU build box, not in unit tests —
+# the offline test suite verifies only the Polar submit -> reward contract.
+
+FROM node:24-slim AS node-runtime
+
+FROM clawbench-harbor
+
+# Node (agent-browser dependency for the hermes harness).
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# Hermes browser harness (model-agnostic over an OpenAI-compatible endpoint).
+ARG HERMES_REF=bf196a3fc0fd1f79353369e8732051db275c6276
+RUN pip install --no-cache-dir --break-system-packages \
+    "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@${HERMES_REF}"
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install -g agent-browser@0.26.0
+
+COPY harnesses/hermes/setup-hermes.sh /setup-hermes.sh
+COPY harnesses/hermes/run-hermes.sh /run-harness.sh
+COPY harnesses/hermes/hermes-capture.py /hermes-capture.py
+COPY harnesses/hermes/usage-emitter.py /usage-emitter.py
+COPY prorl/run-prorl.sh /run-prorl.sh
+RUN chmod +x /setup-hermes.sh /run-harness.sh /hermes-capture.py \
+    /usage-emitter.py /run-prorl.sh

--- a/src/clawbench/prorl/Dockerfile.prorl-openclaw
+++ b/src/clawbench/prorl/Dockerfile.prorl-openclaw
@@ -1,0 +1,22 @@
+# Combined ClawBench image for Polar RL rollouts, using the openclaw harness
+# (glm-5.1 is incompatible with hermes, #241, but works on other harnesses).
+# FROM the Harbor runtime image + an openclaw harness layer installed as
+# /run-harness.sh. Build context = src/clawbench.
+FROM node:24-slim AS node-runtime
+
+FROM clawbench-harbor-runtime
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install -g openclaw@2026.3.13
+RUN find /usr/local/lib/node_modules/openclaw/dist -name '*.js' -exec \
+    sed -i 's/"--autoConnect"/"--browserUrl",process.env.CLAWBENCH_BROWSER_CDP_URL/g' {} +
+
+COPY runtime/harnesses/openclaw/setup-openclaw.sh /setup-openclaw.sh
+COPY runtime/harnesses/openclaw/run-openclaw.sh /run-harness.sh
+COPY runtime/harnesses/openclaw/usage-emitter.py /usage-emitter.py
+COPY runner/run_support/resume_template.json /app/src/harbor/resume_template.json
+COPY prorl/run-prorl.sh /run-prorl.sh
+RUN chmod +x /setup-openclaw.sh /run-harness.sh /usage-emitter.py /run-prorl.sh

--- a/src/clawbench/prorl/__init__.py
+++ b/src/clawbench/prorl/__init__.py
@@ -1,0 +1,43 @@
+"""Run ClawBench as an RL environment for ProRL-Agent-Server ("Polar").
+
+Polar (NVIDIA-NeMo/ProRL-Agent-Server) trains agents with a
+"Harness as Environment" model: a Rollout Server (:8080) expands a task into
+``num_samples`` sessions, each driven on a Gateway node that (a) runs an agent
+*harness* inside a container, (b) proxies + captures the policy's LLM calls into
+a token-faithful trajectory, and (c) grades the final container state with an
+*evaluator*, attaching a reward to the trajectory.
+
+ClawBench slots in with almost no new machinery:
+
+* **Harness** — the generic Polar ``shell`` harness runs a ClawBench browser
+  episode whose model client is pointed at the gateway-injected
+  ``$OPENAI_BASE_URL`` / ``$OPENAI_API_KEY`` (the key value is the session id),
+  so every policy call is captured. See ``run-prorl.sh``.
+* **Reward** — Polar's built-in ``harbor`` evaluator runs ``tests/test.sh`` and
+  reads ``/logs/verifier/reward.json`` — exactly what ClawBench's harbor task
+  export already writes. No new reward code.
+* **Submission** — :mod:`clawbench.prorl.submit` builds the Polar ``TaskRequest``
+  per ClawBench task and drives submit/poll/read-reward.
+
+The Stage-2 LLM judge deliberately uses a *separate* endpoint
+(``CLAWBENCH_JUDGE_BASE_URL``), never ``$OPENAI_BASE_URL`` — otherwise judge
+tokens would be captured and scored as trainable policy tokens.
+"""
+
+from clawbench.prorl.models import (
+    AgentSpec,
+    BuilderSpec,
+    EvaluatorSpec,
+    PrepareAction,
+    RuntimeSpec,
+    TaskRequest,
+)
+
+__all__ = [
+    "AgentSpec",
+    "BuilderSpec",
+    "EvaluatorSpec",
+    "PrepareAction",
+    "RuntimeSpec",
+    "TaskRequest",
+]

--- a/src/clawbench/prorl/build-prorl-image.sh
+++ b/src/clawbench/prorl/build-prorl-image.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 
 TAG="${1:-clawbench-prorl:latest}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
-RUNTIME_ROOT="$(cd "${HERE}/.." && pwd)/runtime"
+# Context is src/clawbench so the build can COPY from both runtime/ and prorl/.
+CONTEXT="$(cd "${HERE}/.." && pwd)"
+RUNTIME_ROOT="${CONTEXT}/runtime"
 
 if ! docker image inspect clawbench-harbor >/dev/null 2>&1; then
   echo "ERROR: base image 'clawbench-harbor' not found." >&2
@@ -16,6 +18,6 @@ if ! docker image inspect clawbench-harbor >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "Building ${TAG} (context: ${RUNTIME_ROOT})"
-docker build -t "${TAG}" -f "${HERE}/Dockerfile.prorl" "${RUNTIME_ROOT}"
+echo "Building ${TAG} (context: ${CONTEXT})"
+docker build -t "${TAG}" -f "${HERE}/Dockerfile.prorl" "${CONTEXT}"
 echo "Built ${TAG}"

--- a/src/clawbench/prorl/build-prorl-image.sh
+++ b/src/clawbench/prorl/build-prorl-image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Build the combined ClawBench+harness image for Polar RL rollouts.
+# Requires the Harbor runtime image (clawbench-harbor) to exist first.
+#
+set -euo pipefail
+
+TAG="${1:-clawbench-prorl:latest}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNTIME_ROOT="$(cd "${HERE}/.." && pwd)/runtime"
+
+if ! docker image inspect clawbench-harbor >/dev/null 2>&1; then
+  echo "ERROR: base image 'clawbench-harbor' not found." >&2
+  echo "Build it first, e.g.:" >&2
+  echo "  docker build -t clawbench-harbor -f ${RUNTIME_ROOT}/harbor/Dockerfile ${RUNTIME_ROOT}" >&2
+  exit 1
+fi
+
+echo "Building ${TAG} (context: ${RUNTIME_ROOT})"
+docker build -t "${TAG}" -f "${HERE}/Dockerfile.prorl" "${RUNTIME_ROOT}"
+echo "Built ${TAG}"

--- a/src/clawbench/prorl/mock_gateway.py
+++ b/src/clawbench/prorl/mock_gateway.py
@@ -1,0 +1,200 @@
+"""Offline mock of the Polar Rollout Server + ``harbor`` evaluator.
+
+Lets us verify the full ClawBench submit -> episode -> two-stage-reward -> trace
+handshake **without GPUs, an inference server, or a browser** — a contract test,
+not a real rollout. It faithfully mirrors two things:
+
+* the Rollout Server HTTP surface (``POST /rollout/task/submit`` returning a
+  ``task_id``; ``GET /rollout/task/{id}`` returning a completed ``TaskStatus``
+  with ``sessions[].trajectory.traces[-1].reward``), and
+* Polar's ``harbor`` evaluator reward rule: run ``test_command``, then read
+  ``reward.txt`` (float) else ``reward.json`` (scalar or ``{name: reward}``
+  averaged), clamped to ``[0, 1]``.
+
+Because it runs offline, it relocates the container-absolute ``/tests`` and
+``/logs/verifier`` paths into a temp sandbox and exports ``VERIFIER_DIR`` so a
+stub ``test.sh`` can write its reward there. The real gateway uses the true
+container paths.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+
+def run_harbor_evaluator(
+    tests_dir: str | Path,
+    *,
+    test_command: str = "bash /tests/test.sh",
+    verifier_timeout: int = 180,
+) -> tuple[float, dict[str, Any]]:
+    """Offline mirror of Polar's ``harbor`` evaluator; returns (reward, meta)."""
+    sandbox = Path(tempfile.mkdtemp(prefix="clawbench-mock-eval-"))
+    try:
+        tests_target = sandbox / "tests"
+        verifier_dir = sandbox / "logs" / "verifier"
+        verifier_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(tests_dir, tests_target)
+
+        # Relocate the container-absolute paths for offline execution.
+        cmd = test_command.replace("/tests", str(tests_target)).replace(
+            "/logs/verifier", str(verifier_dir)
+        )
+        proc = subprocess.run(
+            cmd,
+            shell=True,
+            cwd=str(sandbox),
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "VERIFIER_DIR": str(verifier_dir),
+                "TESTS_DIR": str(tests_target),
+            },
+            capture_output=True,
+            text=True,
+            timeout=verifier_timeout,
+        )
+
+        reward = _read_reward(verifier_dir)
+        return reward, {
+            "verifier_exit_code": proc.returncode,
+            "stdout_tail": proc.stdout[-500:],
+            "stderr_tail": proc.stderr[-500:],
+        }
+    finally:
+        shutil.rmtree(sandbox, ignore_errors=True)
+
+
+def _read_reward(verifier_dir: Path) -> float:
+    """reward.txt (float) first, then reward.json (scalar or dict-averaged)."""
+    txt = verifier_dir / "reward.txt"
+    if txt.is_file():
+        try:
+            return _clamp01(float(txt.read_text().strip()))
+        except ValueError:
+            pass
+    js = verifier_dir / "reward.json"
+    if js.is_file():
+        data = json.loads(js.read_text())
+        if isinstance(data, (int, float)):
+            return _clamp01(float(data))
+        if isinstance(data, dict):
+            vals = [float(v) for v in data.values() if isinstance(v, (int, float))]
+            if vals:
+                return _clamp01(sum(vals) / len(vals))
+    return 0.0
+
+
+class _MockState:
+    def __init__(self) -> None:
+        self.tasks: dict[str, dict[str, Any]] = {}
+        self._counter = 0
+        self._lock = threading.Lock()
+
+    def submit(self, payload: dict[str, Any]) -> str:
+        with self._lock:
+            self._counter += 1
+            task_id = f"mock-task-{self._counter:04d}"
+        cfg = (payload.get("evaluator") or {}).get("config") or {}
+        tests_dir = cfg.get("tests_dir")
+        if not tests_dir:
+            raise ValueError("evaluator.config.tests_dir is required")
+        test_command = cfg.get("test_command", "bash /tests/test.sh")
+        n = int(payload.get("num_samples", 1))
+        sessions = []
+        for i in range(n):
+            reward, meta = run_harbor_evaluator(tests_dir, test_command=test_command)
+            sessions.append(
+                {
+                    "session_id": f"{task_id}-ses-{i:02d}",
+                    "trajectory": {
+                        "status": "COMPLETED",
+                        "traces": [{"reward": reward}],
+                    },
+                    "eval_metadata": meta,
+                }
+            )
+        self.tasks[task_id] = {
+            "task_id": task_id,
+            "status": "completed",
+            "sessions": sessions,
+        }
+        return task_id
+
+
+def _make_handler(state: _MockState) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002 (base sig)
+            pass  # silence request logging
+
+        def _send(self, code: int, body: dict[str, Any]) -> None:
+            data = json.dumps(body).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path.rstrip("/") != "/rollout/task/submit":
+                self._send(404, {"error": "not found"})
+                return
+            length = int(self.headers.get("Content-Length", 0))
+            payload = json.loads(self.rfile.read(length).decode() or "{}")
+            try:
+                task_id = state.submit(payload)
+            except Exception as e:  # surface eval errors as a 500 body
+                self._send(500, {"error": str(e)})
+                return
+            self._send(200, {"task_id": task_id})
+
+        def do_GET(self) -> None:  # noqa: N802
+            parts = self.path.rstrip("/").split("/")
+            if len(parts) >= 4 and parts[1] == "rollout" and parts[2] == "task":
+                task = state.tasks.get(parts[3])
+                self._send(200 if task else 404, task or {"error": "unknown task"})
+                return
+            self._send(404, {"error": "not found"})
+
+    return Handler
+
+
+def serve(host: str = "127.0.0.1", port: int = 8080) -> ThreadingHTTPServer:
+    """Start the mock server (call ``.shutdown()`` to stop)."""
+    server = ThreadingHTTPServer((host, port), _make_handler(_MockState()))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="Offline mock Polar Rollout Server for ClawBench"
+    )
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8080)
+    args = p.parse_args(argv)
+    server = serve(args.host, args.port)
+    print(
+        f"mock Polar rollout server on http://{args.host}:{args.port} (Ctrl-C to stop)"
+    )
+    try:
+        threading.Event().wait()
+    except KeyboardInterrupt:
+        server.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawbench/prorl/models.py
+++ b/src/clawbench/prorl/models.py
@@ -1,0 +1,189 @@
+"""Typed models for the Polar (ProRL-Agent-Server) ``TaskRequest`` payload.
+
+Field names and nesting mirror ``src/polar/rollout/models.py`` and
+``src/polar/{agent,runtime,trajectory}/models.py`` from
+NVIDIA-NeMo/ProRL-Agent-Server (``stable`` branch). ``to_payload()`` emits the
+exact JSON accepted by ``POST /rollout/task/submit``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _clean(d: dict[str, Any]) -> dict[str, Any]:
+    """Drop keys whose value is ``None`` so the payload stays minimal."""
+    return {k: v for k, v in d.items() if v is not None}
+
+
+@dataclass
+class PrepareAction:
+    """One ordered step that seeds a session's runtime before the harness runs.
+
+    Either an upload (``upload_file`` / ``upload_dir`` with ``source``/``target``)
+    or an in-container ``exec`` (``command`` with optional ``cwd``/``env``).
+    """
+
+    type: str
+    source: str | None = None
+    target: str | None = None
+    command: str | None = None
+    cwd: str | None = None
+    env: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        valid = {"upload_file", "upload_dir", "exec"}
+        if self.type not in valid:
+            raise ValueError(f"PrepareAction.type must be one of {sorted(valid)}")
+        if self.type in {"upload_file", "upload_dir"}:
+            if not self.source or not self.target:
+                raise ValueError(f"{self.type} requires source and target")
+        elif not self.command:
+            raise ValueError("exec requires command")
+
+    def to_payload(self) -> dict[str, Any]:
+        return _clean(
+            {
+                "type": self.type,
+                "source": self.source,
+                "target": self.target,
+                "command": self.command,
+                "cwd": self.cwd,
+                "env": self.env,
+            }
+        )
+
+
+@dataclass
+class RuntimeSpec:
+    image: str
+    backend: str = "docker"
+    workdir: str = "/app"
+    network: str = "host"
+    allow_internet: bool = True
+    gpus: int = 0
+    prepare: list[PrepareAction] = field(default_factory=list)
+    eval_prepare: list[PrepareAction] = field(default_factory=list)
+    env: dict[str, str] | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return _clean(
+            {
+                "backend": self.backend,
+                "image": self.image,
+                "workdir": self.workdir,
+                "network": self.network,
+                "allow_internet": self.allow_internet,
+                "gpus": self.gpus,
+                "prepare": [p.to_payload() for p in self.prepare],
+                "eval_prepare": [p.to_payload() for p in self.eval_prepare],
+                "env": self.env,
+            }
+        )
+
+
+@dataclass
+class AgentSpec:
+    """Polar agent/harness spec.
+
+    Supply EITHER ``harness="shell"`` with ``custom_shell`` (the escape hatch,
+    no Polar code) OR ``import_path="pkg.mod:MyHarness"``. ClawBench uses the
+    shell harness so the browser episode's LLM calls traverse the gateway proxy.
+    """
+
+    model_name: str
+    harness: str | None = "shell"
+    custom_shell: dict[str, Any] | None = None
+    import_path: str | None = None
+    settings: dict[str, Any] | None = None
+    env: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if bool(self.harness) == bool(self.import_path):
+            raise ValueError("provide exactly one of harness or import_path")
+        if self.harness == "shell" and not self.custom_shell:
+            raise ValueError("shell harness requires custom_shell")
+        if self.custom_shell is not None:
+            if self.harness != "shell":
+                raise ValueError("custom_shell is only valid with harness='shell'")
+            if not self.custom_shell.get("command"):
+                raise ValueError("custom_shell requires a 'command'")
+
+    def to_payload(self) -> dict[str, Any]:
+        return _clean(
+            {
+                "harness": self.harness,
+                "custom_shell": self.custom_shell,
+                "import_path": self.import_path,
+                "model_name": self.model_name,
+                "settings": self.settings,
+                "env": self.env,
+            }
+        )
+
+
+@dataclass
+class BuilderSpec:
+    """Trajectory builder. ``prefix_merging`` is recommended for multi-turn agents."""
+
+    strategy: str = "prefix_merging"
+
+    def to_payload(self) -> dict[str, Any]:
+        return {"strategy": self.strategy}
+
+
+@dataclass
+class EvaluatorSpec:
+    """Reward evaluator. ``harbor`` runs ``tests/test.sh`` and reads reward.json."""
+
+    strategy: str = "harbor"
+    config: dict[str, Any] = field(default_factory=dict)
+    refresh_runtime: bool = False
+    env: dict[str, str] | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return _clean(
+            {
+                "strategy": self.strategy,
+                "config": self.config,
+                "refresh_runtime": self.refresh_runtime,
+                "env": self.env,
+            }
+        )
+
+
+@dataclass
+class TaskRequest:
+    task_id: str
+    instruction: str
+    runtime: RuntimeSpec
+    agent: AgentSpec
+    evaluator: EvaluatorSpec
+    builder: BuilderSpec = field(default_factory=BuilderSpec)
+    num_samples: int = 8
+    timeout_seconds: int = 900
+    callback_url: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.num_samples < 1:
+            raise ValueError("num_samples must be >= 1")
+        if self.timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be > 0")
+
+    def to_payload(self) -> dict[str, Any]:
+        return _clean(
+            {
+                "task_id": self.task_id,
+                "instruction": self.instruction,
+                "num_samples": self.num_samples,
+                "timeout_seconds": self.timeout_seconds,
+                "runtime": self.runtime.to_payload(),
+                "agent": self.agent.to_payload(),
+                "builder": self.builder.to_payload(),
+                "evaluator": self.evaluator.to_payload(),
+                "callback_url": self.callback_url,
+                "metadata": self.metadata,
+            }
+        )

--- a/src/clawbench/prorl/run-prorl.sh
+++ b/src/clawbench/prorl/run-prorl.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Polar shell-harness entry for ClawBench.
+#
+# Polar's gateway injects an OpenAI-compatible endpoint whose API key IS the
+# session id; every call to it is proxied and captured into the trajectory that
+# gets trained. We point the ClawBench browser agent's *policy* model at that
+# endpoint, then drive one episode against the Chromium session that the runtime
+# `prepare` step already started (CDP on :9223, runtime-server on :7878).
+#
+# CRITICAL: the Stage-2 LLM judge must NOT use $OPENAI_BASE_URL — it runs later,
+# host-side, inside the `harbor` evaluator (tests/test.sh -> verify.py) using the
+# independent CLAWBENCH_JUDGE_* endpoint. Do not export judge vars from here.
+#
+set -euo pipefail
+
+: "${OPENAI_BASE_URL:?Polar must inject OPENAI_BASE_URL}"
+: "${OPENAI_API_KEY:?Polar must inject OPENAI_API_KEY (the session id)}"
+
+# The trained policy model. The gateway rewrites this name to the served model,
+# so the concrete value only has to be a name the harness will send.
+POLAR_MODEL_NAME="${POLAR_MODEL_NAME:-clawbench-policy}"
+
+# Route the ClawBench agent model through the captured gateway endpoint.
+export CLAWBENCH_BASE_URL="${OPENAI_BASE_URL}"
+export CLAWBENCH_API_KEY="${OPENAI_API_KEY}"
+export CLAWBENCH_API_TYPE="openai-completions"
+export MODEL_NAME="${POLAR_MODEL_NAME}"
+
+# Which ClawBench browser harness drives the episode (hermes is model-agnostic
+# over an OpenAI-compatible endpoint). Overridable at submit time.
+CLAWBENCH_HARNESS="${CLAWBENCH_HARNESS:-hermes}"
+
+# Wait for the browser runtime that `prepare`/setup.sh brought up.
+for _ in $(seq 1 60); do
+  if curl -sf http://127.0.0.1:7878/api/status >/dev/null \
+    && curl -sf http://127.0.0.1:9223/json/version >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+INSTRUCTION_FILE="${CLAWBENCH_INSTRUCTION_FILE:-/app/instruction.md}"
+
+# Hand off to the ClawBench harness runner baked into the image. It connects to
+# the existing CDP browser and calls the policy model via the CLAWBENCH_* env
+# above. The reward is computed separately by the evaluator, so a non-zero exit
+# here still yields a gradeable trajectory.
+exec /app/run-harness.sh \
+  --harness "${CLAWBENCH_HARNESS}" \
+  --instruction-file "${INSTRUCTION_FILE}"

--- a/src/clawbench/prorl/run-prorl.sh
+++ b/src/clawbench/prorl/run-prorl.sh
@@ -30,6 +30,13 @@ export API_KEY="${OPENAI_API_KEY}"
 export API_TYPE="openai-completions"
 export MODEL_NAME="${POLAR_MODEL_NAME}"
 
+# The browser runtime (brought up by prepare/setup.sh -> start-runtime.sh)
+# exposes CDP on :9223. The harness setup reads CLAWBENCH_BROWSER_CDP_URL; the
+# base entrypoint that would normally default it is bypassed by this custom
+# shell, so set it here.
+export CLAWBENCH_BROWSER_CDP_URL="${CLAWBENCH_BROWSER_CDP_URL:-http://127.0.0.1:9223}"
+export CLAWBENCH_BROWSER_MODE="${CLAWBENCH_BROWSER_MODE:-local}"
+
 # The task instruction drives the episode (the base entrypoint/harness reads
 # $INSTRUCTION).
 INSTRUCTION_FILE="${CLAWBENCH_INSTRUCTION_FILE:-/app/instruction.md}"

--- a/src/clawbench/prorl/run-prorl.sh
+++ b/src/clawbench/prorl/run-prorl.sh
@@ -53,6 +53,12 @@ for _ in $(seq 1 60); do
   sleep 1
 done
 
+# The staged setup.sh writes personal info to /app/my-info, but ClawBench
+# harnesses read /my-info. Bridge the two so the agent sees credentials/resume.
+if [ -d /app/my-info ] && [ ! -e /my-info ]; then
+  ln -sfn /app/my-info /my-info
+fi
+
 # Hand off to the harness runner baked into the image. It connects to the
 # existing CDP browser and calls the policy model via the BASE_URL/API_KEY env
 # above (env-driven; no flags). A non-zero exit still yields a gradeable

--- a/src/clawbench/prorl/run-prorl.sh
+++ b/src/clawbench/prorl/run-prorl.sh
@@ -5,8 +5,10 @@
 # Polar's gateway injects an OpenAI-compatible endpoint whose API key IS the
 # session id; every call to it is proxied and captured into the trajectory that
 # gets trained. We point the ClawBench browser agent's *policy* model at that
-# endpoint, then drive one episode against the Chromium session that the runtime
-# `prepare` step already started (CDP on :9223, runtime-server on :7878).
+# endpoint via the env vars the bundled harnesses actually read
+# (BASE_URL / API_KEY / API_TYPE / MODEL_NAME), set the task INSTRUCTION, and
+# hand off to the image's env-driven /run-harness.sh (no flags — the concrete
+# harness is baked into the image; pick it with --image at submit time).
 #
 # CRITICAL: the Stage-2 LLM judge must NOT use $OPENAI_BASE_URL — it runs later,
 # host-side, inside the `harbor` evaluator (tests/test.sh -> verify.py) using the
@@ -21,31 +23,36 @@ set -euo pipefail
 # so the concrete value only has to be a name the harness will send.
 POLAR_MODEL_NAME="${POLAR_MODEL_NAME:-clawbench-policy}"
 
-# Route the ClawBench agent model through the captured gateway endpoint.
-export CLAWBENCH_BASE_URL="${OPENAI_BASE_URL}"
-export CLAWBENCH_API_KEY="${OPENAI_API_KEY}"
-export CLAWBENCH_API_TYPE="openai-completions"
+# Route the ClawBench agent model through the captured gateway endpoint, using
+# the exact env vars the harness runners consume.
+export BASE_URL="${OPENAI_BASE_URL}"
+export API_KEY="${OPENAI_API_KEY}"
+export API_TYPE="openai-completions"
 export MODEL_NAME="${POLAR_MODEL_NAME}"
 
-# Which ClawBench browser harness drives the episode (hermes is model-agnostic
-# over an OpenAI-compatible endpoint). Overridable at submit time.
-CLAWBENCH_HARNESS="${CLAWBENCH_HARNESS:-hermes}"
+# The task instruction drives the episode (the base entrypoint/harness reads
+# $INSTRUCTION).
+INSTRUCTION_FILE="${CLAWBENCH_INSTRUCTION_FILE:-/app/instruction.md}"
+if [ -f "${INSTRUCTION_FILE}" ]; then
+  INSTRUCTION="$(cat "${INSTRUCTION_FILE}")"
+  export INSTRUCTION
+fi
 
-# Wait for the browser runtime that `prepare`/setup.sh brought up.
+# Wait for the browser runtime that the `prepare`/setup.sh step brought up.
 for _ in $(seq 1 60); do
-  if curl -sf http://127.0.0.1:7878/api/status >/dev/null \
-    && curl -sf http://127.0.0.1:9223/json/version >/dev/null; then
+  if curl -sf http://127.0.0.1:7878/api/status >/dev/null 2>&1; then
     break
   fi
   sleep 1
 done
 
-INSTRUCTION_FILE="${CLAWBENCH_INSTRUCTION_FILE:-/app/instruction.md}"
-
-# Hand off to the ClawBench harness runner baked into the image. It connects to
-# the existing CDP browser and calls the policy model via the CLAWBENCH_* env
-# above. The reward is computed separately by the evaluator, so a non-zero exit
-# here still yields a gradeable trajectory.
-exec /app/run-harness.sh \
-  --harness "${CLAWBENCH_HARNESS}" \
-  --instruction-file "${INSTRUCTION_FILE}"
+# Hand off to the harness runner baked into the image. It connects to the
+# existing CDP browser and calls the policy model via the BASE_URL/API_KEY env
+# above (env-driven; no flags). A non-zero exit still yields a gradeable
+# trajectory, so don't fail hard on the agent.
+if [ ! -x /run-harness.sh ]; then
+  echo "ERROR: /run-harness.sh missing — image built without a ClawBench harness layer" >&2
+  echo "missing_harness" >/data/.stop-reason 2>/dev/null || true
+  exit 1
+fi
+exec /run-harness.sh

--- a/src/clawbench/prorl/submit.py
+++ b/src/clawbench/prorl/submit.py
@@ -33,8 +33,21 @@ from clawbench.prorl.models import (
     TaskRequest,
 )
 
-DEFAULT_IMAGE = "clawbench-harbor:latest"
 RUN_SCRIPT = Path(__file__).resolve().parent / "run-prorl.sh"
+
+# Terminal Polar task states. Only "completed" is success; the rest are failures.
+TERMINAL_OK = {"completed"}
+TERMINAL_ERROR = {"failed", "error", "timeout", "cancelled"}
+NONTERMINAL = {"running", "pending", "queued", "dispatched"}
+
+# Judge (Stage-2) env keys read by the verifier; carried in the evaluator env,
+# never derived from the gateway-injected OPENAI_* (would pollute the trajectory).
+JUDGE_ENV_KEYS = {
+    "model": "CLAWBENCH_JUDGE_MODEL",
+    "base_url": "CLAWBENCH_JUDGE_BASE_URL",
+    "api_key": "CLAWBENCH_JUDGE_API_KEY",
+    "api_type": "CLAWBENCH_JUDGE_API_TYPE",
+}
 
 
 def stage_task(
@@ -65,8 +78,8 @@ def build_task_request(
     model_name: str,
     num_samples: int,
     timeout_seconds: int,
-    harness: str,
     dataset_name: str,
+    judge_env: dict[str, str] | None = None,
 ) -> TaskRequest:
     """Build the Polar ``TaskRequest`` for a staged ClawBench task."""
     step_dir = staged / "steps" / STEP_NAME
@@ -99,13 +112,14 @@ def build_task_request(
         custom_shell={"command": "bash /app/run-prorl.sh", "cwd": "/app"},
         env={
             "POLAR_MODEL_NAME": model_name,
-            "CLAWBENCH_HARNESS": harness,
             "CLAWBENCH_INSTRUCTION_FILE": "/app/instruction.md",
         },
     )
 
     # Reward: Polar's built-in harbor evaluator runs our tests/test.sh, which
-    # runs the two-stage scorer and writes /logs/verifier/reward.json.
+    # runs the two-stage scorer and writes /logs/verifier/reward.json. The judge
+    # (Stage-2) config is carried in the evaluator env — independent of the
+    # policy's OPENAI_* endpoint — so judging actually runs during rollouts.
     evaluator = EvaluatorSpec(
         strategy="harbor",
         config={
@@ -116,6 +130,7 @@ def build_task_request(
             "verifier_timeout": 180,
         },
         refresh_runtime=False,
+        env=judge_env or None,
     )
 
     return TaskRequest(
@@ -168,10 +183,17 @@ def poll_task(
     waited = 0.0
     while True:
         status = _get_json(url)
-        if str(status.get("status", "")).lower() != "running":
+        state = str(status.get("status", "")).lower()
+        if state in TERMINAL_OK:
             return status
+        if state in TERMINAL_ERROR:
+            raise RuntimeError(
+                f"task {task_id} ended in state {state!r}: {status.get('error') or status}"
+            )
+        if state not in NONTERMINAL:
+            raise RuntimeError(f"task {task_id} returned unexpected status {state!r}")
         if waited >= max_wait:
-            raise TimeoutError(f"task {task_id} still running after {max_wait}s")
+            raise TimeoutError(f"task {task_id} still {state} after {max_wait}s")
         time.sleep(interval)
         waited += interval
 
@@ -201,12 +223,25 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--rollout-url", default="http://127.0.0.1:8080", help="Rollout Server URL"
     )
-    p.add_argument("--image", default=DEFAULT_IMAGE, help="ClawBench runtime image")
+    p.add_argument(
+        "--image",
+        default=None,
+        help="ClawBench runtime image (must bundle a harness + browser runtime); "
+        "default: clawbench-<harness>:latest",
+    )
     p.add_argument(
         "--model-name",
         default="clawbench-policy",
         help="Policy model name sent by the harness",
     )
+    p.add_argument("--judge-model", default=None, help="Stage-2 judge model name")
+    p.add_argument(
+        "--judge-base-url",
+        default=None,
+        help="Stage-2 judge base URL (NOT the policy endpoint)",
+    )
+    p.add_argument("--judge-api-key", default=None, help="Stage-2 judge API key")
+    p.add_argument("--judge-api-type", default=None, help="Stage-2 judge api_type")
     p.add_argument(
         "--num-samples",
         type=int,
@@ -250,61 +285,86 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     task_dir, task = cases[0]
 
-    import tempfile
-
-    staging_root = args.staging_dir or Path(tempfile.mkdtemp(prefix="clawbench-prorl-"))
-    staging_root.mkdir(parents=True, exist_ok=True)
-    output_name = sanitize_task_name(task_dir.name)
-    staged = stage_task(
-        task_dir,
-        task,
-        staging_root,
-        org=args.org,
-        dataset_name=args.dataset_name,
-        output_name=output_name,
-    )
-
-    request = build_task_request(
-        staged,
-        task_id=task_dir.name,
-        image=args.image,
-        model_name=args.model_name,
-        num_samples=args.num_samples,
-        timeout_seconds=args.timeout,
-        harness=args.harness,
-        dataset_name=args.dataset_name,
-    )
-    payload = request.to_payload()
-
-    if args.dry_run:
-        print(json.dumps(payload, indent=2, ensure_ascii=False))
-        return 0
-
-    try:
-        task_id = submit_task(args.rollout_url, payload)
+    image = args.image or f"clawbench-{args.harness}:latest"
+    judge_env = {
+        env_key: getattr(args, f"judge_{arg}")
+        for arg, env_key in JUDGE_ENV_KEYS.items()
+        if getattr(args, f"judge_{arg}")
+    }
+    if not args.dry_run and not judge_env:
         print(
-            f"submitted task {task_id}; polling {args.rollout_url} ...", file=sys.stderr
+            "WARNING: no --judge-* config given; the Stage-2 judge will be "
+            "unconfigured and rewards may fall to 0.0. Pass "
+            "--judge-model/--judge-base-url/--judge-api-key, or use a "
+            "Stage-1-only test.sh.",
+            file=sys.stderr,
         )
-        status = poll_task(args.rollout_url, task_id)
-    except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
-        print(f"ERROR: rollout failed: {e}", file=sys.stderr)
-        return 1
 
-    rewards = extract_rewards(status)
-    mean = sum(rewards) / len(rewards) if rewards else 0.0
-    print(
-        json.dumps(
-            {
-                "task": task_dir.name,
-                "status": status.get("status"),
-                "num_sessions": len(rewards),
-                "rewards": rewards,
-                "mean_reward": mean,
-            },
-            indent=2,
+    import tempfile
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        if args.staging_dir:
+            staging_root = args.staging_dir
+            staging_root.mkdir(parents=True, exist_ok=True)
+        else:
+            staging_root = Path(
+                stack.enter_context(
+                    tempfile.TemporaryDirectory(prefix="clawbench-prorl-")
+                )
+            )
+        output_name = sanitize_task_name(task_dir.name)
+        staged = stage_task(
+            task_dir,
+            task,
+            staging_root,
+            org=args.org,
+            dataset_name=args.dataset_name,
+            output_name=output_name,
         )
-    )
-    return 0
+
+        request = build_task_request(
+            staged,
+            task_id=task_dir.name,
+            image=image,
+            model_name=args.model_name,
+            num_samples=args.num_samples,
+            timeout_seconds=args.timeout,
+            dataset_name=args.dataset_name,
+            judge_env=judge_env or None,
+        )
+        payload = request.to_payload()
+
+        if args.dry_run:
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return 0
+
+        try:
+            task_id = submit_task(args.rollout_url, payload)
+            print(
+                f"submitted task {task_id}; polling {args.rollout_url} ...",
+                file=sys.stderr,
+            )
+            status = poll_task(args.rollout_url, task_id)
+        except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
+            print(f"ERROR: rollout failed: {e}", file=sys.stderr)
+            return 1
+
+        rewards = extract_rewards(status)
+        mean = sum(rewards) / len(rewards) if rewards else 0.0
+        print(
+            json.dumps(
+                {
+                    "task": task_dir.name,
+                    "status": status.get("status"),
+                    "num_sessions": len(rewards),
+                    "rewards": rewards,
+                    "mean_reward": mean,
+                },
+                indent=2,
+            )
+        )
+        return 0
 
 
 if __name__ == "__main__":

--- a/src/clawbench/prorl/submit.py
+++ b/src/clawbench/prorl/submit.py
@@ -24,6 +24,7 @@ from clawbench.eval.harbor_adapter import (
     sanitize_task_name,
     write_harbor_task,
 )
+from clawbench.utils.paths import RUNTIME_ROOT
 from clawbench.prorl.models import (
     AgentSpec,
     BuilderSpec,
@@ -87,10 +88,18 @@ def build_task_request(
     tests_dir = step_dir / "tests"
     instruction = (step_dir / "instruction.md").read_text()
 
-    # Seed the session: stage the task workdir + run script + instruction, then
-    # bring up the browser runtime via the task's own setup.sh.
+    # Seed the session: stage the task workdir + run script + instruction, upload
+    # the Harbor runtime scripts the staged setup.sh/verify.py reference (so a
+    # plain ClawBench harness image — base + harness + runtime-server — works
+    # without a bespoke combined image), then bring up the browser runtime via
+    # the task's own setup.sh.
     prepare = [
         PrepareAction(type="upload_dir", source=str(workdir), target="/app"),
+        PrepareAction(
+            type="upload_dir",
+            source=str(RUNTIME_ROOT / "harbor"),
+            target="/app/src/harbor",
+        ),
         PrepareAction(
             type="upload_file", source=str(RUN_SCRIPT), target="/app/run-prorl.sh"
         ),

--- a/src/clawbench/prorl/submit.py
+++ b/src/clawbench/prorl/submit.py
@@ -24,6 +24,7 @@ from clawbench.eval.harbor_adapter import (
     sanitize_task_name,
     write_harbor_task,
 )
+from clawbench.runner.run_support.task import RESUME_TEMPLATE
 from clawbench.utils.paths import RUNTIME_ROOT
 from clawbench.prorl.models import (
     AgentSpec,
@@ -100,6 +101,14 @@ def build_task_request(
             type="upload_dir",
             source=str(RUNTIME_ROOT / "harbor"),
             target="/app/src/harbor",
+        ),
+        # prepare-task.py renders the persona resume from this template; it lives
+        # in run_support (not runtime/harbor), so upload it explicitly — without
+        # it setup.sh FileNotFounds and the runtime never boots.
+        PrepareAction(
+            type="upload_file",
+            source=str(RESUME_TEMPLATE),
+            target="/app/src/harbor/resume_template.json",
         ),
         PrepareAction(
             type="upload_file", source=str(RUN_SCRIPT), target="/app/run-prorl.sh"

--- a/src/clawbench/prorl/submit.py
+++ b/src/clawbench/prorl/submit.py
@@ -81,6 +81,7 @@ def build_task_request(
     timeout_seconds: int,
     dataset_name: str,
     judge_env: dict[str, str] | None = None,
+    runtime_env: dict[str, str] | None = None,
 ) -> TaskRequest:
     """Build the Polar ``TaskRequest`` for a staged ClawBench task."""
     step_dir = staged / "steps" / STEP_NAME
@@ -88,11 +89,11 @@ def build_task_request(
     tests_dir = step_dir / "tests"
     instruction = (step_dir / "instruction.md").read_text()
 
-    # Seed the session: stage the task workdir + run script + instruction, upload
-    # the Harbor runtime scripts the staged setup.sh/verify.py reference (so a
-    # plain ClawBench harness image — base + harness + runtime-server — works
-    # without a bespoke combined image), then bring up the browser runtime via
-    # the task's own setup.sh.
+    # Seed the session: stage the task workdir + run script + instruction. The
+    # combined clawbench-prorl image already bakes the Harbor runtime scripts,
+    # but we also upload RUNTIME_ROOT/harbor -> /app/src/harbor as a fallback so
+    # the staged setup.sh/verify.py references resolve even if the image lags.
+    # Then bring up the browser runtime via the task's own setup.sh.
     prepare = [
         PrepareAction(type="upload_dir", source=str(workdir), target="/app"),
         PrepareAction(
@@ -111,7 +112,7 @@ def build_task_request(
         PrepareAction(type="exec", command="bash /app/setup.sh", cwd="/app"),
     ]
 
-    runtime = RuntimeSpec(image=image, prepare=prepare)
+    runtime = RuntimeSpec(image=image, prepare=prepare, env=runtime_env or None)
 
     # Shell harness: the browser episode, with the policy model routed through
     # the gateway-injected $OPENAI_BASE_URL (captured into the trajectory).
@@ -235,8 +236,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--image",
         default=None,
-        help="ClawBench runtime image (must bundle a harness + browser runtime); "
-        "default: clawbench-<harness>:latest",
+        help="Combined ClawBench image (harness + Harbor browser runtime); "
+        "default clawbench-prorl:latest — build with build-prorl-image.sh",
     )
     p.add_argument(
         "--model-name",
@@ -252,17 +253,22 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--judge-api-key", default=None, help="Stage-2 judge API key")
     p.add_argument("--judge-api-type", default=None, help="Stage-2 judge api_type")
     p.add_argument(
+        "--purelymail-api-key",
+        default=None,
+        help="PurelyMail API key (email-signup tasks)",
+    )
+    p.add_argument(
+        "--purelymail-domain",
+        default=None,
+        help="PurelyMail domain (email-signup tasks)",
+    )
+    p.add_argument(
         "--num-samples",
         type=int,
         default=8,
         help="Rollout sessions per task (GRPO group size)",
     )
     p.add_argument("--timeout", type=int, default=900, help="Per-session timeout (s)")
-    p.add_argument(
-        "--harness",
-        default="hermes",
-        help="ClawBench browser harness to drive the episode",
-    )
     p.add_argument("--org", default="clawbench", help="Package org prefix")
     p.add_argument(
         "--dataset-name", default="clawbench-v2", help="Dataset label in metadata"
@@ -294,12 +300,17 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     task_dir, task = cases[0]
 
-    image = args.image or f"clawbench-{args.harness}:latest"
+    image = args.image or "clawbench-prorl:latest"
     judge_env = {
         env_key: getattr(args, f"judge_{arg}")
         for arg, env_key in JUDGE_ENV_KEYS.items()
         if getattr(args, f"judge_{arg}")
     }
+    runtime_env: dict[str, str] = {}
+    if args.purelymail_api_key:
+        runtime_env["PURELY_MAIL_API_KEY"] = args.purelymail_api_key
+    if args.purelymail_domain:
+        runtime_env["PURELY_MAIL_DOMAIN"] = args.purelymail_domain
     if not args.dry_run and not judge_env:
         print(
             "WARNING: no --judge-* config given; the Stage-2 judge will be "
@@ -341,6 +352,7 @@ def main(argv: list[str] | None = None) -> int:
             timeout_seconds=args.timeout,
             dataset_name=args.dataset_name,
             judge_env=judge_env or None,
+            runtime_env=runtime_env or None,
         )
         payload = request.to_payload()
 

--- a/src/clawbench/prorl/submit.py
+++ b/src/clawbench/prorl/submit.py
@@ -1,0 +1,311 @@
+"""``clawbench-prorl-submit`` — submit a ClawBench task to Polar as an RL rollout.
+
+Stages a ClawBench V2 task with the existing Harbor adapter (instruction + a
+``tests/test.sh`` that writes ``/logs/verifier/reward.json``), wraps it in a
+Polar ``TaskRequest`` (shell harness + ``harbor`` evaluator), and drives
+submit / poll / read-reward against a Rollout Server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from clawbench.eval.harbor_adapter import (
+    DEFAULT_CASES_DIR,
+    STEP_NAME,
+    discover_cases,
+    sanitize_task_name,
+    write_harbor_task,
+)
+from clawbench.prorl.models import (
+    AgentSpec,
+    BuilderSpec,
+    EvaluatorSpec,
+    PrepareAction,
+    RuntimeSpec,
+    TaskRequest,
+)
+
+DEFAULT_IMAGE = "clawbench-harbor:latest"
+RUN_SCRIPT = Path(__file__).resolve().parent / "run-prorl.sh"
+
+
+def stage_task(
+    task_dir: Path,
+    task: dict[str, Any],
+    staging_root: Path,
+    *,
+    org: str,
+    dataset_name: str,
+    output_name: str,
+) -> Path:
+    """Stage one task into a Harbor package layout; return the package dir."""
+    return write_harbor_task(
+        task_dir=task_dir,
+        task=task,
+        output_root=staging_root,
+        output_name=output_name,
+        org=org,
+        dataset_name=dataset_name,
+    )
+
+
+def build_task_request(
+    staged: Path,
+    *,
+    task_id: str,
+    image: str,
+    model_name: str,
+    num_samples: int,
+    timeout_seconds: int,
+    harness: str,
+    dataset_name: str,
+) -> TaskRequest:
+    """Build the Polar ``TaskRequest`` for a staged ClawBench task."""
+    step_dir = staged / "steps" / STEP_NAME
+    workdir = step_dir / "workdir"
+    tests_dir = step_dir / "tests"
+    instruction = (step_dir / "instruction.md").read_text()
+
+    # Seed the session: stage the task workdir + run script + instruction, then
+    # bring up the browser runtime via the task's own setup.sh.
+    prepare = [
+        PrepareAction(type="upload_dir", source=str(workdir), target="/app"),
+        PrepareAction(
+            type="upload_file", source=str(RUN_SCRIPT), target="/app/run-prorl.sh"
+        ),
+        PrepareAction(
+            type="upload_file",
+            source=str(step_dir / "instruction.md"),
+            target="/app/instruction.md",
+        ),
+        PrepareAction(type="exec", command="bash /app/setup.sh", cwd="/app"),
+    ]
+
+    runtime = RuntimeSpec(image=image, prepare=prepare)
+
+    # Shell harness: the browser episode, with the policy model routed through
+    # the gateway-injected $OPENAI_BASE_URL (captured into the trajectory).
+    agent = AgentSpec(
+        model_name=model_name,
+        harness="shell",
+        custom_shell={"command": "bash /app/run-prorl.sh", "cwd": "/app"},
+        env={
+            "POLAR_MODEL_NAME": model_name,
+            "CLAWBENCH_HARNESS": harness,
+            "CLAWBENCH_INSTRUCTION_FILE": "/app/instruction.md",
+        },
+    )
+
+    # Reward: Polar's built-in harbor evaluator runs our tests/test.sh, which
+    # runs the two-stage scorer and writes /logs/verifier/reward.json.
+    evaluator = EvaluatorSpec(
+        strategy="harbor",
+        config={
+            "tests_dir": str(tests_dir),
+            "tests_target": "/tests",
+            "verifier_dir": "/logs/verifier",
+            "test_command": "bash /tests/test.sh",
+            "verifier_timeout": 180,
+        },
+        refresh_runtime=False,
+    )
+
+    return TaskRequest(
+        task_id=task_id,
+        instruction=instruction,
+        runtime=runtime,
+        agent=agent,
+        evaluator=evaluator,
+        builder=BuilderSpec(strategy="prefix_merging"),
+        num_samples=num_samples,
+        timeout_seconds=timeout_seconds,
+        metadata={"clawbench_task": task_id, "dataset": dataset_name},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rollout Server client (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+def _post_json(
+    url: str, payload: dict[str, Any], timeout: float = 30.0
+) -> dict[str, Any]:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (trusted host)
+        return json.loads(resp.read().decode())
+
+
+def _get_json(url: str, timeout: float = 30.0) -> dict[str, Any]:
+    req = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read().decode())
+
+
+def submit_task(rollout_url: str, payload: dict[str, Any]) -> str:
+    result = _post_json(rollout_url.rstrip("/") + "/rollout/task/submit", payload)
+    task_id = result.get("task_id")
+    if not task_id:
+        raise RuntimeError(f"submit did not return a task_id: {result}")
+    return str(task_id)
+
+
+def poll_task(
+    rollout_url: str, task_id: str, *, interval: float = 3.0, max_wait: float = 3600.0
+) -> dict[str, Any]:
+    url = f"{rollout_url.rstrip('/')}/rollout/task/{task_id}"
+    waited = 0.0
+    while True:
+        status = _get_json(url)
+        if str(status.get("status", "")).lower() != "running":
+            return status
+        if waited >= max_wait:
+            raise TimeoutError(f"task {task_id} still running after {max_wait}s")
+        time.sleep(interval)
+        waited += interval
+
+
+def extract_rewards(status: dict[str, Any]) -> list[float]:
+    """Pull per-session final-trace rewards out of a completed TaskStatus."""
+    rewards: list[float] = []
+    for session in status.get("sessions", []) or []:
+        traj = session.get("trajectory") or {}
+        traces = traj.get("traces") or []
+        if traces and traces[-1].get("reward") is not None:
+            rewards.append(float(traces[-1]["reward"]))
+    return rewards
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="clawbench-prorl-submit",
+        description="Submit a ClawBench V2 task to ProRL-Agent-Server (Polar) as an RL rollout.",
+    )
+    p.add_argument(
+        "--task", required=True, help="ClawBench task id (dir name under the cases dir)"
+    )
+    p.add_argument(
+        "--cases-dir", type=Path, default=None, help="V2 cases dir (default: bundled)"
+    )
+    p.add_argument(
+        "--rollout-url", default="http://127.0.0.1:8080", help="Rollout Server URL"
+    )
+    p.add_argument("--image", default=DEFAULT_IMAGE, help="ClawBench runtime image")
+    p.add_argument(
+        "--model-name",
+        default="clawbench-policy",
+        help="Policy model name sent by the harness",
+    )
+    p.add_argument(
+        "--num-samples",
+        type=int,
+        default=8,
+        help="Rollout sessions per task (GRPO group size)",
+    )
+    p.add_argument("--timeout", type=int, default=900, help="Per-session timeout (s)")
+    p.add_argument(
+        "--harness",
+        default="hermes",
+        help="ClawBench browser harness to drive the episode",
+    )
+    p.add_argument("--org", default="clawbench", help="Package org prefix")
+    p.add_argument(
+        "--dataset-name", default="clawbench-v2", help="Dataset label in metadata"
+    )
+    p.add_argument(
+        "--staging-dir",
+        type=Path,
+        default=None,
+        help="Where to stage the task (default: temp)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the TaskRequest payload; do not submit",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    cases_dir = (args.cases_dir or DEFAULT_CASES_DIR).resolve()
+    if not cases_dir.exists():
+        print(f"ERROR: cases directory not found: {cases_dir}", file=sys.stderr)
+        return 1
+    cases = discover_cases(cases_dir, {args.task})
+    if not cases:
+        print(f"ERROR: task {args.task!r} not found under {cases_dir}", file=sys.stderr)
+        return 1
+    task_dir, task = cases[0]
+
+    import tempfile
+
+    staging_root = args.staging_dir or Path(tempfile.mkdtemp(prefix="clawbench-prorl-"))
+    staging_root.mkdir(parents=True, exist_ok=True)
+    output_name = sanitize_task_name(task_dir.name)
+    staged = stage_task(
+        task_dir,
+        task,
+        staging_root,
+        org=args.org,
+        dataset_name=args.dataset_name,
+        output_name=output_name,
+    )
+
+    request = build_task_request(
+        staged,
+        task_id=task_dir.name,
+        image=args.image,
+        model_name=args.model_name,
+        num_samples=args.num_samples,
+        timeout_seconds=args.timeout,
+        harness=args.harness,
+        dataset_name=args.dataset_name,
+    )
+    payload = request.to_payload()
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    try:
+        task_id = submit_task(args.rollout_url, payload)
+        print(
+            f"submitted task {task_id}; polling {args.rollout_url} ...", file=sys.stderr
+        )
+        status = poll_task(args.rollout_url, task_id)
+    except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
+        print(f"ERROR: rollout failed: {e}", file=sys.stderr)
+        return 1
+
+    rewards = extract_rewards(status)
+    mean = sum(rewards) / len(rewards) if rewards else 0.0
+    print(
+        json.dumps(
+            {
+                "task": task_dir.name,
+                "status": status.get("status"),
+                "num_sessions": len(rewards),
+                "rewards": rewards,
+                "mean_reward": mean,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawbench/prorl/topology.example.yaml
+++ b/src/clawbench/prorl/topology.example.yaml
@@ -1,0 +1,31 @@
+# Polar (ProRL-Agent-Server) fleet topology for ClawBench RL rollouts.
+#
+# The topology defines the *fleet* (rollout server + gateway nodes + inference
+# servers). The *environment* (image / harness / evaluator) is defined per task
+# in the submission payload — see `clawbench-prorl-submit`.
+#
+# Bring up: `polar rollout --topology topology.yaml` (see ProRL-Agent-Server
+# docs). Each gateway node needs an OpenAI-compatible inference server
+# (SGLang or vLLM) serving the policy. Because ClawBench agents send screenshots,
+# `model_served` MUST be a vision-language model.
+
+rollout:
+  host: 127.0.0.1
+  port: 8080
+  public_url: http://127.0.0.1:8080
+  save_dir: ./clawbench_rollout_results
+
+gateway:
+  heartbeat_interval_seconds: 30
+  nodes:
+    - id: clawbench-node-01
+      host: 127.0.0.1
+      port: 8100
+      public_url: http://127.0.0.1:8100
+      max_init_workers: 4      # each session starts a fresh browser container
+      max_run_workers: 4
+      max_postrun_workers: 4
+      model_served: Qwen/Qwen3-VL-8B-Instruct   # <-- your VLM policy checkpoint
+      inference:
+        engine: vllm           # or: sglang
+        base_url: http://127.0.0.1:8000

--- a/tests/test_prorl_mock.py
+++ b/tests/test_prorl_mock.py
@@ -1,0 +1,65 @@
+"""End-to-end contract test via the offline mock Polar rollout server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clawbench.prorl import mock_gateway, submit
+
+
+def _stub_tests_dir(tmp_path: Path, reward: float) -> Path:
+    """A tests/ dir whose test.sh writes a fixed reward (no browser/runtime)."""
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text(
+        "#!/bin/bash\n"
+        "set -e\n"
+        'mkdir -p "$VERIFIER_DIR"\n'
+        f'echo \'{{"reward": {reward}}}\' > "$VERIFIER_DIR/reward.json"\n'
+    )
+    return tests
+
+
+def test_harbor_evaluator_reads_reward(tmp_path: Path) -> None:
+    tests = _stub_tests_dir(tmp_path, 1.0)
+    reward, meta = mock_gateway.run_harbor_evaluator(tests)
+    assert reward == 1.0
+    assert meta["verifier_exit_code"] == 0
+
+
+def test_harbor_evaluator_clamps_and_defaults(tmp_path: Path) -> None:
+    tests = _stub_tests_dir(tmp_path, 5.0)  # out of range -> clamped
+    reward, _ = mock_gateway.run_harbor_evaluator(tests)
+    assert reward == 1.0
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    (empty / "test.sh").write_text("#!/bin/bash\ntrue\n")  # writes no reward
+    reward2, _ = mock_gateway.run_harbor_evaluator(empty)
+    assert reward2 == 0.0
+
+
+def test_full_submit_poll_reward_over_http(tmp_path: Path) -> None:
+    """Hand-built payload → mock server → client submit/poll/extract reward."""
+    tests = _stub_tests_dir(tmp_path, 0.75)
+    payload = {
+        "task_id": "v2-smoke",
+        "num_samples": 3,
+        "evaluator": {
+            "strategy": "harbor",
+            "config": {"tests_dir": str(tests), "test_command": "bash /tests/test.sh"},
+        },
+    }
+
+    server = mock_gateway.serve(host="127.0.0.1", port=0)
+    try:
+        host, port = server.server_address[0], server.server_address[1]
+        url = f"http://{host}:{port}"
+        task_id = submit.submit_task(url, payload)
+        status = submit.poll_task(url, task_id, interval=0.05, max_wait=30)
+        rewards = submit.extract_rewards(status)
+    finally:
+        server.shutdown()
+
+    assert status["status"] == "completed"
+    assert rewards == [0.75, 0.75, 0.75]

--- a/tests/test_prorl_models.py
+++ b/tests/test_prorl_models.py
@@ -1,0 +1,101 @@
+"""Unit tests for the Polar TaskRequest models."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawbench.prorl.models import (
+    AgentSpec,
+    EvaluatorSpec,
+    PrepareAction,
+    RuntimeSpec,
+    TaskRequest,
+)
+
+
+def _minimal_request(**overrides) -> TaskRequest:
+    kwargs = dict(
+        task_id="v2-001",
+        instruction="do the thing",
+        runtime=RuntimeSpec(image="clawbench-harbor:latest"),
+        agent=AgentSpec(
+            model_name="policy",
+            harness="shell",
+            custom_shell={"command": "bash /app/run-prorl.sh"},
+        ),
+        evaluator=EvaluatorSpec(strategy="harbor", config={"tests_dir": "/x"}),
+    )
+    kwargs.update(overrides)
+    return TaskRequest(**kwargs)
+
+
+def test_task_request_payload_has_contract_keys() -> None:
+    payload = _minimal_request().to_payload()
+    for key in (
+        "task_id",
+        "instruction",
+        "num_samples",
+        "timeout_seconds",
+        "runtime",
+        "agent",
+        "builder",
+        "evaluator",
+    ):
+        assert key in payload
+    assert payload["builder"]["strategy"] == "prefix_merging"
+    assert payload["runtime"]["backend"] == "docker"
+    assert payload["evaluator"]["strategy"] == "harbor"
+    assert payload["evaluator"]["refresh_runtime"] is False
+
+
+def test_shell_agent_requires_custom_shell() -> None:
+    with pytest.raises(ValueError, match="custom_shell"):
+        AgentSpec(model_name="p", harness="shell")
+
+
+def test_agent_exactly_one_of_harness_or_import_path() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        AgentSpec(model_name="p", harness="shell", import_path="m:C")
+    # custom_shell may not accompany an import_path harness
+    with pytest.raises(ValueError, match="only valid with harness='shell'"):
+        AgentSpec(
+            model_name="p",
+            harness=None,
+            import_path="m:C",
+            custom_shell={"command": "x"},
+        )
+
+
+def test_agent_payload_shape() -> None:
+    payload = AgentSpec(
+        model_name="policy",
+        harness="shell",
+        custom_shell={"command": "bash /app/run-prorl.sh"},
+        env={"POLAR_MODEL_NAME": "policy"},
+    ).to_payload()
+    assert payload["harness"] == "shell"
+    assert payload["custom_shell"]["command"].endswith("run-prorl.sh")
+    assert payload["model_name"] == "policy"
+    assert "import_path" not in payload  # None dropped
+
+
+def test_prepare_action_validation() -> None:
+    with pytest.raises(ValueError, match="requires source and target"):
+        PrepareAction(type="upload_dir", source="a")
+    with pytest.raises(ValueError, match="exec requires command"):
+        PrepareAction(type="exec")
+    with pytest.raises(ValueError, match="type must be one of"):
+        PrepareAction(type="bogus")
+    ok = PrepareAction(type="exec", command="bash /app/setup.sh", cwd="/app")
+    assert ok.to_payload() == {
+        "type": "exec",
+        "command": "bash /app/setup.sh",
+        "cwd": "/app",
+    }
+
+
+def test_num_samples_and_timeout_guards() -> None:
+    with pytest.raises(ValueError, match="num_samples"):
+        _minimal_request(num_samples=0)
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        _minimal_request(timeout_seconds=0)

--- a/tests/test_prorl_submit.py
+++ b/tests/test_prorl_submit.py
@@ -96,6 +96,8 @@ def test_run_script_routes_policy_but_not_judge() -> None:
     assert 'API_KEY="${OPENAI_API_KEY}"' in text
     # the harness setup needs the browser CDP endpoint (entrypoint is bypassed)
     assert "CLAWBENCH_BROWSER_CDP_URL" in text
+    # personal info is staged at /app/my-info but harnesses read /my-info
+    assert "/my-info" in text
     # the judge endpoint is never derived from the gateway endpoint
     for line in text.splitlines():
         if "CLAWBENCH_JUDGE_BASE_URL" in line:
@@ -123,6 +125,30 @@ def test_dry_run_prints_valid_payload(one_case, capsys, tmp_path: Path) -> None:
     assert payload["task_id"] == task_dir.name
     assert payload["agent"]["harness"] == "shell"
     assert payload["evaluator"]["strategy"] == "harbor"
+    # defaults to the combined image (harness + Harbor runtime)
+    assert payload["runtime"]["image"] == "clawbench-prorl:latest"
+
+
+def test_purelymail_env_passthrough(one_case, capsys, tmp_path: Path) -> None:
+    task_dir, _ = one_case
+    rc = submit.main(
+        [
+            "--task",
+            task_dir.name,
+            "--dry-run",
+            "--staging-dir",
+            str(tmp_path / "s"),
+            "--purelymail-api-key",
+            "pm-key",
+            "--purelymail-domain",
+            "mail.example",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    env = payload["runtime"]["env"]
+    assert env["PURELY_MAIL_API_KEY"] == "pm-key"
+    assert env["PURELY_MAIL_DOMAIN"] == "mail.example"
 
 
 def test_poll_completed_returns(monkeypatch) -> None:

--- a/tests/test_prorl_submit.py
+++ b/tests/test_prorl_submit.py
@@ -46,12 +46,16 @@ def test_build_task_request_shape(staged) -> None:
     req = submit.build_task_request(
         dest,
         task_id=task_dir.name,
-        image="clawbench-harbor:latest",
+        image="clawbench-hermes:latest",
         model_name="policy",
         num_samples=4,
         timeout_seconds=600,
-        harness="hermes",
         dataset_name="clawbench-v2",
+        judge_env={
+            "CLAWBENCH_JUDGE_MODEL": "glm-5.1",
+            "CLAWBENCH_JUDGE_BASE_URL": "https://judge.example/v1",
+            "CLAWBENCH_JUDGE_API_KEY": "sk-judge",
+        },
     )
     payload = req.to_payload()
 
@@ -67,6 +71,10 @@ def test_build_task_request_shape(staged) -> None:
     assert Path(ev["config"]["tests_dir"]).name == "tests"
     assert (Path(ev["config"]["tests_dir"]) / "test.sh").is_file()
 
+    # judge config is carried in the evaluator env, independent of the policy
+    assert ev["env"]["CLAWBENCH_JUDGE_MODEL"] == "glm-5.1"
+    assert ev["env"]["CLAWBENCH_JUDGE_BASE_URL"] == "https://judge.example/v1"
+
     # runtime prepares the browser env
     types = [p["type"] for p in payload["runtime"]["prepare"]]
     assert "upload_dir" in types and "exec" in types
@@ -76,8 +84,10 @@ def test_build_task_request_shape(staged) -> None:
 def test_run_script_routes_policy_but_not_judge() -> None:
     """The episode's policy model uses $OPENAI_BASE_URL; the judge must not."""
     text = submit.RUN_SCRIPT.read_text()
-    # policy is routed through the captured gateway endpoint
-    assert 'CLAWBENCH_BASE_URL="${OPENAI_BASE_URL}"' in text
+    # policy is routed through the captured gateway endpoint via the env vars
+    # the ClawBench harness runners actually read.
+    assert 'BASE_URL="${OPENAI_BASE_URL}"' in text
+    assert 'API_KEY="${OPENAI_API_KEY}"' in text
     # the judge endpoint is never derived from the gateway endpoint
     for line in text.splitlines():
         if "CLAWBENCH_JUDGE_BASE_URL" in line:
@@ -105,3 +115,26 @@ def test_dry_run_prints_valid_payload(one_case, capsys, tmp_path: Path) -> None:
     assert payload["task_id"] == task_dir.name
     assert payload["agent"]["harness"] == "shell"
     assert payload["evaluator"]["strategy"] == "harbor"
+
+
+def test_poll_completed_returns(monkeypatch) -> None:
+    seq = iter([{"status": "running"}, {"status": "completed", "sessions": []}])
+    monkeypatch.setattr(submit, "_get_json", lambda url, timeout=30.0: next(seq))
+    status = submit.poll_task("http://x", "t1", interval=0, max_wait=5)
+    assert status["status"] == "completed"
+
+
+def test_poll_failed_raises(monkeypatch) -> None:
+    monkeypatch.setattr(
+        submit,
+        "_get_json",
+        lambda url, timeout=30.0: {"status": "failed", "error": "boom"},
+    )
+    with pytest.raises(RuntimeError, match="failed"):
+        submit.poll_task("http://x", "t1", interval=0, max_wait=5)
+
+
+def test_poll_unexpected_status_raises(monkeypatch) -> None:
+    monkeypatch.setattr(submit, "_get_json", lambda url, timeout=30.0: {"status": ""})
+    with pytest.raises(RuntimeError, match="unexpected status"):
+        submit.poll_task("http://x", "t1", interval=0, max_wait=5)

--- a/tests/test_prorl_submit.py
+++ b/tests/test_prorl_submit.py
@@ -1,0 +1,107 @@
+"""Tests for staging + payload construction in clawbench.prorl.submit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from clawbench.eval.harbor_adapter import DEFAULT_CASES_DIR, discover_cases
+from clawbench.prorl import submit
+
+
+@pytest.fixture(scope="module")
+def one_case():
+    cases = discover_cases(DEFAULT_CASES_DIR)
+    if not cases:
+        pytest.skip("no bundled V2 cases available")
+    return cases[0]
+
+
+@pytest.fixture
+def staged(one_case, tmp_path: Path):
+    task_dir, task = one_case
+    dest = submit.stage_task(
+        task_dir,
+        task,
+        tmp_path,
+        org="clawbench",
+        dataset_name="clawbench-v2",
+        output_name="case",
+    )
+    return task_dir, dest
+
+
+def test_stage_produces_instruction_and_tests(staged) -> None:
+    _, dest = staged
+    step = dest / "steps" / "run"
+    assert (step / "instruction.md").is_file()
+    assert (step / "tests" / "test.sh").is_file()
+    assert (step / "workdir" / "setup.sh").is_file()
+
+
+def test_build_task_request_shape(staged) -> None:
+    task_dir, dest = staged
+    req = submit.build_task_request(
+        dest,
+        task_id=task_dir.name,
+        image="clawbench-harbor:latest",
+        model_name="policy",
+        num_samples=4,
+        timeout_seconds=600,
+        harness="hermes",
+        dataset_name="clawbench-v2",
+    )
+    payload = req.to_payload()
+
+    # shell harness drives run-prorl.sh
+    assert payload["agent"]["harness"] == "shell"
+    assert payload["agent"]["custom_shell"]["command"].endswith("run-prorl.sh")
+    assert payload["agent"]["env"]["POLAR_MODEL_NAME"] == "policy"
+
+    # harbor evaluator points at the staged tests dir
+    ev = payload["evaluator"]
+    assert ev["strategy"] == "harbor"
+    assert ev["refresh_runtime"] is False
+    assert Path(ev["config"]["tests_dir"]).name == "tests"
+    assert (Path(ev["config"]["tests_dir"]) / "test.sh").is_file()
+
+    # runtime prepares the browser env
+    types = [p["type"] for p in payload["runtime"]["prepare"]]
+    assert "upload_dir" in types and "exec" in types
+    assert payload["num_samples"] == 4
+
+
+def test_run_script_routes_policy_but_not_judge() -> None:
+    """The episode's policy model uses $OPENAI_BASE_URL; the judge must not."""
+    text = submit.RUN_SCRIPT.read_text()
+    # policy is routed through the captured gateway endpoint
+    assert 'CLAWBENCH_BASE_URL="${OPENAI_BASE_URL}"' in text
+    # the judge endpoint is never derived from the gateway endpoint
+    for line in text.splitlines():
+        if "CLAWBENCH_JUDGE_BASE_URL" in line:
+            assert "OPENAI_BASE_URL" not in line, (
+                "judge endpoint must not reuse the gateway proxy — it would "
+                "pollute the trajectory with judge tokens"
+            )
+
+
+def test_dry_run_prints_valid_payload(one_case, capsys, tmp_path: Path) -> None:
+    task_dir, _ = one_case
+    rc = submit.main(
+        [
+            "--task",
+            task_dir.name,
+            "--dry-run",
+            "--staging-dir",
+            str(tmp_path / "stage"),
+            "--model-name",
+            "policy",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["task_id"] == task_dir.name
+    assert payload["agent"]["harness"] == "shell"
+    assert payload["evaluator"]["strategy"] == "harbor"

--- a/tests/test_prorl_submit.py
+++ b/tests/test_prorl_submit.py
@@ -75,9 +75,15 @@ def test_build_task_request_shape(staged) -> None:
     assert ev["env"]["CLAWBENCH_JUDGE_MODEL"] == "glm-5.1"
     assert ev["env"]["CLAWBENCH_JUDGE_BASE_URL"] == "https://judge.example/v1"
 
-    # runtime prepares the browser env
-    types = [p["type"] for p in payload["runtime"]["prepare"]]
+    # runtime prepares the browser env + uploads the Harbor runtime scripts the
+    # staged setup.sh/verify.py reference
+    prepare = payload["runtime"]["prepare"]
+    types = [p["type"] for p in prepare]
     assert "upload_dir" in types and "exec" in types
+    assert any(p.get("target") == "/app/src/harbor" for p in prepare), (
+        "harbor runtime scripts must be uploaded so a harness image resolves "
+        "the staged setup.sh/verify.py"
+    )
     assert payload["num_samples"] == 4
 
 
@@ -88,6 +94,8 @@ def test_run_script_routes_policy_but_not_judge() -> None:
     # the ClawBench harness runners actually read.
     assert 'BASE_URL="${OPENAI_BASE_URL}"' in text
     assert 'API_KEY="${OPENAI_API_KEY}"' in text
+    # the harness setup needs the browser CDP endpoint (entrypoint is bypassed)
+    assert "CLAWBENCH_BROWSER_CDP_URL" in text
     # the judge endpoint is never derived from the gateway endpoint
     for line in text.splitlines():
         if "CLAWBENCH_JUDGE_BASE_URL" in line:


### PR DESCRIPTION
## Run ClawBench as a ProRL-Agent-Server ("Polar") RL environment

Closes #219. Adds `clawbench.prorl`: expose ClawBench V2 tasks as RL rollouts for [NVIDIA-NeMo/ProRL-Agent-Server](https://github.com/NVIDIA-NeMo/ProRL-Agent-Server) ("Polar"), NVIDIA's HTTP rollout framework for agentic RL.

### Why it's thin (reuse, not rebuild)
Polar uses a **"Harness as Environment"** model — the gateway proxies + captures the policy's LLM calls into a token-faithful trajectory, then grades the container with an *evaluator*. So:
- **Reward is done:** Polar's built-in **`harbor` evaluator** runs a `tests/test.sh` and reads `/logs/verifier/reward.json` — exactly what `clawbench-harbor-adapt` already emits. **Zero new reward code.**
- **Token capture is Polar's job**, not ours (its proxy does it) — unlike a Harbor-native RL rollout, which would need a vLLM/Tinker-served policy to recover token IDs. ClawBench only routes the policy model through the injected `$OPENAI_BASE_URL`.

### What's added (`src/clawbench/prorl/`)
| File | Role |
|---|---|
| `models.py` | Typed Polar `TaskRequest` + `to_payload()` |
| `submit.py` (`clawbench-prorl-submit`) | Stage a task (reusing `harbor_adapter`) → build payload → submit/poll/read reward |
| `run-prorl.sh` | Shell-harness entry: policy model → `$OPENAI_BASE_URL`; **judge kept off the proxy** |
| `topology.example.yaml` | Fleet template (rollout + gateway + vLLM/SGLang VLM) |
| `mock_gateway.py` (`clawbench-prorl-mock`) | Offline Rollout-Server + `harbor`-evaluator mock |
| `docs/prorl-rl-env.md` | Design + judge-isolation guard + **GPU training runbook** |

### Correctness guard
The Stage-2 LLM judge must **not** use `$OPENAI_BASE_URL` — else judge tokens get captured and scored as trainable policy tokens, corrupting the gradient. `run-prorl.sh` routes only the policy there; a test (`test_run_script_routes_policy_but_not_judge`) enforces it.

### Verified
- **13 new tests** (models, staging/payload, judge isolation, **offline mock end-to-end** proving `submit → harbor-eval → reward` round-trips with no GPU/browser). Full suite **99 passed**; ruff + pyright clean.
- **Live dry-run** produces a real Polar `TaskRequest` for `v2-047-…` (shell harness → `run-prorl.sh`, harbor evaluator over staged `tests/`, `prefix_merging`, GRPO group 8).

### Scope
This makes ClawBench **submittable + gradeable** as a Polar env, verified at the contract level offline. A full RL *training* run (GPUs + vLLM/SGLang VLM serve + trainer) is the documented runbook in `docs/prorl-rl-env.md` for the GPU box.
