### PR TITLE
feat(harness): null baseline harness — the benchmark floor (closes #245)

### DIFF
--- a/src/clawbench/runtime/harnesses/harnesses.yaml
+++ b/src/clawbench/runtime/harnesses/harnesses.yaml
@@ -112,3 +112,14 @@ harnesses:
         path: /data/agent-messages.jsonl
       - type: file
         path: /data/agent-messages.raw.jsonl
+  # Null baseline — takes no action; establishes the benchmark floor (~0 score,
+  # and the interceptor must not fire without genuine agent activity).
+  - name: "null"
+    image: clawbench-null
+    dockerfile: "null/Dockerfile.null"
+    setup_script: "null/setup-null.sh"
+    run_script: "null/run-null.sh"
+    usage_emitter: "null/usage-emitter.py"
+    agent_message_sources:
+      - type: file
+        path: /data/agent-messages.jsonl

--- a/src/clawbench/runtime/harnesses/null/Dockerfile.null
+++ b/src/clawbench/runtime/harnesses/null/Dockerfile.null
@@ -1,0 +1,9 @@
+FROM clawbench-base
+
+# The null baseline agent installs nothing and takes no action — it establishes
+# the benchmark floor (a do-nothing agent must score ~0, and the interceptor
+# must not fire without genuine activity).
+COPY harnesses/null/setup-null.sh /setup-null.sh
+COPY harnesses/null/run-null.sh /run-harness.sh
+COPY harnesses/null/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-null.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/null/run-null.sh
+++ b/src/clawbench/runtime/harnesses/null/run-null.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+#
+# Null baseline harness — the benchmark FLOOR.
+#
+# It connects to nothing and takes no browser action, so the run records zero
+# actions/requests and the interceptor never fires. A do-nothing agent must
+# therefore score ~0: this proves ClawBench is not luck-passable and that the
+# HTTP interceptor has no false positives without genuine agent activity.
+#
+/setup-null.sh
+
+mkdir -p /data
+# a well-formed (empty) transcript so the run is complete, not "missing files"
+: > /data/agent-messages.jsonl
+
+echo "null baseline agent: taking no action for this task"
+# exit cleanly — the runtime stops and writes interception.json (intercepted=false)
+exit 0

--- a/src/clawbench/runtime/harnesses/null/setup-null.sh
+++ b/src/clawbench/runtime/harnesses/null/setup-null.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+# The null baseline installs nothing.
+echo "null baseline: no setup"

--- a/src/clawbench/runtime/harnesses/null/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/null/usage-emitter.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Null harness usage emitter: the null baseline makes no model calls."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    # No model calls → an empty usage stream.
+    Path("/data/usage.jsonl").write_text("")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_harness_registry.py
+++ b/tests/test_harness_registry.py
@@ -27,6 +27,7 @@ EXPECTED_HARNESSES = (
     "claw-code",
     "hermes",
     "pi",
+    "null",
 )
 
 EXPECTED_SCRIPTS = {
@@ -82,6 +83,7 @@ EXPECTED_AGENT_MESSAGE_SOURCES = {
         ("file", "/data/agent-messages.raw.jsonl"),
     ),
     "harbor": (("file", "/data/agent-messages.jsonl"),),
+    "null": (("file", "/data/agent-messages.jsonl"),),
 }
 
 


### PR DESCRIPTION
## Null baseline harness — the benchmark floor (closes #245)

Adds a `null` harness: a do-nothing agent that connects to nothing and takes no browser action, so the run records **0 actions/requests and the interceptor never fires**. A null agent must therefore score **~0**.

**Why it matters (the methodological artifact reviewers ask for):**
- Establishes the **benchmark floor** — proves ClawBench isn't luck-passable.
- Directly demonstrates the **interceptor false-positive rate** — Stage-1 must not fire without genuine agent activity. (The rate is computed by the new `clawbench-analyze` tool, #159/#255.)

**What's here**
- `runtime/harnesses/null/{Dockerfile.null, setup-null.sh, run-null.sh, usage-emitter.py}` — `FROM clawbench-base`, makes no model call (no API key needed).
- Registered in `harnesses.yaml` (name quoted to dodge the YAML `null` keyword) + `test_harness_registry` expectations.

**Verified:** registry test passes (`null` registered); `clawbench-null` **builds** from `clawbench-base`; composition check confirms the scripts are present and `run-null` is a genuine no-op. Full suite green; ruff clean.

Run it: `clawbench-run --harness null --task <id>` → expect 0 actions, `intercepted: false`, reward 0. A follow-up can add a `random-click` baseline for a non-trivial floor.
