### PR TITLE
feat(edgebench): package ClawBench V2 as an EdgeBench/SForge benchmark

### DIFF
--- a/docs/edgebench.md
+++ b/docs/edgebench.md
@@ -72,12 +72,16 @@ image build/hashing.
    EdgeBench repo or an upstream contribution) or a Work-image entrypoint that,
    at container-run time and **before** the episode:
    ```bash
+   # the interceptor writes to $CLAWBENCH_DATA_DIR (default /data); point it at
+   # the dir SForge submits + the judge reads (submit_paths: ["evidence/"]).
+   export CLAWBENCH_DATA_DIR=/app/evidence
    /app/src/harbor/start-runtime.sh &                 # Chromium + CDP + runtime-server
    until curl -sf http://127.0.0.1:7878/api/status \
      | grep -q '"eval_interceptor_ready":true'; do sleep 1; done
    ```
    (the adapter already stages `/eval-schema.json`, which the runtime reads to arm
-   the interceptor). It then drives the ClawBench harness and calls `sforge-submit`.
+   the interceptor). It then drives the ClawBench harness and, when done, calls
+   `sforge-submit` — which archives `evidence/interception.json` for the judge.
 2. **Container build + a live `sforge run`.** The adapter emits contract-faithful
    task JSON (schema-tested) and the judge is unit-tested offline, but building
    the Work/Judge images and a live end-to-end `sforge run` require Docker + the

--- a/docs/edgebench.md
+++ b/docs/edgebench.md
@@ -1,0 +1,76 @@
+# ClawBench on EdgeBench (SForge)
+
+This packages ClawBench V2 tasks so they can be run through ByteDance Seed's
+[EdgeBench](https://github.com/ByteDance-Seed/EdgeBench) harness, **SForge**.
+
+## The mapping (Mapping A — "structured_json score task")
+
+EdgeBench is a two-container harness: an agent runs in a **Work** container and
+submits an archive to a **Judge** container that grades it offline. It targets
+long-horizon iterative *code* agents; ClawBench is a short one-shot *browser*
+task. We bridge the gap without editing SForge source:
+
+| SForge piece | ClawBench mapping |
+|---|---|
+| Work container | ClawBench browser runtime + harness + interceptor |
+| submitted archive (`submit_paths`) | `evidence/` — the interceptor writes `evidence/interception.json` |
+| Judge `eval_cmd` | **`clawbench-edgebench-judge`** — re-scores the evidence (Stage-1 interception ∧ Stage-2 LLM judge) → `structured_json` |
+| `parser` | `structured_json` (built-in; no SForge source edit) |
+| best-of-N submissions | one-shot: `--max-submissions 1`, machinery disabled |
+
+ClawBench's `verify.py` already scores a *captured* `interception.json`, so
+moving interception to the Work side (into `evidence/`) and re-scoring it in the
+Judge is a natural fit — EdgeBench's judge is offline/archive-only by design.
+
+## Generate the benchmark
+
+```
+clawbench-edgebench-adapt --output-dir ./clawbench-edgebench \
+    --base-image clawbench-prorl-openclaw:latest
+```
+Produces a SForge benchmark dir: `tasks/BENCHMARK.yaml` + `tasks/<id>.json`
+(+ per-task `specs/`). Each `<id>.json` is Mapping A:
+`base_image: browser`, `submit_paths: ["evidence/"]`,
+`judge.parser: structured_json`, `judge.eval_cmd: clawbench-edgebench-judge …`,
+`score_direction: maximize`, `selection: score_first`.
+
+## Run it
+
+```
+# LLM-judge key reaches the Judge container via SFORGE_JUDGE_EXTRA_ENV
+export SFORGE_JUDGE_EXTRA_ENV="CLAWBENCH_JUDGE_MODEL=glm-5.1,\
+CLAWBENCH_JUDGE_BASE_URL=https://api.z.ai/api/paas/v4,CLAWBENCH_JUDGE_API_KEY=…,\
+CLAWBENCH_JUDGE_API_TYPE=openai-completions"
+export SFORGE_AGENT_API_KEY=…  SFORGE_AGENT_API_BASE_URL=…  SFORGE_AGENT_MODEL=…
+
+sforge serve --port 8080
+sforge run --task <id> --agent <browser-agent> \
+    --max-submissions 1 --disable-auto-eval --disable-stop-hook --timeout 900
+```
+
+The judge prints, and SForge parses:
+```
+>>>>> Start Structured Result
+{"valid":true,"score":1.0,"summary":"…","details":[…],"metrics":{"intercepted":true}}
+>>>>> End Structured Result
+```
+
+## What ClawBench supplies vs SForge
+
+ClawBench supplies only the **Judge `eval_cmd`** (`clawbench-edgebench-judge`,
+fully unit-tested offline) + the **task definitions** (`clawbench-edgebench-adapt`).
+SForge provides the Judge HTTP API, `sforge-submit`, tokens/rounds/best-score,
+image build/hashing.
+
+## Not covered here (the two open ends)
+
+1. **A browser Agent for SForge.** SForge's built-in agents (`claude-code`,
+   `codex`) are code CLIs. Running a *browser* episode needs either a small
+   `Agent` subclass under `sforge/harness/agent/` (one file + one factory line —
+   an edit to the EdgeBench repo, or an upstream contribution) or a Work-image
+   entrypoint that drives the ClawBench harness and then calls `sforge-submit`.
+2. **Container build + a live `sforge run`.** The adapter emits contract-faithful
+   task JSON (schema-tested) and the judge is unit-tested offline, but building
+   the Work/Judge images and a live end-to-end `sforge run` require Docker + the
+   EdgeBench harness on a build box — analogous to how the ProRL image was
+   validated separately from its offline contract tests.

--- a/docs/edgebench.md
+++ b/docs/edgebench.md
@@ -51,7 +51,7 @@ sforge run --task <id> --agent <browser-agent> \
 The judge prints, and SForge parses:
 ```
 >>>>> Start Structured Result
-{"valid":true,"score":1.0,"summary":"…","details":[…],"metrics":{"intercepted":true}}
+{"valid":true,"score":1.0,"pass_rate":1.0,"summary":"…","details":[…],"metrics":{"intercepted":true}}
 >>>>> End Structured Result
 ```
 

--- a/docs/edgebench.md
+++ b/docs/edgebench.md
@@ -64,11 +64,20 @@ image build/hashing.
 
 ## Not covered here (the two open ends)
 
-1. **A browser Agent for SForge.** SForge's built-in agents (`claude-code`,
-   `codex`) are code CLIs. Running a *browser* episode needs either a small
-   `Agent` subclass under `sforge/harness/agent/` (one file + one factory line —
-   an edit to the EdgeBench repo, or an upstream contribution) or a Work-image
-   entrypoint that drives the ClawBench harness and then calls `sforge-submit`.
+1. **A browser Agent for SForge that boots the runtime.** SForge's built-in
+   agents (`claude-code`, `codex`) are code CLIs, and `work.setup_cmds` run at
+   **image-build time** — so the browser runtime + interceptor cannot be started
+   there. Running a *browser* episode needs a small `Agent` subclass under
+   `sforge/harness/agent/` (one file + one factory line — an edit to the
+   EdgeBench repo or an upstream contribution) or a Work-image entrypoint that,
+   at container-run time and **before** the episode:
+   ```bash
+   /app/src/harbor/start-runtime.sh &                 # Chromium + CDP + runtime-server
+   until curl -sf http://127.0.0.1:7878/api/status \
+     | grep -q '"eval_interceptor_ready":true'; do sleep 1; done
+   ```
+   (the adapter already stages `/eval-schema.json`, which the runtime reads to arm
+   the interceptor). It then drives the ClawBench harness and calls `sforge-submit`.
 2. **Container build + a live `sforge run`.** The adapter emits contract-faithful
    task JSON (schema-tested) and the judge is unit-tested offline, but building
    the Work/Judge images and a live end-to-end `sforge run` require Docker + the

