### PR TITLE
fix(prorl): green up CI after #251 (pyright typing + Windows bash skip)

### DIFF
--- a/tests/test_prorl_mock.py
+++ b/tests/test_prorl_mock.py
@@ -1,10 +1,22 @@
-"""End-to-end contract test via the offline mock Polar rollout server."""
+"""End-to-end contract test via the offline mock Polar rollout server.
+
+These tests exercise the ``harbor`` evaluator path, which runs a POSIX
+``test.sh`` via ``bash`` (ClawBench's runtime is Linux containers). They are
+skipped on Windows, which has no ``bash``.
+"""
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
+import pytest
+
 from clawbench.prorl import mock_gateway, submit
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="harbor evaluator runs a POSIX test.sh via bash"
+)
 
 
 def _stub_tests_dir(tmp_path: Path, reward: float) -> Path:

--- a/tests/test_prorl_models.py
+++ b/tests/test_prorl_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from clawbench.prorl.models import (
@@ -13,8 +15,8 @@ from clawbench.prorl.models import (
 )
 
 
-def _minimal_request(**overrides) -> TaskRequest:
-    kwargs = dict(
+def _minimal_request(**overrides: Any) -> TaskRequest:
+    kwargs: dict[str, Any] = dict(
         task_id="v2-001",
         instruction="do the thing",
         runtime=RuntimeSpec(image="clawbench-harbor:latest"),


### PR DESCRIPTION
Restores green CI on main after #251. Two failures from the new prorl tests (ubuntu/macos already passed):
- **static-check**: `test_prorl_models._minimal_request` built a heterogeneous `dict` → pyright inferred a union for `**kwargs`. Annotated `kwargs: dict[str, Any]`.
- **pytest (windows)**: `test_prorl_mock` shells out to `bash` to run the harbor evaluator's POSIX `test.sh`; Windows has no bash. Skip the module on win32 (ClawBench runtime is Linux containers by design).

Verified locally: `pyright src/clawbench tests` 0 errors, ruff clean, `pytest` 110 passed.