### PR TITLE
feat(judge): support Gemini (google-generative-ai) as an LLM judge (closes #247)

### DIFF
--- a/src/clawbench/runner/judge.py
+++ b/src/clawbench/runner/judge.py
@@ -96,6 +96,18 @@ def _post_json(
         return json.loads(resp.read())
 
 
+def _gemini_openai_cfg(model_cfg: dict) -> dict:
+    """Route a Gemini (google-generative-ai) judge through its OpenAI-compat API.
+
+    Gemini's native root 404s on /chat/completions; the OpenAI-compatible surface
+    lives at .../v1beta/openai. Normalize the base so a native root still works.
+    """
+    base = model_cfg["base_url"].rstrip("/")
+    if "/openai" not in base:
+        base = base + "/v1beta/openai"
+    return {**model_cfg, "base_url": base}
+
+
 def _call_openai_chat(model_cfg: dict, model_name: str, system: str, user: str) -> str:
     base = model_cfg["base_url"].rstrip("/")
     url = f"{base}/chat/completions"
@@ -206,6 +218,11 @@ def judge_request(
         try:
             if api_type == "openai-completions":
                 raw = _call_openai_chat(model_cfg, judge_model_name, system, user)
+            elif api_type == "google-generative-ai":
+                # Gemini via its OpenAI-compatible endpoint (/v1beta/openai)
+                raw = _call_openai_chat(
+                    _gemini_openai_cfg(model_cfg), judge_model_name, system, user
+                )
             elif api_type == "openai-responses":
                 raw = _call_openai_responses(model_cfg, judge_model_name, system, user)
             elif api_type == "anthropic-messages":

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,0 +1,54 @@
+"""Tests for the LLM judge, incl. Gemini (google-generative-ai) routing (#247)."""
+
+from __future__ import annotations
+
+from clawbench.runner import judge
+
+
+def test_gemini_openai_cfg_normalizes_native_root() -> None:
+    # native Google root → OpenAI-compat path appended
+    cfg = judge._gemini_openai_cfg(
+        {"base_url": "https://generativelanguage.googleapis.com/", "api_key": "k"}
+    )
+    assert cfg["base_url"] == "https://generativelanguage.googleapis.com/v1beta/openai"
+    # already an /openai path → left as-is
+    cfg2 = judge._gemini_openai_cfg(
+        {
+            "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+            "api_key": "k",
+        }
+    )
+    assert cfg2["base_url"].endswith("/v1beta/openai")
+
+
+def test_gemini_judge_routes_through_openai_compat(monkeypatch) -> None:
+    seen = {}
+
+    def fake_post(url, headers, payload):
+        seen["url"] = url
+        return {
+            "choices": [{"message": {"content": '{"match": true, "reason": "ok"}'}}]
+        }
+
+    monkeypatch.setattr(judge, "_post_json", fake_post)
+    cfg = {
+        "base_url": "https://generativelanguage.googleapis.com",  # native root
+        "api_key": "k",
+        "api_type": "google-generative-ai",
+    }
+    r = judge.judge_request(cfg, "gemini-3.5-flash", "do it", {"request": {"url": "x"}})
+    assert r["match"] is True
+    # hit the OpenAI-compat chat endpoint, not the native root
+    assert seen["url"] == (
+        "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+    )
+
+
+def test_unsupported_api_type_reports_error(monkeypatch) -> None:
+    r = judge.judge_request(
+        {"base_url": "http://x", "api_key": "k", "api_type": "bogus-type"},
+        "m",
+        "do it",
+        {"request": {"url": "x"}},
+    )
+    assert r["match"] is None and r["error"] == "unsupported_api_type"


### PR DESCRIPTION
Closes #247. The judge rejected `api_type: google-generative-ai` as unsupported, so a native **Gemini** key — the most common/cheapest judge key — couldn't be the LLM judge (and the default `deepseek-v4-pro` is frequently unavailable, #240).

**Fix:** route `google-generative-ai` through Gemini's OpenAI-compatible endpoint — reuse `_call_openai_chat` with the base normalized to `.../v1beta/openai` (the native root 404s on `/chat/completions`, a well-known gotcha). Other api_types unchanged.

**Tests:** gemini routing hits `/v1beta/openai/chat/completions`; base normalization (native root vs already-`/openai`); unsupported api_type still errors. ruff + pyright clean; suite green.