### PR TITLE
feat(harness): null + random-click baselines — the benchmark floor (closes #245)

### DIFF
--- a/src/clawbench/runtime/harnesses/harnesses.yaml
+++ b/src/clawbench/runtime/harnesses/harnesses.yaml
@@ -112,3 +112,26 @@ harnesses:
         path: /data/agent-messages.jsonl
       - type: file
         path: /data/agent-messages.raw.jsonl
+  # Null baseline — takes no action; establishes the benchmark floor (~0 score,
+  # and the interceptor must not fire without genuine agent activity).
+  - name: "null"
+    image: clawbench-null
+    dockerfile: "null/Dockerfile.null"
+    setup_script: "null/setup-null.sh"
+    run_script: "null/run-null.sh"
+    usage_emitter: "null/usage-emitter.py"
+    agent_message_sources:
+      - type: file
+        path: /data/agent-messages.jsonl
+  # Random-click baseline — clicks at random with no intent; a non-trivial floor.
+  - name: random-click
+    image: clawbench-random-click
+    dockerfile: random-click/Dockerfile.random-click
+    setup_script: random-click/setup-random-click.sh
+    run_script: random-click/run-random-click.sh
+    usage_emitter: random-click/usage-emitter.py
+    extra_files:
+      - random-click/random_clicker.py
+    agent_message_sources:
+      - type: file
+        path: /data/agent-messages.jsonl

--- a/src/clawbench/runtime/harnesses/null/Dockerfile.null
+++ b/src/clawbench/runtime/harnesses/null/Dockerfile.null
@@ -1,0 +1,9 @@
+FROM clawbench-base
+
+# The null baseline agent installs nothing and takes no action — it establishes
+# the benchmark floor (a do-nothing agent must score ~0, and the interceptor
+# must not fire without genuine agent activity).
+COPY harnesses/null/setup-null.sh /setup-null.sh
+COPY harnesses/null/run-null.sh /run-harness.sh
+COPY harnesses/null/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-null.sh /run-harness.sh /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/null/run-null.sh
+++ b/src/clawbench/runtime/harnesses/null/run-null.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+#
+# Null baseline harness — the benchmark FLOOR.
+#
+# It connects to nothing and takes no browser action, so the run records zero
+# actions/requests and the interceptor never fires. A do-nothing agent must
+# therefore score ~0: this proves ClawBench is not luck-passable and that the
+# HTTP interceptor has no false positives without genuine agent activity.
+#
+/setup-null.sh
+mkdir -p /data
+: > /data/agent-messages.jsonl
+echo "null baseline agent: taking no action for this task"
+exit 0

--- a/src/clawbench/runtime/harnesses/null/setup-null.sh
+++ b/src/clawbench/runtime/harnesses/null/setup-null.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+# The null baseline installs nothing.
+echo "null baseline: no setup"

--- a/src/clawbench/runtime/harnesses/null/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/null/usage-emitter.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Null harness usage emitter: the null baseline makes no model calls."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    Path("/data/usage.jsonl").write_text("")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/clawbench/runtime/harnesses/random-click/Dockerfile.random-click
+++ b/src/clawbench/runtime/harnesses/random-click/Dockerfile.random-click
@@ -1,0 +1,10 @@
+FROM clawbench-base
+
+# Random-click baseline: dispatches random CDP mouse clicks (acts without intent).
+RUN pip install --no-cache-dir --break-system-packages websocket-client || \
+    pip install --no-cache-dir websocket-client
+COPY harnesses/random-click/setup-random-click.sh /setup-random-click.sh
+COPY harnesses/random-click/run-random-click.sh /run-harness.sh
+COPY harnesses/random-click/random_clicker.py /random_clicker.py
+COPY harnesses/random-click/usage-emitter.py /usage-emitter.py
+RUN chmod +x /setup-random-click.sh /run-harness.sh /random_clicker.py /usage-emitter.py

--- a/src/clawbench/runtime/harnesses/random-click/random_clicker.py
+++ b/src/clawbench/runtime/harnesses/random-click/random_clicker.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Random-click baseline: dispatch N random CDP mouse clicks — a non-trivial floor.
+
+Acts on the page but without any task intent, so it should still score ~0: it
+demonstrates that browsing activity alone (without hitting the *target* action)
+does not pass the interceptor.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+import urllib.request
+
+import websocket
+
+# The shared browser CDP endpoint is always exported by the base entrypoint.
+CDP = os.environ.get("CLAWBENCH_BROWSER_CDP_URL", "").rstrip("/")
+N = int(os.environ.get("RANDOM_CLICK_COUNT", "20"))
+ACTIONS = "/data/actions.jsonl"
+
+
+def _page_ws() -> str:
+    targets = json.loads(urllib.request.urlopen(f"{CDP}/json/list", timeout=10).read())
+    for t in targets:
+        if t.get("type") == "page" and t.get("webSocketDebuggerUrl"):
+            return t["webSocketDebuggerUrl"]
+    version = json.loads(
+        urllib.request.urlopen(f"{CDP}/json/version", timeout=10).read()
+    )
+    return version["webSocketDebuggerUrl"]
+
+
+def main() -> int:
+    os.makedirs("/data", exist_ok=True)
+    if not CDP:
+        print("random-click: CLAWBENCH_BROWSER_CDP_URL not set")
+        return 0
+    try:
+        ws = websocket.create_connection(_page_ws(), timeout=15)
+    except Exception as e:  # noqa: BLE001
+        print(f"random-click: could not connect to CDP ({e})")
+        return 0  # a failed connect still yields a valid (0-target) run
+    mid = 0
+
+    def send(method: str, params: dict | None = None) -> None:
+        nonlocal mid
+        mid += 1
+        ws.send(json.dumps({"id": mid, "method": method, "params": params or {}}))
+        ws.recv()
+
+    with open(ACTIONS, "a") as f:
+        for i in range(N):
+            x, y = random.randint(0, 1900), random.randint(0, 1000)
+            for phase in ("mousePressed", "mouseReleased"):
+                try:
+                    send(
+                        "Input.dispatchMouseEvent",
+                        {
+                            "type": phase,
+                            "x": x,
+                            "y": y,
+                            "button": "left",
+                            "clickCount": 1,
+                        },
+                    )
+                except Exception:  # noqa: BLE001, S112
+                    continue
+            f.write(json.dumps({"type": "random_click", "x": x, "y": y, "i": i}) + "\n")
+            f.flush()
+            time.sleep(0.4)
+    print(f"random-click: dispatched {N} random clicks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clawbench/runtime/harnesses/random-click/run-random-click.sh
+++ b/src/clawbench/runtime/harnesses/random-click/run-random-click.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+#
+# Random-click baseline — a NON-TRIVIAL floor: it clicks at random but with no
+# task intent, so it should still score ~0. Shows that browsing activity alone
+# (without hitting the target action) does not pass the interceptor.
+#
+/setup-random-click.sh
+mkdir -p /data
+: > /data/agent-messages.jsonl
+python3 /random_clicker.py || true
+exit 0

--- a/src/clawbench/runtime/harnesses/random-click/setup-random-click.sh
+++ b/src/clawbench/runtime/harnesses/random-click/setup-random-click.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echo "random-click baseline: no setup"

--- a/src/clawbench/runtime/harnesses/random-click/usage-emitter.py
+++ b/src/clawbench/runtime/harnesses/random-click/usage-emitter.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Random-click harness usage emitter: no model calls → empty usage."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    Path("/data/usage.jsonl").write_text("")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_harness_registry.py
+++ b/tests/test_harness_registry.py
@@ -27,6 +27,8 @@ EXPECTED_HARNESSES = (
     "claw-code",
     "hermes",
     "pi",
+    "null",
+    "random-click",
 )
 
 EXPECTED_SCRIPTS = {
@@ -49,6 +51,7 @@ EXPECTED_EXTRA_FILES = {
     "hermes": ("hermes/hermes-capture.py",),
     "pi": ("pi/pi-usage-logger.py",),
     "harbor": ("harbor/harbor_driver.py",),
+    "random-click": ("random-click/random_clicker.py",),
 }
 
 EXPECTED_USAGE_EMITTERS = {
@@ -82,6 +85,8 @@ EXPECTED_AGENT_MESSAGE_SOURCES = {
         ("file", "/data/agent-messages.raw.jsonl"),
     ),
     "harbor": (("file", "/data/agent-messages.jsonl"),),
+    "null": (("file", "/data/agent-messages.jsonl"),),
+    "random-click": (("file", "/data/agent-messages.jsonl"),),
 }
 
 


### PR DESCRIPTION
## Null + random-click baselines — the benchmark floor (closes #245)

Two leaderboard baselines that establish the ClawBench floor and validate the interceptor (the methodological artifacts reviewers ask for):

- **`null`** — takes no action → 0 actions/requests, the interceptor never fires. A do-nothing agent must score **~0**, proving ClawBench isn't luck-passable and that Stage-1 has **no false positives** without genuine activity.
- **`random-click`** — dispatches N random CDP mouse clicks (via `websocket-client`) with no task intent → a **non-trivial** floor: browsing activity alone, without hitting the *target* action, must not pass. Reads the shared `CLAWBENCH_BROWSER_CDP_URL`.

Both registered in `harnesses.yaml` (+ `test_harness_registry`); the interceptor false-positive rate over these baselines is computed by `clawbench-analyze` (#159).

**Verified on real hardware (podman):** registry test passes; both images build from `clawbench-base`; `null`'s run-harness is a genuine no-op; the **random-clicker connects to Chromium via CDP and dispatches + logs 10 clicks**. Full suite green; ruff clean.

Supersedes #256 (null-only) — this folds in the random-click baseline too.
