### PR TITLE
test(corpus): guard task-target integrity (non-empty valid-regex url_pattern + no dupes)

### DIFF
--- a/tests/test_host_tasks.py
+++ b/tests/test_host_tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -52,6 +53,45 @@ def test_checked_task_json_files_parse_and_validate(suite: str) -> None:
         task = json.loads(task_file.read_bytes())
         validated = validate_task_data(task, task_file)
         assert validated is task
+
+
+@pytest.mark.parametrize("suite", sorted(batch.CASE_SUITES))
+def test_task_url_patterns_are_nonempty_and_valid_regex(suite: str) -> None:
+    """validate_task_data only checks url_pattern is a *string* — an empty pattern
+    (re.search('', url) matches everything → false positives) or a malformed regex
+    (interceptor crashes at runtime) still slips through. Guard against both."""
+    for task_file in _task_files_for_suite(suite):
+        task = json.loads(task_file.read_bytes())
+        pattern = task["eval_schema"]["url_pattern"]
+        assert pattern.strip(), (
+            f"{task_file}: eval_schema.url_pattern is empty — would match every "
+            f"request (false-positive interceptions)"
+        )
+        try:
+            re.compile(pattern)
+        except re.error as exc:  # malformed regex would crash the interceptor
+            raise AssertionError(
+                f"{task_file}: url_pattern is not valid regex: {exc}"
+            ) from exc
+
+
+@pytest.mark.parametrize("suite", sorted(batch.CASE_SUITES))
+def test_tasks_are_not_duplicated(suite: str) -> None:
+    """No two tasks share the same target + instruction (accidental copy-paste)."""
+    seen: dict[tuple[str, str, str], str] = {}
+    for task_file in _task_files_for_suite(suite):
+        task = json.loads(task_file.read_bytes())
+        schema = task["eval_schema"]
+        key = (
+            schema["url_pattern"],
+            str(schema.get("method", "")),
+            str(task["instruction"]).strip(),
+        )
+        prev = seen.get(key)
+        assert prev is None, (
+            f"duplicate task in {suite}: {task_file.parent.name} == {prev}"
+        )
+        seen[key] = task_file.parent.name
 
 
 def test_v1_lite_linked_files_are_readable_from_python() -> None:


### PR DESCRIPTION
Adds corpus-integrity CI guards (re #244).

`validate_task_data` checks `eval_schema.url_pattern` is a *string* but not that it's **non-empty** or a **valid regex** — so two silent-corruption classes slip through:
- **empty** `url_pattern` → `re.search('', url)` matches **every** request → false-positive Stage-1 interceptions (task always 'passes' Stage-1)
- **malformed regex** → the runtime interceptor crashes at eval time

New tests over every suite (v1/v2/v1-lite/claw-eval): `url_pattern` is non-empty + compiles as a regex, and no two tasks share the same `(url_pattern, method, instruction)` (accidental copy-paste). Both **pass on the current corpus** and act as a drift/corruption guard.

(The 129-vs-130 count reconciliation in #244 needs the source data — left to maintainers.)