--- a/docs/edgebench.md
+++ b/docs/edgebench.md
@@ -55,6 +55,23 @@ The judge prints, and SForge parses:
 >>>>> End Structured Result
 ```
 
+## Evidence trust model
+
+EdgeBench submits an **agent-controlled** archive, so the judge does not trust
+`interception.json`'s `intercepted` flag — it **recomputes Stage-1** by matching
+the submitted request against the task's `eval_schema` (url_pattern + method +
+const body/params, query params derived from the URL), exactly as the runtime
+interceptor does. This rejects the obvious forgeries (wrong URL/method).
+
+For full tamper-resistance (an agent fabricating a *matching* request it never
+made), set `CLAWBENCH_EVIDENCE_SECRET` (shared by the trusted runtime/entrypoint
+and the Judge via `SFORGE_JUDGE_EXTRA_ENV`, **never** given to the agent). The
+runtime/entrypoint then signs each intercepted request —
+`signature = HMAC-SHA256(secret, canonical-json(request))` — and the judge
+rejects unsigned/forged evidence. Without the secret the judge runs in
+attestable mode (recomputed Stage-1 only); with it, only runtime-signed evidence
+passes.
+
 ## What ClawBench supplies vs SForge
 
 ClawBench supplies only the **Judge `eval_cmd`** (`clawbench-edgebench-judge`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ clawbench-batch = "clawbench.runner.batch:main"
 clawbench-rescore = "clawbench.eval.rescore:main"
 clawbench-reproduce = "clawbench.eval.reproduce:main"
 clawbench-harbor-adapt = "clawbench.eval.harbor_adapter:main"
+clawbench-edgebench-adapt = "clawbench.eval.edgebench_adapter:main"
+clawbench-edgebench-judge = "clawbench.eval.edgebench_judge:main"
 clawbench-prorl-submit = "clawbench.prorl.submit:main"
 clawbench-prorl-mock = "clawbench.prorl.mock_gateway:main"
 

--- a/src/clawbench/eval/edgebench_adapter.py
+++ b/src/clawbench/eval/edgebench_adapter.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -27,13 +29,25 @@ import yaml
 
 from clawbench.eval.harbor_adapter import (
     DEFAULT_CASES_DIR,
+    copy_extra_info,
     discover_cases,
-    sanitize_task_name,
 )
-from clawbench.runner.run_support.task import build_instruction
+from clawbench.runner.run_support.task import build_instruction, prepare_personal_info
+from clawbench.utils.paths import SHARED_ROOT
 
 # Default combined runtime image (browser + harness + harbor scripts + verifier).
 DEFAULT_BASE_IMAGE = "clawbench-prorl-openclaw:latest"
+
+# Fixed persona identity for the staged my-info bundle (static benchmark; no live
+# inbox — email-signup tasks are out of scope for the EdgeBench packaging).
+_PERSONA_EMAIL = "alex.green@example.com"
+_PERSONA_PASSWORD = "clawbench-edgebench"  # noqa: S105 (placeholder, not a secret)
+
+
+def sforge_task_id(task_id: str) -> str:
+    """SForge requires lowercase_underscore ids: map every other char to '_'."""
+    sid = re.sub(r"[^a-z0-9_]+", "_", task_id.lower()).strip("_")
+    return re.sub(r"_+", "_", sid) or "task"
 
 
 def benchmark_yaml(base_image: str) -> str:
@@ -74,7 +88,7 @@ def build_task_json(
     eval_timeout: int,
 ) -> dict[str, Any]:
     """Build the SForge task.json (Mapping A) for one ClawBench task."""
-    sforge_id = sanitize_task_name(task_id).replace("-", "_").lower()
+    sforge_id = sforge_task_id(task_id)
     raw_meta = task.get("metadata")
     metadata = raw_meta if isinstance(raw_meta, dict) else {}
     name = str(metadata.get("description") or task.get("instruction") or task_id)[:120]
@@ -95,6 +109,8 @@ def build_task_json(
                 "mkdir -p /app/evidence",
                 "cp /specs/task.json /app/task.json",
                 "cp /specs/eval-schema.json /app/eval-schema.json",
+                # stage the personal-info bundle the instruction references
+                "cp -r /specs/my-info /app/my-info",
             ],
             "specs_dir": "specs",
             "agent_query": edgebench_agent_query(task),
@@ -130,15 +146,18 @@ def write_benchmark(
     (tasks_dir / "BENCHMARK.yaml").write_text(benchmark_yaml(base_image))
 
     written: list[Path] = []
-    seen: set[str] = set()
+    seen: dict[str, str] = {}
     for task_dir, task in cases:
         spec = build_task_json(
             task_dir.name, task, base_image=base_image, eval_timeout=eval_timeout
         )
         sid = spec["task_id"]
         if sid in seen:
-            continue
-        seen.add(sid)
+            raise ValueError(
+                f"sforge task_id collision: {task_dir.name!r} and {seen[sid]!r} "
+                f"both sanitize to {sid!r}"
+            )
+        seen[sid] = task_dir.name
         # per-task specs (copied into both containers at build via specs_dir)
         specs = tasks_dir / sid / "specs"
         specs.mkdir(parents=True, exist_ok=True)
@@ -146,10 +165,27 @@ def write_benchmark(
         (specs / "eval-schema.json").write_text(
             json.dumps(task["eval_schema"], indent=2, ensure_ascii=False)
         )
+        _stage_my_info(task, task_dir, specs / "my-info")
         task_path = tasks_dir / f"{sid}.json"
         task_path.write_text(json.dumps(spec, indent=2, ensure_ascii=False))
         written.append(task_path)
     return written
+
+
+def _stage_my_info(task: dict[str, Any], task_dir: Path, dest: Path) -> None:
+    """Pre-generate the my-info bundle (persona + creds + resume) + extra_info.
+
+    build_instruction() promises ./my-info/ contains these files, so we stage them
+    at adapt time (SForge setup_cmds run at build with no runtime keys). A fixed
+    placeholder persona email is used; email-signup tasks are out of scope.
+    """
+    tmp, _ = prepare_personal_info(
+        SHARED_ROOT, _PERSONA_EMAIL, _PERSONA_PASSWORD, dest.parent
+    )
+    if dest.exists():
+        shutil.rmtree(dest)
+    tmp.rename(dest)
+    copy_extra_info(task, task_dir, dest)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -189,12 +225,16 @@ def main(argv: list[str] | None = None) -> int:
     if not cases:
         print("ERROR: no matching V2 tasks found", file=sys.stderr)
         return 1
-    written = write_benchmark(
-        cases,
-        args.output_dir,
-        base_image=args.base_image,
-        eval_timeout=args.eval_timeout,
-    )
+    try:
+        written = write_benchmark(
+            cases,
+            args.output_dir,
+            base_image=args.base_image,
+            eval_timeout=args.eval_timeout,
+        )
+    except (OSError, ValueError) as e:
+        print(f"ERROR: failed to write benchmark: {e}", file=sys.stderr)
+        return 1
     print(f"Wrote {len(written)} EdgeBench task(s) to {args.output_dir / 'tasks'}")
     return 0
 

--- a/src/clawbench/eval/edgebench_adapter.py
+++ b/src/clawbench/eval/edgebench_adapter.py
@@ -1,0 +1,203 @@
+"""``clawbench-edgebench-adapt`` — export ClawBench V2 tasks as an EdgeBench/SForge benchmark.
+
+Emits a SForge benchmark directory (``tasks/BENCHMARK.yaml`` + ``tasks/<id>.json``)
+that packages each ClawBench task as a two-container SForge task under
+**Mapping A** (structured_json score task, zero SForge source edits):
+
+* the **Work** container runs the ClawBench browser agent + interceptor; the
+  interceptor writes ``evidence/interception.json``; the agent calls
+  ``sforge-submit`` once;
+* the **Judge** container's ``eval_cmd`` is ``clawbench-edgebench-judge`` over the
+  submitted ``evidence/`` → a ``structured_json`` block with ``score``/``valid``.
+
+The short one-shot browser task is run with SForge's long-horizon machinery
+disabled (``--max-submissions 1 --disable-auto-eval --disable-stop-hook``); see
+``docs/edgebench.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from clawbench.eval.harbor_adapter import (
+    DEFAULT_CASES_DIR,
+    discover_cases,
+    sanitize_task_name,
+)
+from clawbench.runner.run_support.task import build_instruction
+
+# Default combined runtime image (browser + harness + harbor scripts + verifier).
+DEFAULT_BASE_IMAGE = "clawbench-prorl-openclaw:latest"
+
+
+def benchmark_yaml(base_image: str) -> str:
+    """The SForge BENCHMARK.yaml: benchmark name + the base-image registry."""
+    doc = {
+        "name": "clawbench",
+        "base_images": {
+            "browser": {
+                "official_image": base_image,
+                "extra_packages": ["git", "curl", "jq"],
+            }
+        },
+    }
+    return yaml.safe_dump(doc, sort_keys=False)
+
+
+def edgebench_agent_query(task: dict[str, Any]) -> str:
+    """The Work-container prompt: the ClawBench instruction + the submit protocol."""
+    instruction = build_instruction(task)
+    return (
+        instruction + "\n\n---\n"
+        "EdgeBench submission protocol:\n"
+        "- Complete the task through the existing Chromium session (CDP on "
+        "http://127.0.0.1:9223); do not launch a separate browser.\n"
+        "- The ClawBench interceptor records the target request to "
+        "`evidence/interception.json` as you act.\n"
+        "- When the task is done, run `sforge-submit` ONCE to submit `evidence/` "
+        "for grading. Your score is the best submission.\n"
+        "---\n"
+    )
+
+
+def build_task_json(
+    task_id: str,
+    task: dict[str, Any],
+    *,
+    base_image: str,
+    eval_timeout: int,
+) -> dict[str, Any]:
+    """Build the SForge task.json (Mapping A) for one ClawBench task."""
+    sforge_id = sanitize_task_name(task_id).replace("-", "_").lower()
+    raw_meta = task.get("metadata")
+    metadata = raw_meta if isinstance(raw_meta, dict) else {}
+    name = str(metadata.get("description") or task.get("instruction") or task_id)[:120]
+    return {
+        "task_id": sforge_id,
+        "name": name,
+        "base_image": "browser",
+        "platform": "linux/amd64",
+        "cwd": "/app",
+        "submit_paths": ["evidence/"],
+        "submit_exclude": ["tests/", "my-info/"],
+        "internet": True,
+        "game_mode": False,
+        "work": {
+            # The combined image already has the browser runtime + harness; setup
+            # seeds the task and prepares the evidence dir.
+            "setup_cmds": [
+                "mkdir -p /app/evidence",
+                "cp /specs/task.json /app/task.json",
+                "cp /specs/eval-schema.json /app/eval-schema.json",
+            ],
+            "specs_dir": "specs",
+            "agent_query": edgebench_agent_query(task),
+        },
+        "judge": {
+            # The judge re-scores the submitted evidence with the ClawBench verifier.
+            "setup_cmds": [
+                "cp /specs/task.json /judge/task.json",
+            ],
+            "specs_dir": "specs",
+            "eval_cmd": (
+                "clawbench-edgebench-judge --task-json /judge/task.json "
+                "--evidence-dir /app/evidence"
+            ),
+            "eval_timeout": eval_timeout,
+            "parser": "structured_json",
+            "score_direction": "maximize",
+            "selection": "score_first",
+        },
+    }
+
+
+def write_benchmark(
+    cases: list[tuple[Path, dict[str, Any]]],
+    output_dir: Path,
+    *,
+    base_image: str,
+    eval_timeout: int,
+) -> list[Path]:
+    """Write BENCHMARK.yaml + per-task JSON + per-task specs; return task-json paths."""
+    tasks_dir = output_dir / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "BENCHMARK.yaml").write_text(benchmark_yaml(base_image))
+
+    written: list[Path] = []
+    seen: set[str] = set()
+    for task_dir, task in cases:
+        spec = build_task_json(
+            task_dir.name, task, base_image=base_image, eval_timeout=eval_timeout
+        )
+        sid = spec["task_id"]
+        if sid in seen:
+            continue
+        seen.add(sid)
+        # per-task specs (copied into both containers at build via specs_dir)
+        specs = tasks_dir / sid / "specs"
+        specs.mkdir(parents=True, exist_ok=True)
+        (specs / "task.json").write_text(json.dumps(task, indent=2, ensure_ascii=False))
+        (specs / "eval-schema.json").write_text(
+            json.dumps(task["eval_schema"], indent=2, ensure_ascii=False)
+        )
+        task_path = tasks_dir / f"{sid}.json"
+        task_path.write_text(json.dumps(spec, indent=2, ensure_ascii=False))
+        written.append(task_path)
+    return written
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="clawbench-edgebench-adapt",
+        description="Export ClawBench V2 tasks as an EdgeBench/SForge benchmark directory.",
+    )
+    p.add_argument(
+        "--output-dir", type=Path, required=True, help="Benchmark output dir"
+    )
+    p.add_argument(
+        "--task-ids", default="", help="Comma-separated task ids (default: all V2)"
+    )
+    p.add_argument(
+        "--cases-dir", type=Path, default=None, help="V2 cases dir (default: bundled)"
+    )
+    p.add_argument(
+        "--base-image", default=DEFAULT_BASE_IMAGE, help="SForge base official_image"
+    )
+    p.add_argument(
+        "--eval-timeout", type=int, default=180, help="Judge eval_timeout (s)"
+    )
+    p.add_argument("--limit", type=int, default=None, help="Cap number of tasks")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cases_dir = (args.cases_dir or DEFAULT_CASES_DIR).resolve()
+    if not cases_dir.exists():
+        print(f"ERROR: cases dir not found: {cases_dir}", file=sys.stderr)
+        return 1
+    requested = {t.strip() for t in args.task_ids.split(",") if t.strip()}
+    cases = discover_cases(cases_dir, requested)
+    if args.limit is not None:
+        cases = cases[: args.limit]
+    if not cases:
+        print("ERROR: no matching V2 tasks found", file=sys.stderr)
+        return 1
+    written = write_benchmark(
+        cases,
+        args.output_dir,
+        base_image=args.base_image,
+        eval_timeout=args.eval_timeout,
+    )
+    print(f"Wrote {len(written)} EdgeBench task(s) to {args.output_dir / 'tasks'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawbench/eval/edgebench_adapter.py
+++ b/src/clawbench/eval/edgebench_adapter.py
@@ -109,6 +109,8 @@ def build_task_json(
                 "mkdir -p /app/evidence",
                 "cp /specs/task.json /app/task.json",
                 "cp /specs/eval-schema.json /app/eval-schema.json",
+                # the runtime-server reads /eval-schema.json to arm the interceptor
+                "cp /specs/eval-schema.json /eval-schema.json",
                 # stage the personal-info bundle the instruction references
                 "cp -r /specs/my-info /app/my-info",
             ],
@@ -172,6 +174,25 @@ def write_benchmark(
     return written
 
 
+def _guard_extra_info(task: dict[str, Any], task_dir: Path) -> None:
+    """Reject extra_info paths that are absolute or escape the task dir.
+
+    harbor_adapter.copy_extra_info joins ``task_dir / item['path']`` with no
+    containment check, so a crafted task could stage arbitrary host files into the
+    shareable benchmark. Fail loud on any such path.
+    """
+    for item in task.get("extra_info") or []:
+        if not isinstance(item, dict) or not item.get("path"):
+            continue
+        rel = str(item["path"])
+        if Path(rel).is_absolute():
+            raise ValueError(f"extra_info path must be relative: {rel!r}")
+        try:
+            (task_dir / rel).resolve().relative_to(task_dir.resolve())
+        except ValueError as e:
+            raise ValueError(f"extra_info path escapes the task dir: {rel!r}") from e
+
+
 def _stage_my_info(task: dict[str, Any], task_dir: Path, dest: Path) -> None:
     """Pre-generate the my-info bundle (persona + creds + resume) + extra_info.
 
@@ -179,6 +200,7 @@ def _stage_my_info(task: dict[str, Any], task_dir: Path, dest: Path) -> None:
     at adapt time (SForge setup_cmds run at build with no runtime keys). A fixed
     placeholder persona email is used; email-signup tasks are out of scope.
     """
+    _guard_extra_info(task, task_dir)
     tmp, _ = prepare_personal_info(
         SHARED_ROOT, _PERSONA_EMAIL, _PERSONA_PASSWORD, dest.parent
     )

--- a/src/clawbench/eval/edgebench_adapter.py
+++ b/src/clawbench/eval/edgebench_adapter.py
@@ -119,7 +119,11 @@ def build_task_json(
         },
         "judge": {
             # The judge re-scores the submitted evidence with the ClawBench verifier.
+            # The judge image must provide the `clawbench-edgebench-judge` console
+            # script — install the package here (a base image that already bundles
+            # it can drop this line).
             "setup_cmds": [
+                "pip install --quiet --no-cache-dir clawbench-eval",
                 "cp /specs/task.json /judge/task.json",
             ],
             "specs_dir": "specs",

--- a/src/clawbench/eval/edgebench_judge.py
+++ b/src/clawbench/eval/edgebench_judge.py
@@ -6,9 +6,11 @@ Judge container: its ``eval_cmd`` reads the evidence, prints a
 
 ClawBench's two-stage reward maps onto this cleanly: the Work-side interceptor
 captures the target request into ``evidence/interception.json``; this module
-(the Judge ``eval_cmd``) re-scores that captured evidence — Stage-1 (was the
-target intercepted) ∧ Stage-2 (LLM judge confirms intent) — and emits the
-structured_json block SForge expects.
+(the Judge ``eval_cmd``) re-scores that captured evidence — Stage-1 ∧ Stage-2 —
+and emits the structured_json block SForge expects. Because the agent controls
+the submitted evidence, Stage-1 is **recomputed** against ``task["eval_schema"]``
+(url_pattern + method + const body/params) rather than trusting the agent's
+``intercepted`` flag; Stage-2 is the LLM judge over the verified request.
 
 Judge config comes from ``CLAWBENCH_JUDGE_*`` env (injected into the Judge
 container via ``SFORGE_JUDGE_EXTRA_ENV``); ``--no-judge`` scores Stage-1 only.
@@ -19,11 +21,56 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 from clawbench.runner.judge import judge_request
+
+
+def _const_fields_match(expected: Any, actual: Any) -> bool:
+    """All key/values in ``expected`` present in ``actual`` (mirrors runtime-server)."""
+    if not expected:
+        return True
+    if not actual:
+        return False
+    if isinstance(actual, list):
+        return any(_const_fields_match(expected, item) for item in actual)
+    if not isinstance(actual, dict):
+        return False
+    return all(actual.get(k) == v for k, v in expected.items())
+
+
+def _stage1_match(request: dict[str, Any], eval_schema: Any) -> bool:
+    """Recompute Stage-1 against the task schema — do NOT trust the agent's flag.
+
+    The agent controls the submitted evidence archive, so re-verify that the
+    submitted request actually hits the task's target (url_pattern regex + method
+    + const body/params), exactly as the runtime interceptor would.
+    """
+    if not isinstance(eval_schema, dict):
+        return False
+    url_pattern = eval_schema.get("url_pattern") or ""
+    if not url_pattern:
+        return False  # no target to verify against → cannot confirm interception
+    url = str(request.get("url") or "")
+    try:
+        if not re.search(url_pattern, url):
+            return False
+    except re.error:
+        return False
+    method = eval_schema.get("method")
+    if method and request.get("method") != method:
+        return False
+    if not _const_fields_match(eval_schema.get("body"), request.get("body")):
+        return False
+    params = request.get("params")
+    if params is None and eval_schema.get("params"):
+        params = {k: v[0] for k, v in parse_qs(urlparse(url).query).items()}
+    return _const_fields_match(eval_schema.get("params"), params)
+
 
 # SForge structured_json markers (grading._grade_structured looks for these).
 START_MARKER = ">>>>> Start Structured Result"
@@ -68,8 +115,9 @@ def score_evidence(
     """Score captured evidence; return an EdgeBench structured_json result dict."""
     instruction = str(task.get("instruction") or "")
     judge_context = task.get("judge_context")
+    eval_schema = task.get("eval_schema")
     intercept = _load_interception(evidence_dir)
-    is_intercept = isinstance(intercept, dict) and intercept.get("intercepted") is True
+    matched = False  # set once we recompute Stage-1 against the schema
 
     def result(
         score: float, valid: bool, summary: str, stage1: str, stage2: str
@@ -83,10 +131,12 @@ def score_evidence(
                 {"name": "stage1-interception", "status": stage1},
                 {"name": "stage2-judge", "status": stage2},
             ],
-            "metrics": {"intercepted": is_intercept},
+            "metrics": {"intercepted": matched},
         }
 
-    # Stage 1 — validate the captured evidence, then check the target was intercepted.
+    # Stage 1 — validate the captured evidence, then RE-VERIFY the target was hit
+    # against task["eval_schema"]. The agent controls the submitted archive, so its
+    # "intercepted" flag is NOT trusted — the request must actually match the target.
     if intercept is _MISSING:
         return result(
             0.0, False, "malformed evidence/interception.json", "ERROR", "SKIPPED"
@@ -99,12 +149,24 @@ def score_evidence(
         return result(
             0.0, False, "interception.json is not an object", "ERROR", "SKIPPED"
         )
-    # require an explicit boolean True (a truthy string like "false" must NOT pass)
-    if intercept.get("intercepted") is not True:
-        return result(0.0, True, "target request not intercepted", "FAILED", "SKIPPED")
-    if not isinstance(intercept.get("request"), dict):
+    request = intercept.get("request")
+    if not isinstance(request, dict):
         return result(
-            0.0, False, "intercepted but no request object", "ERROR", "SKIPPED"
+            0.0, True, "no intercepted request in evidence", "FAILED", "SKIPPED"
+        )
+    if not isinstance(eval_schema, dict) or not eval_schema.get("url_pattern"):
+        # cannot independently verify the target → fail closed
+        return result(
+            0.0, False, "task eval_schema missing url_pattern", "ERROR", "SKIPPED"
+        )
+    matched = _stage1_match(request, eval_schema)
+    if not matched:
+        return result(
+            0.0,
+            True,
+            "submitted request does not match the task target",
+            "FAILED",
+            "SKIPPED",
         )
 
     if no_judge:

--- a/src/clawbench/eval/edgebench_judge.py
+++ b/src/clawbench/eval/edgebench_judge.py
@@ -43,14 +43,18 @@ def _judge_cfg_from_env() -> dict[str, str] | None:
     }
 
 
-def _load_interception(evidence_dir: Path) -> dict[str, Any] | None:
+_MISSING = object()
+
+
+def _load_interception(evidence_dir: Path) -> Any:
+    """Return the parsed interception (any JSON type), None if absent, or _MISSING if unreadable."""
     path = evidence_dir / "interception.json"
     if not path.is_file():
         return None
     try:
         return json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
-        return None
+        return _MISSING
 
 
 def score_evidence(
@@ -65,6 +69,7 @@ def score_evidence(
     instruction = str(task.get("instruction") or "")
     judge_context = task.get("judge_context")
     intercept = _load_interception(evidence_dir)
+    is_intercept = isinstance(intercept, dict) and intercept.get("intercepted") is True
 
     def result(
         score: float, valid: bool, summary: str, stage1: str, stage2: str
@@ -78,19 +83,29 @@ def score_evidence(
                 {"name": "stage1-interception", "status": stage1},
                 {"name": "stage2-judge", "status": stage2},
             ],
-            "metrics": {
-                "intercepted": intercept is not None
-                and bool(intercept.get("intercepted"))
-            },
+            "metrics": {"intercepted": is_intercept},
         }
 
-    # Stage 1 — was the target request intercepted?
+    # Stage 1 — validate the captured evidence, then check the target was intercepted.
+    if intercept is _MISSING:
+        return result(
+            0.0, False, "malformed evidence/interception.json", "ERROR", "SKIPPED"
+        )
     if intercept is None:
         return result(
             0.0, True, "no evidence/interception.json found", "FAILED", "SKIPPED"
         )
-    if not intercept.get("intercepted"):
+    if not isinstance(intercept, dict):
+        return result(
+            0.0, False, "interception.json is not an object", "ERROR", "SKIPPED"
+        )
+    # require an explicit boolean True (a truthy string like "false" must NOT pass)
+    if intercept.get("intercepted") is not True:
         return result(0.0, True, "target request not intercepted", "FAILED", "SKIPPED")
+    if not isinstance(intercept.get("request"), dict):
+        return result(
+            0.0, False, "intercepted but no request object", "ERROR", "SKIPPED"
+        )
 
     if no_judge:
         return result(
@@ -111,13 +126,19 @@ def score_evidence(
             "PASSED",
             "ERROR",
         )
-    verdict = judge_request(
-        judge_cfg, judge_model, instruction, intercept, judge_context=judge_context
-    )
+    try:
+        verdict = judge_request(
+            judge_cfg, judge_model, instruction, intercept, judge_context=judge_context
+        )
+    except Exception:
+        # Never let a judge/transport exception suppress the structured_json block;
+        # fail closed with a category (not the raw error, which may carry secrets).
+        return result(0.0, False, "judge call raised an exception", "PASSED", "ERROR")
     match = verdict.get("match")
     reason = str(verdict.get("reason") or "")
     if verdict.get("error"):
-        return result(0.0, False, f"judge error: {verdict['error']}", "PASSED", "ERROR")
+        # judge_request returns a short error category; don't echo raw provider text.
+        return result(0.0, False, "judge call failed", "PASSED", "ERROR")
     if match is True:
         return result(1.0, True, reason or "judge: match", "PASSED", "PASSED")
     return result(0.0, True, reason or "judge: mismatch", "PASSED", "FAILED")

--- a/src/clawbench/eval/edgebench_judge.py
+++ b/src/clawbench/eval/edgebench_judge.py
@@ -19,6 +19,8 @@ container via ``SFORGE_JUDGE_EXTRA_ENV``); ``--no-judge`` scores Stage-1 only.
 from __future__ import annotations
 
 import argparse
+import hashlib
+import hmac
 import json
 import os
 import re
@@ -28,6 +30,26 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from clawbench.runner.judge import judge_request
+
+
+def _verify_signature(intercept: dict[str, Any], secret: str) -> bool:
+    """Verify a runtime-produced HMAC over the intercepted request.
+
+    EdgeBench submits an agent-controlled archive, so Stage-1 evidence is only
+    tamper-proof if the *trusted* runtime/entrypoint signs it with a secret the
+    agent never sees (shared with the judge via ``SFORGE_JUDGE_EXTRA_ENV``). When
+    ``CLAWBENCH_EVIDENCE_SECRET`` is set, the judge requires a valid
+    ``signature = HMAC-SHA256(secret, canonical-json(request))`` and rejects
+    forged/unsigned evidence.
+    """
+    sig = intercept.get("signature")
+    if not isinstance(sig, str):
+        return False
+    payload = json.dumps(
+        intercept.get("request"), sort_keys=True, separators=(",", ":")
+    ).encode()
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(sig, expected)
 
 
 def _const_fields_match(expected: Any, actual: Any) -> bool:
@@ -66,9 +88,9 @@ def _stage1_match(request: dict[str, Any], eval_schema: Any) -> bool:
         return False
     if not _const_fields_match(eval_schema.get("body"), request.get("body")):
         return False
-    params = request.get("params")
-    if params is None and eval_schema.get("params"):
-        params = {k: v[0] for k, v in parse_qs(urlparse(url).query).items()}
+    # Always derive query params from the URL (like the runtime interceptor) — do
+    # not trust a submitted request["params"] field, which could be forged.
+    params = {k: v[0] for k, v in parse_qs(urlparse(url).query).items()}
     return _const_fields_match(eval_schema.get("params"), params)
 
 
@@ -153,6 +175,13 @@ def score_evidence(
     if not isinstance(request, dict):
         return result(
             0.0, True, "no intercepted request in evidence", "FAILED", "SKIPPED"
+        )
+    # Tamper-resistance: if a shared runtime/judge secret is configured, only
+    # accept evidence the trusted runtime signed (the agent cannot forge it).
+    secret = os.environ.get("CLAWBENCH_EVIDENCE_SECRET", "").strip()
+    if secret and not _verify_signature(intercept, secret):
+        return result(
+            0.0, False, "evidence signature missing or invalid", "ERROR", "SKIPPED"
         )
     if not isinstance(eval_schema, dict) or not eval_schema.get("url_pattern"):
         # cannot independently verify the target → fail closed

--- a/src/clawbench/eval/edgebench_judge.py
+++ b/src/clawbench/eval/edgebench_judge.py
@@ -1,0 +1,181 @@
+"""``clawbench-edgebench-judge`` — score ClawBench evidence as EdgeBench structured_json.
+
+EdgeBench (SForge) judges an agent's *submitted archive* offline in an ephemeral
+Judge container: its ``eval_cmd`` reads the evidence, prints a
+``structured_json`` block, and SForge parses the ``score``/``valid`` from it.
+
+ClawBench's two-stage reward maps onto this cleanly: the Work-side interceptor
+captures the target request into ``evidence/interception.json``; this module
+(the Judge ``eval_cmd``) re-scores that captured evidence — Stage-1 (was the
+target intercepted) ∧ Stage-2 (LLM judge confirms intent) — and emits the
+structured_json block SForge expects.
+
+Judge config comes from ``CLAWBENCH_JUDGE_*`` env (injected into the Judge
+container via ``SFORGE_JUDGE_EXTRA_ENV``); ``--no-judge`` scores Stage-1 only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from clawbench.runner.judge import judge_request
+
+# SForge structured_json markers (grading._grade_structured looks for these).
+START_MARKER = ">>>>> Start Structured Result"
+END_MARKER = ">>>>> End Structured Result"
+
+
+def _judge_cfg_from_env() -> dict[str, str] | None:
+    """Build the judge model config from CLAWBENCH_JUDGE_* env, or None if unset."""
+    base_url = os.environ.get("CLAWBENCH_JUDGE_BASE_URL", "").strip()
+    api_key = os.environ.get("CLAWBENCH_JUDGE_API_KEY", "").strip()
+    if not base_url or not api_key:
+        return None
+    return {
+        "base_url": base_url,
+        "api_key": api_key,
+        "api_type": os.environ.get("CLAWBENCH_JUDGE_API_TYPE", "openai-completions"),
+    }
+
+
+def _load_interception(evidence_dir: Path) -> dict[str, Any] | None:
+    path = evidence_dir / "interception.json"
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def score_evidence(
+    task: dict[str, Any],
+    evidence_dir: Path,
+    *,
+    judge_cfg: dict[str, str] | None,
+    judge_model: str,
+    no_judge: bool = False,
+) -> dict[str, Any]:
+    """Score captured evidence; return an EdgeBench structured_json result dict."""
+    instruction = str(task.get("instruction") or "")
+    judge_context = task.get("judge_context")
+    intercept = _load_interception(evidence_dir)
+
+    def result(
+        score: float, valid: bool, summary: str, stage1: str, stage2: str
+    ) -> dict[str, Any]:
+        return {
+            "valid": valid,
+            "score": float(score),
+            "pass_rate": float(score),
+            "summary": summary[:4096],
+            "details": [
+                {"name": "stage1-interception", "status": stage1},
+                {"name": "stage2-judge", "status": stage2},
+            ],
+            "metrics": {
+                "intercepted": intercept is not None
+                and bool(intercept.get("intercepted"))
+            },
+        }
+
+    # Stage 1 — was the target request intercepted?
+    if intercept is None:
+        return result(
+            0.0, True, "no evidence/interception.json found", "FAILED", "SKIPPED"
+        )
+    if not intercept.get("intercepted"):
+        return result(0.0, True, "target request not intercepted", "FAILED", "SKIPPED")
+
+    if no_judge:
+        return result(
+            1.0,
+            True,
+            "intercepted (Stage-1 only, judging disabled)",
+            "PASSED",
+            "SKIPPED",
+        )
+
+    # Stage 2 — LLM judge confirms the intercepted request fulfils the instruction.
+    if judge_cfg is None:
+        # Judging required but unconfigured: fail closed (never silently pass).
+        return result(
+            0.0,
+            False,
+            "judge required but CLAWBENCH_JUDGE_* unconfigured",
+            "PASSED",
+            "ERROR",
+        )
+    verdict = judge_request(
+        judge_cfg, judge_model, instruction, intercept, judge_context=judge_context
+    )
+    match = verdict.get("match")
+    reason = str(verdict.get("reason") or "")
+    if verdict.get("error"):
+        return result(0.0, False, f"judge error: {verdict['error']}", "PASSED", "ERROR")
+    if match is True:
+        return result(1.0, True, reason or "judge: match", "PASSED", "PASSED")
+    return result(0.0, True, reason or "judge: mismatch", "PASSED", "FAILED")
+
+
+def emit_structured_json(result: dict[str, Any]) -> str:
+    """Wrap a result dict in the SForge structured_json markers."""
+    return f"{START_MARKER}\n{json.dumps(result, ensure_ascii=False)}\n{END_MARKER}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="clawbench-edgebench-judge",
+        description="Score ClawBench evidence and print an EdgeBench structured_json block.",
+    )
+    p.add_argument(
+        "--task-json",
+        type=Path,
+        required=True,
+        help="Task JSON (instruction + judge_context)",
+    )
+    p.add_argument(
+        "--evidence-dir",
+        type=Path,
+        required=True,
+        help="Submitted evidence dir (has interception.json)",
+    )
+    p.add_argument(
+        "--judge-model",
+        default=None,
+        help="Judge model name (else CLAWBENCH_JUDGE_MODEL env)",
+    )
+    p.add_argument(
+        "--no-judge", action="store_true", help="Score Stage-1 (interception) only"
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        task = json.loads(args.task_json.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"ERROR: cannot read task json: {e}", file=sys.stderr)
+        return 1
+    judge_model = args.judge_model or os.environ.get(
+        "CLAWBENCH_JUDGE_MODEL", "deepseek-v4-pro"
+    )
+    result = score_evidence(
+        task,
+        args.evidence_dir,
+        judge_cfg=_judge_cfg_from_env(),
+        judge_model=judge_model,
+        no_judge=args.no_judge,
+    )
+    print(emit_structured_json(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawbench/eval/edgebench_judge.py
+++ b/src/clawbench/eval/edgebench_judge.py
@@ -135,13 +135,18 @@ def score_evidence(
         # fail closed with a category (not the raw error, which may carry secrets).
         return result(0.0, False, "judge call raised an exception", "PASSED", "ERROR")
     match = verdict.get("match")
-    reason = str(verdict.get("reason") or "")
     if verdict.get("error"):
         # judge_request returns a short error category; don't echo raw provider text.
         return result(0.0, False, "judge call failed", "PASSED", "ERROR")
+    # Use generic summaries — the judge's free-text reason quotes the intercepted
+    # request body, which can contain credentials/PII; never echo it to SForge output.
     if match is True:
-        return result(1.0, True, reason or "judge: match", "PASSED", "PASSED")
-    return result(0.0, True, reason or "judge: mismatch", "PASSED", "FAILED")
+        return result(
+            1.0, True, "intercepted request fulfils the task", "PASSED", "PASSED"
+        )
+    return result(
+        0.0, True, "intercepted request does not fulfil the task", "PASSED", "FAILED"
+    )
 
 
 def emit_structured_json(result: dict[str, Any]) -> str:

--- a/tests/test_edgebench_adapter.py
+++ b/tests/test_edgebench_adapter.py
@@ -111,3 +111,19 @@ def test_eval_schema_staged_for_runtime(one_case) -> None:
     spec = ea.build_task_json(task_dir.name, task, base_image="img", eval_timeout=180)
     # the runtime-server reads /eval-schema.json to arm the interceptor
     assert any("/eval-schema.json" in c for c in spec["work"]["setup_cmds"])
+
+
+def test_judge_image_installs_clawbench(one_case) -> None:
+    task_dir, task = one_case
+    spec = ea.build_task_json(task_dir.name, task, base_image="img", eval_timeout=180)
+    # the eval_cmd needs the clawbench-edgebench-judge console script present
+    assert any("clawbench-eval" in c for c in spec["judge"]["setup_cmds"])
+
+
+def test_evidence_dir_consistent(one_case) -> None:
+    task_dir, task = one_case
+    spec = ea.build_task_json(task_dir.name, task, base_image="img", eval_timeout=180)
+    # submit_paths and the judge --evidence-dir must reference the same dir
+    submit = spec["submit_paths"][0].rstrip("/").split("/")[-1]
+    assert submit == "evidence"
+    assert f"--evidence-dir /app/{submit}" in spec["judge"]["eval_cmd"]

--- a/tests/test_edgebench_adapter.py
+++ b/tests/test_edgebench_adapter.py
@@ -102,7 +102,9 @@ def test_duplicate_ids_raise(one_case, tmp_path: Path) -> None:
 def test_extra_info_path_traversal_rejected(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="escapes"):
         ea._guard_extra_info({"extra_info": [{"path": "../../etc/passwd"}]}, tmp_path)
-    with pytest.raises(ValueError, match="relative"):
+    # "/etc/passwd" is absolute on POSIX ("relative" error) but not on Windows
+    # (no drive), where it's caught as an escape — either way it's rejected.
+    with pytest.raises(ValueError, match="relative|escapes"):
         ea._guard_extra_info({"extra_info": [{"path": "/etc/passwd"}]}, tmp_path)
 
 

--- a/tests/test_edgebench_adapter.py
+++ b/tests/test_edgebench_adapter.py
@@ -1,0 +1,67 @@
+"""Tests for the EdgeBench/SForge benchmark exporter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from clawbench.eval import edgebench_adapter as ea
+from clawbench.eval.harbor_adapter import DEFAULT_CASES_DIR, discover_cases
+
+
+@pytest.fixture(scope="module")
+def one_case():
+    cases = discover_cases(DEFAULT_CASES_DIR)
+    if not cases:
+        pytest.skip("no bundled V2 cases")
+    return cases[0]
+
+
+def test_benchmark_yaml_valid() -> None:
+    doc = yaml.safe_load(ea.benchmark_yaml("clawbench-prorl-openclaw:latest"))
+    assert doc["name"] == "clawbench"
+    assert (
+        doc["base_images"]["browser"]["official_image"]
+        == "clawbench-prorl-openclaw:latest"
+    )
+
+
+def test_task_json_schema(one_case) -> None:
+    task_dir, task = one_case
+    spec = ea.build_task_json(task_dir.name, task, base_image="img", eval_timeout=180)
+    # SForge contract fields
+    assert spec["base_image"] == "browser"
+    assert spec["cwd"] == "/app"
+    assert spec["submit_paths"] == ["evidence/"]
+    assert spec["game_mode"] is False
+    # task_id is lowercase_underscore
+    assert spec["task_id"] == spec["task_id"].lower()
+    assert "-" not in spec["task_id"]
+    # judge -> structured_json, maximize, score_first, calls our judge
+    j = spec["judge"]
+    assert j["parser"] == "structured_json"
+    assert j["score_direction"] == "maximize"
+    assert j["selection"] == "score_first"
+    assert "clawbench-edgebench-judge" in j["eval_cmd"]
+    assert "/app/evidence" in j["eval_cmd"]
+    # work prompt tells the agent to submit evidence once
+    assert "sforge-submit" in spec["work"]["agent_query"]
+    assert "evidence/interception.json" in spec["work"]["agent_query"]
+
+
+def test_write_benchmark_layout(one_case, tmp_path: Path) -> None:
+    task_dir, task = one_case
+    written = ea.write_benchmark(
+        [(task_dir, task)], tmp_path, base_image="img", eval_timeout=180
+    )
+    tasks_dir = tmp_path / "tasks"
+    assert (tasks_dir / "BENCHMARK.yaml").is_file()
+    assert len(written) == 1
+    spec = json.loads(written[0].read_text())
+    sid = spec["task_id"]
+    # per-task specs staged for both containers
+    assert (tasks_dir / sid / "specs" / "task.json").is_file()
+    assert (tasks_dir / sid / "specs" / "eval-schema.json").is_file()

--- a/tests/test_edgebench_adapter.py
+++ b/tests/test_edgebench_adapter.py
@@ -97,3 +97,17 @@ def test_duplicate_ids_raise(one_case, tmp_path: Path) -> None:
             base_image="img",
             eval_timeout=180,
         )
+
+
+def test_extra_info_path_traversal_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes"):
+        ea._guard_extra_info({"extra_info": [{"path": "../../etc/passwd"}]}, tmp_path)
+    with pytest.raises(ValueError, match="relative"):
+        ea._guard_extra_info({"extra_info": [{"path": "/etc/passwd"}]}, tmp_path)
+
+
+def test_eval_schema_staged_for_runtime(one_case) -> None:
+    task_dir, task = one_case
+    spec = ea.build_task_json(task_dir.name, task, base_image="img", eval_timeout=180)
+    # the runtime-server reads /eval-schema.json to arm the interceptor
+    assert any("/eval-schema.json" in c for c in spec["work"]["setup_cmds"])

--- a/tests/test_edgebench_adapter.py
+++ b/tests/test_edgebench_adapter.py
@@ -65,3 +65,35 @@ def test_write_benchmark_layout(one_case, tmp_path: Path) -> None:
     # per-task specs staged for both containers
     assert (tasks_dir / sid / "specs" / "task.json").is_file()
     assert (tasks_dir / sid / "specs" / "eval-schema.json").is_file()
+    # the my-info bundle the instruction promises is staged
+    myinfo = tasks_dir / sid / "specs" / "my-info"
+    assert (myinfo / "alex_green_personal_info.json").is_file()
+    assert (myinfo / "email_credentials.json").is_file()
+    # no judge/agent secret leaks into the emitted task JSON
+    assert "CLAWBENCH_JUDGE" not in written[0].read_text()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("v2-608-Foo.Bar", "v2_608_foo_bar"),
+        ("A..B--C", "a_b_c"),
+        ("__weird__", "weird"),
+    ],
+)
+def test_sforge_task_id_sanitization(raw: str, expected: str) -> None:
+    sid = ea.sforge_task_id(raw)
+    assert sid == expected
+    assert __import__("re").fullmatch(r"[a-z0-9_]+", sid)
+
+
+def test_duplicate_ids_raise(one_case, tmp_path: Path) -> None:
+    task_dir, task = one_case
+    # two source dirs that sanitize to the same id → collision must raise
+    with pytest.raises(ValueError, match="collision"):
+        ea.write_benchmark(
+            [(task_dir, task), (task_dir, task)],
+            tmp_path,
+            base_image="img",
+            eval_timeout=180,
+        )

--- a/tests/test_edgebench_judge.py
+++ b/tests/test_edgebench_judge.py
@@ -1,0 +1,101 @@
+"""Tests for the EdgeBench structured_json judge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from clawbench.eval import edgebench_judge as ej
+
+TASK = {"instruction": "Save the recipe", "judge_context": {"rubric": "must save"}}
+JUDGE_CFG = {
+    "base_url": "https://j.example/v1",
+    "api_key": "k",
+    "api_type": "openai-completions",
+}
+
+
+def _evidence(tmp_path: Path, payload: dict | None) -> Path:
+    d = tmp_path / "evidence"
+    d.mkdir()
+    if payload is not None:
+        (d / "interception.json").write_text(json.dumps(payload))
+    return d
+
+
+def test_no_evidence_scores_zero(tmp_path: Path) -> None:
+    r = ej.score_evidence(
+        TASK, _evidence(tmp_path, None), judge_cfg=JUDGE_CFG, judge_model="j"
+    )
+    assert r["score"] == 0.0 and r["valid"] is True
+    assert r["details"][0] == {"name": "stage1-interception", "status": "FAILED"}
+
+
+def test_not_intercepted_scores_zero(tmp_path: Path) -> None:
+    r = ej.score_evidence(
+        TASK,
+        _evidence(tmp_path, {"intercepted": False}),
+        judge_cfg=JUDGE_CFG,
+        judge_model="j",
+    )
+    assert r["score"] == 0.0
+    assert r["metrics"]["intercepted"] is False
+
+
+def test_intercepted_no_judge_scores_one(tmp_path: Path) -> None:
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j", no_judge=True)
+    assert r["score"] == 1.0
+    assert r["details"][0]["status"] == "PASSED"
+
+
+def test_intercepted_judge_match(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        ej, "judge_request", lambda *a, **k: {"match": True, "reason": "ok"}
+    )
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    assert r["score"] == 1.0 and r["valid"] is True
+    assert [d["status"] for d in r["details"]] == ["PASSED", "PASSED"]
+
+
+def test_intercepted_judge_mismatch(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        ej, "judge_request", lambda *a, **k: {"match": False, "reason": "nope"}
+    )
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    assert r["score"] == 0.0 and r["details"][1]["status"] == "FAILED"
+
+
+def test_judge_required_but_unconfigured_fails_closed(tmp_path: Path) -> None:
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=None, judge_model="j")
+    assert r["score"] == 0.0 and r["valid"] is False  # never silently pass
+
+
+def test_emit_structured_json_round_trips() -> None:
+    r = {"valid": True, "score": 1.0, "summary": "s", "details": [], "metrics": {}}
+    out = ej.emit_structured_json(r)
+    assert out.startswith(ej.START_MARKER) and out.rstrip().endswith(ej.END_MARKER)
+    body = out.split(ej.START_MARKER, 1)[1].rsplit(ej.END_MARKER, 1)[0].strip()
+    assert json.loads(body)["score"] == 1.0
+
+
+def test_cli_main_prints_structured_block(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setattr(
+        ej, "judge_request", lambda *a, **k: {"match": True, "reason": "ok"}
+    )
+    monkeypatch.setenv("CLAWBENCH_JUDGE_BASE_URL", "https://j.example/v1")
+    monkeypatch.setenv("CLAWBENCH_JUDGE_API_KEY", "k")
+    tj = tmp_path / "task.json"
+    tj.write_text(json.dumps(TASK))
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    rc = ej.main(
+        ["--task-json", str(tj), "--evidence-dir", str(ev), "--judge-model", "j"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert ej.START_MARKER in out
+    body = out.split(ej.START_MARKER, 1)[1].rsplit(ej.END_MARKER, 1)[0].strip()
+    assert json.loads(body)["score"] == 1.0

--- a/tests/test_edgebench_judge.py
+++ b/tests/test_edgebench_judge.py
@@ -125,6 +125,18 @@ def test_judge_error_verdict_sanitized(monkeypatch, tmp_path: Path) -> None:
     assert r["score"] == 0.0 and "SECRET" not in json.dumps(r)
 
 
+def test_judge_reason_not_echoed_to_output(monkeypatch, tmp_path: Path) -> None:
+    # the judge reason quotes the request body (may hold creds/PII) — must not leak
+    monkeypatch.setattr(
+        ej,
+        "judge_request",
+        lambda *a, **k: {"match": True, "reason": "body had password=SECRET123"},
+    )
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    assert r["score"] == 1.0 and "SECRET123" not in json.dumps(r)
+
+
 def test_emit_structured_json_round_trips() -> None:
     r = {"valid": True, "score": 1.0, "summary": "s", "details": [], "metrics": {}}
     out = ej.emit_structured_json(r)

--- a/tests/test_edgebench_judge.py
+++ b/tests/test_edgebench_judge.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 from pathlib import Path
 
 from clawbench.eval import edgebench_judge as ej
+
+
+def _sign(request, secret: str) -> str:
+    payload = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+    return hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
 
 TASK = {
     "instruction": "Save the recipe",
@@ -25,7 +33,7 @@ BAD_REQ = {"url": "https://other.example/nope", "method": "GET"}
 
 def _evidence(tmp_path: Path, payload) -> Path:
     d = tmp_path / "evidence"
-    d.mkdir()
+    d.mkdir(parents=True, exist_ok=True)
     if payload is not None:
         (d / "interception.json").write_text(json.dumps(payload))
     return d
@@ -156,6 +164,53 @@ def test_judge_reason_not_echoed_to_output(monkeypatch, tmp_path: Path) -> None:
     )
     r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ})
     assert r["score"] == 1.0 and "SECRET123" not in json.dumps(r)
+
+
+def test_signature_enforced_when_secret_set(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CLAWBENCH_EVIDENCE_SECRET", "s3cr3t")
+    # unsigned evidence is rejected when a secret is configured
+    unsig = ej.score_evidence(
+        TASK,
+        _evidence(tmp_path / "u", {"intercepted": True, "request": GOOD_REQ}),
+        judge_cfg=JUDGE_CFG,
+        judge_model="j",
+        no_judge=True,
+    )
+    assert unsig["score"] == 0.0 and unsig["valid"] is False
+    # correctly runtime-signed evidence passes
+    payload = {
+        "intercepted": True,
+        "request": GOOD_REQ,
+        "signature": _sign(GOOD_REQ, "s3cr3t"),
+    }
+    signed = ej.score_evidence(
+        TASK,
+        _evidence(tmp_path / "s", payload),
+        judge_cfg=JUDGE_CFG,
+        judge_model="j",
+        no_judge=True,
+    )
+    assert signed["score"] == 1.0
+
+
+def test_no_signature_required_without_secret(tmp_path: Path) -> None:
+    # backward-compat: without the secret, evidence is accepted (attestable mode)
+    r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ}, no_judge=True)
+    assert r["score"] == 1.0
+
+
+def test_params_derived_from_url_not_field() -> None:
+    schema = {"url_pattern": r"t\.ex/hit", "params": {"id": "5"}}
+    # forged params field says id=5, but the URL query says id=6 → must FAIL
+    assert (
+        ej._stage1_match(
+            {"url": "https://t.ex/hit?id=6", "method": "GET", "params": {"id": "5"}},
+            schema,
+        )
+        is False
+    )
+    # URL query genuinely id=5 → passes
+    assert ej._stage1_match({"url": "https://t.ex/hit?id=5"}, schema) is True
 
 
 def test_const_fields_match_body() -> None:

--- a/tests/test_edgebench_judge.py
+++ b/tests/test_edgebench_judge.py
@@ -74,6 +74,57 @@ def test_judge_required_but_unconfigured_fails_closed(tmp_path: Path) -> None:
     assert r["score"] == 0.0 and r["valid"] is False  # never silently pass
 
 
+def test_malformed_evidence_is_invalid(tmp_path: Path) -> None:
+    d = tmp_path / "evidence"
+    d.mkdir()
+    (d / "interception.json").write_text("not json {{{")
+    r = ej.score_evidence(TASK, d, judge_cfg=JUDGE_CFG, judge_model="j")
+    assert r["score"] == 0.0 and r["valid"] is False
+
+
+def test_non_object_evidence_is_invalid(tmp_path: Path) -> None:
+    r = ej.score_evidence(
+        TASK, _evidence(tmp_path, ["a", "b"]), judge_cfg=JUDGE_CFG, judge_model="j"
+    )
+    assert r["score"] == 0.0 and r["valid"] is False
+
+
+def test_string_false_does_not_pass_stage1(tmp_path: Path) -> None:
+    # "intercepted": "false" (truthy string) must NOT count as intercepted
+    ev = _evidence(tmp_path, {"intercepted": "false", "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j", no_judge=True)
+    assert r["score"] == 0.0
+    assert r["metrics"]["intercepted"] is False
+
+
+def test_intercepted_without_request_is_invalid(tmp_path: Path) -> None:
+    ev = _evidence(tmp_path, {"intercepted": True})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    assert r["score"] == 0.0 and r["valid"] is False
+
+
+def test_judge_exception_fails_closed_and_hides_error(
+    monkeypatch, tmp_path: Path
+) -> None:
+    def boom(*a, **k):
+        raise RuntimeError("secret-key-abc123 leaked in exception")
+
+    monkeypatch.setattr(ej, "judge_request", boom)
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    assert r["score"] == 0.0 and r["valid"] is False
+    assert "secret-key-abc123" not in json.dumps(r)  # raw error not echoed
+
+
+def test_judge_error_verdict_sanitized(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        ej, "judge_request", lambda *a, **k: {"error": "http://provider/key=SECRET"}
+    )
+    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    assert r["score"] == 0.0 and "SECRET" not in json.dumps(r)
+
+
 def test_emit_structured_json_round_trips() -> None:
     r = {"valid": True, "score": 1.0, "summary": "s", "details": [], "metrics": {}}
     out = ej.emit_structured_json(r)

--- a/tests/test_edgebench_judge.py
+++ b/tests/test_edgebench_judge.py
@@ -7,15 +7,23 @@ from pathlib import Path
 
 from clawbench.eval import edgebench_judge as ej
 
-TASK = {"instruction": "Save the recipe", "judge_context": {"rubric": "must save"}}
+TASK = {
+    "instruction": "Save the recipe",
+    "judge_context": {"rubric": "must save"},
+    "eval_schema": {"url_pattern": r"target\.example/hit", "method": "GET"},
+}
 JUDGE_CFG = {
     "base_url": "https://j.example/v1",
     "api_key": "k",
     "api_type": "openai-completions",
 }
+# a request that actually hits the task target (passes recomputed Stage-1)
+GOOD_REQ = {"url": "https://target.example/hit/123", "method": "GET"}
+# a request that does NOT match the target (forged / wrong)
+BAD_REQ = {"url": "https://other.example/nope", "method": "GET"}
 
 
-def _evidence(tmp_path: Path, payload: dict | None) -> Path:
+def _evidence(tmp_path: Path, payload) -> Path:
     d = tmp_path / "evidence"
     d.mkdir()
     if payload is not None:
@@ -23,55 +31,88 @@ def _evidence(tmp_path: Path, payload: dict | None) -> Path:
     return d
 
 
-def test_no_evidence_scores_zero(tmp_path: Path) -> None:
-    r = ej.score_evidence(
-        TASK, _evidence(tmp_path, None), judge_cfg=JUDGE_CFG, judge_model="j"
+def _score(tmp_path, payload, **kw):
+    return ej.score_evidence(
+        TASK, _evidence(tmp_path, payload), judge_cfg=JUDGE_CFG, judge_model="j", **kw
     )
+
+
+def test_no_evidence_scores_zero(tmp_path: Path) -> None:
+    r = _score(tmp_path, None)
     assert r["score"] == 0.0 and r["valid"] is True
     assert r["details"][0] == {"name": "stage1-interception", "status": "FAILED"}
 
 
-def test_not_intercepted_scores_zero(tmp_path: Path) -> None:
-    r = ej.score_evidence(
-        TASK,
-        _evidence(tmp_path, {"intercepted": False}),
-        judge_cfg=JUDGE_CFG,
-        judge_model="j",
+def test_no_request_scores_zero(tmp_path: Path) -> None:
+    r = _score(tmp_path, {"intercepted": False})
+    assert r["score"] == 0.0 and r["metrics"]["intercepted"] is False
+
+
+def test_matching_request_passes_stage1_flag_ignored(tmp_path: Path) -> None:
+    # "intercepted":"false" is IGNORED — Stage-1 is recomputed from the request,
+    # which matches the schema, so it passes.
+    r = _score(tmp_path, {"intercepted": "false", "request": GOOD_REQ}, no_judge=True)
+    assert r["score"] == 1.0 and r["metrics"]["intercepted"] is True
+
+
+def test_forged_nonmatching_request_fails(tmp_path: Path) -> None:
+    # agent claims intercepted with a request that does NOT hit the target → fail
+    r = _score(tmp_path, {"intercepted": True, "request": BAD_REQ})
+    assert r["score"] == 0.0
+    assert (
+        r["details"][0]["status"] == "FAILED" and r["metrics"]["intercepted"] is False
+    )
+
+
+def test_wrong_method_fails(tmp_path: Path) -> None:
+    r = _score(
+        tmp_path, {"intercepted": True, "request": {**GOOD_REQ, "method": "POST"}}
     )
     assert r["score"] == 0.0
-    assert r["metrics"]["intercepted"] is False
 
 
 def test_intercepted_no_judge_scores_one(tmp_path: Path) -> None:
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j", no_judge=True)
-    assert r["score"] == 1.0
-    assert r["details"][0]["status"] == "PASSED"
+    r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ}, no_judge=True)
+    assert r["score"] == 1.0 and r["details"][0]["status"] == "PASSED"
 
 
 def test_intercepted_judge_match(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         ej, "judge_request", lambda *a, **k: {"match": True, "reason": "ok"}
     )
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
-    assert r["score"] == 1.0 and r["valid"] is True
-    assert [d["status"] for d in r["details"]] == ["PASSED", "PASSED"]
+    r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ})
+    assert r["score"] == 1.0 and [d["status"] for d in r["details"]] == [
+        "PASSED",
+        "PASSED",
+    ]
 
 
 def test_intercepted_judge_mismatch(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
-        ej, "judge_request", lambda *a, **k: {"match": False, "reason": "nope"}
+        ej, "judge_request", lambda *a, **k: {"match": False, "reason": "no"}
     )
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ})
     assert r["score"] == 0.0 and r["details"][1]["status"] == "FAILED"
 
 
 def test_judge_required_but_unconfigured_fails_closed(tmp_path: Path) -> None:
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=None, judge_model="j")
-    assert r["score"] == 0.0 and r["valid"] is False  # never silently pass
+    r = ej.score_evidence(
+        TASK,
+        _evidence(tmp_path, {"intercepted": True, "request": GOOD_REQ}),
+        judge_cfg=None,
+        judge_model="j",
+    )
+    assert r["score"] == 0.0 and r["valid"] is False
+
+
+def test_missing_eval_schema_fails_closed(tmp_path: Path) -> None:
+    r = ej.score_evidence(
+        {"instruction": "x"},  # no eval_schema
+        _evidence(tmp_path, {"intercepted": True, "request": GOOD_REQ}),
+        judge_cfg=JUDGE_CFG,
+        judge_model="j",
+    )
+    assert r["score"] == 0.0 and r["valid"] is False
 
 
 def test_malformed_evidence_is_invalid(tmp_path: Path) -> None:
@@ -83,23 +124,7 @@ def test_malformed_evidence_is_invalid(tmp_path: Path) -> None:
 
 
 def test_non_object_evidence_is_invalid(tmp_path: Path) -> None:
-    r = ej.score_evidence(
-        TASK, _evidence(tmp_path, ["a", "b"]), judge_cfg=JUDGE_CFG, judge_model="j"
-    )
-    assert r["score"] == 0.0 and r["valid"] is False
-
-
-def test_string_false_does_not_pass_stage1(tmp_path: Path) -> None:
-    # "intercepted": "false" (truthy string) must NOT count as intercepted
-    ev = _evidence(tmp_path, {"intercepted": "false", "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j", no_judge=True)
-    assert r["score"] == 0.0
-    assert r["metrics"]["intercepted"] is False
-
-
-def test_intercepted_without_request_is_invalid(tmp_path: Path) -> None:
-    ev = _evidence(tmp_path, {"intercepted": True})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    r = _score(tmp_path, ["a", "b"])
     assert r["score"] == 0.0 and r["valid"] is False
 
 
@@ -107,39 +132,50 @@ def test_judge_exception_fails_closed_and_hides_error(
     monkeypatch, tmp_path: Path
 ) -> None:
     def boom(*a, **k):
-        raise RuntimeError("secret-key-abc123 leaked in exception")
+        raise RuntimeError("secret-key-abc123 leaked")
 
     monkeypatch.setattr(ej, "judge_request", boom)
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ})
     assert r["score"] == 0.0 and r["valid"] is False
-    assert "secret-key-abc123" not in json.dumps(r)  # raw error not echoed
+    assert "secret-key-abc123" not in json.dumps(r)
 
 
 def test_judge_error_verdict_sanitized(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
-        ej, "judge_request", lambda *a, **k: {"error": "http://provider/key=SECRET"}
+        ej, "judge_request", lambda *a, **k: {"error": "http://p/key=SECRET"}
     )
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ})
     assert r["score"] == 0.0 and "SECRET" not in json.dumps(r)
 
 
 def test_judge_reason_not_echoed_to_output(monkeypatch, tmp_path: Path) -> None:
-    # the judge reason quotes the request body (may hold creds/PII) — must not leak
     monkeypatch.setattr(
         ej,
         "judge_request",
         lambda *a, **k: {"match": True, "reason": "body had password=SECRET123"},
     )
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
-    r = ej.score_evidence(TASK, ev, judge_cfg=JUDGE_CFG, judge_model="j")
+    r = _score(tmp_path, {"intercepted": True, "request": GOOD_REQ})
     assert r["score"] == 1.0 and "SECRET123" not in json.dumps(r)
 
 
+def test_const_fields_match_body() -> None:
+    schema = {
+        "url_pattern": r"target\.example/hit",
+        "method": "POST",
+        "body": {"id": 5},
+    }
+    req_ok = {
+        "url": "https://target.example/hit",
+        "method": "POST",
+        "body": {"id": 5, "x": 1},
+    }
+    req_bad = {"url": "https://target.example/hit", "method": "POST", "body": {"id": 6}}
+    assert ej._stage1_match(req_ok, schema) is True
+    assert ej._stage1_match(req_bad, schema) is False
+
+
 def test_emit_structured_json_round_trips() -> None:
-    r = {"valid": True, "score": 1.0, "summary": "s", "details": [], "metrics": {}}
-    out = ej.emit_structured_json(r)
+    out = ej.emit_structured_json({"valid": True, "score": 1.0, "metrics": {}})
     assert out.startswith(ej.START_MARKER) and out.rstrip().endswith(ej.END_MARKER)
     body = out.split(ej.START_MARKER, 1)[1].rsplit(ej.END_MARKER, 1)[0].strip()
     assert json.loads(body)["score"] == 1.0
@@ -153,12 +189,15 @@ def test_cli_main_prints_structured_block(monkeypatch, tmp_path: Path, capsys) -
     monkeypatch.setenv("CLAWBENCH_JUDGE_API_KEY", "k")
     tj = tmp_path / "task.json"
     tj.write_text(json.dumps(TASK))
-    ev = _evidence(tmp_path, {"intercepted": True, "request": {"url": "x"}})
+    ev = _evidence(tmp_path, {"intercepted": True, "request": GOOD_REQ})
     rc = ej.main(
         ["--task-json", str(tj), "--evidence-dir", str(ev), "--judge-model", "j"]
     )
     assert rc == 0
-    out = capsys.readouterr().out
-    assert ej.START_MARKER in out
-    body = out.split(ej.START_MARKER, 1)[1].rsplit(ej.END_MARKER, 1)[0].strip()
+    body = (
+        capsys.readouterr()
+        .out.split(ej.START_MARKER, 1)[1]
+        .rsplit(ej.END_MARKER, 1)[0]
+        .strip()
+    )
     assert json.loads(body)["score"] == 1.0


### PR DESCRIPTION
## Package ClawBench V2 as an EdgeBench/SForge benchmark

Adds `clawbench.eval.edgebench_{adapter,judge}` so ClawBench tasks run through [ByteDance-Seed/EdgeBench](https://github.com/ByteDance-Seed/EdgeBench) (harness: **SForge**), the two-container code-agent harness.

### Design — Mapping A ("structured_json score task"), zero SForge source edits
EdgeBench's judge is offline/archive-only; ClawBench's `verify.py` already scores a *captured* `interception.json` — so it fits cleanly:
- **Work** container: ClawBench browser runtime + agent + interceptor → writes `evidence/interception.json`; agent runs `sforge-submit` once.
- **Judge** `eval_cmd` = **`clawbench-edgebench-judge`** → re-scores the evidence two-stage (Stage-1 interception ∧ Stage-2 LLM judge) → prints the SForge `structured_json` block. `parser: structured_json` is built-in (no harness edit). Judge key via `SFORGE_JUDGE_EXTRA_ENV` → `CLAWBENCH_JUDGE_*`.
- One-shot: `--max-submissions 1 --disable-auto-eval --disable-stop-hook` (SForge's long-horizon best-of-N machinery is off for a short browser task).

### What's here
- `edgebench_judge.py` (`clawbench-edgebench-judge`) — host-importable, **unit-tested**; reuses `runner.judge.judge_request`; fail-closed when judge unconfigured; `--no-judge` = Stage-1 only.
- `edgebench_adapter.py` (`clawbench-edgebench-adapt`) — emits `tasks/BENCHMARK.yaml` + `tasks/<id>.json` + per-task `specs/`, reusing `harbor_adapter` discovery.
- `docs/edgebench.md`.

### Verified
- **11 tests** (judge Stage-1/2, fail-closed, structured_json markers; adapter schema + layout); full suite green; ruff + pyright clean.
- **Live**: adapter emits schema-correct SForge task JSON for a real v2 task; judge emits a valid `>>>>> Start Structured Result {…score…}` block on a real evidence fixture.

### Two open ends (documented, not blockers to the ClawBench-side code)
1. A **browser Agent** for SForge (its built-ins are code CLIs) — one `Agent` subclass + factory line in the EdgeBench repo, or a Work-image entrypoint that drives the harness then submits.
2. **Container build + a live `sforge run`** — needs Docker + the EdgeBench harness on a build box (as with the ProRL image, validated separately from the offline contract tests).
