### PR TITLE
feat(judge): answer/rubric judge — primitive for importing rubric benchmarks (re #170/#188/#189/#190)

### DIFF
--- a/docs/answer-mode-tasks.md
+++ b/docs/answer-mode-tasks.md
@@ -1,0 +1,52 @@
+# Answer / rubric judge — importing rubric-based benchmarks
+
+ClawBench's native scoring is **two-stage HTTP interception**: Stage-1 matches the
+agent's request against `eval_schema.{url_pattern, method}`, Stage-2 asks the LLM
+judge whether that request fulfils the instruction (`judge_request`).
+
+Many other agent benchmarks — **claw-eval** (#170), **AssistantBench** (#188),
+**Online-Mind2Web** (#189), **WebVoyager** (#190) — instead score a **free-text
+answer or a rubric**, with no single interceptable target request. To import them
+without disturbing the interception path, this adds the missing primitive:
+
+## `judge_answer(...)`
+
+`clawbench.runner.judge.judge_answer(model_cfg, judge_model_name, instruction,
+answer, *, judge_context=None)` returns the same verdict dict as `judge_request`
+(`match`/`reason`/`judge_model`/`raw`/`error`), but judges the agent's **final
+answer/outcome** against the instruction and an optional **rubric** in
+`judge_context` (`rubric` / `reference_solution` / `gold_answer`).
+
+Both judges now share `_run_judge()` (dispatch by api_type + parse), so behaviour
+and provider support stay identical.
+
+## Proposed "answer-mode" task shape (opt-in, non-breaking)
+
+An imported task is expressed with an `eval_schema.mode` discriminator
+(default `"interception"`, unchanged for all existing tasks):
+
+```json
+{
+  "instruction": "...",              // from the source benchmark's query
+  "eval_schema": {"mode": "judge"},  // no url_pattern needed for judge-mode
+  "judge_context": {"rubric": "..."},// the source benchmark's rubric / gold
+  "metadata": {"category": "...", "source": "claw-eval"},
+  "time_limit": 15
+}
+```
+
+At scoring time: `mode == "interception"` → the current Stage-1 + `judge_request`
+path; `mode == "judge"` → skip Stage-1 and score the agent's final answer with
+`judge_answer`. (The corpus-integrity guard that requires a non-empty
+`url_pattern` becomes mode-aware: required for interception tasks, not judge
+tasks.)
+
+## What this unblocks
+
+This is the enabling primitive for the import-adapter issues. e.g. **claw-eval**
+(`task_id, query, fixture, language, category`, HF `claw-eval/Claw-Eval`, 300
+tasks) maps as `query → instruction`, `category → metadata`, its eval-yaml rubric
+→ `judge_context`, `mode: "judge"`. The remaining runner wiring (extract the
+agent's final answer from the trajectory, branch on `mode`) is a small, separate
+change; this PR lands the tested judge primitive so that work has a foundation and
+the direction can be reviewed first.

--- a/src/clawbench/runner/judge.py
+++ b/src/clawbench/runner/judge.py
@@ -187,20 +187,15 @@ def _parse_verdict(text: str) -> tuple[bool | None, str]:
         return None, text[:200] or "unparseable"
 
 
-def judge_request(
+def _run_judge(
     model_cfg: dict,
     judge_model_name: str,
-    instruction: str,
-    intercept: dict[str, Any],
-    *,
-    judge_context: dict[str, Any] | None = None,
-    retries: int = 2,
+    system: str,
+    user: str,
+    retries: int,
 ) -> dict[str, Any]:
-    """Run a single judge call. Returns dict with keys match/reason/judge_model/raw/error."""
-    system = JUDGE_SYSTEM
-    user = _build_user_msg(instruction, intercept, judge_context)
+    """Dispatch a judge call by api_type, parse the verdict; shared by both judges."""
     api_type = model_cfg.get("api_type", "openai-completions")
-
     last_err: Exception | None = None
     for attempt in range(retries + 1):
         try:
@@ -239,3 +234,77 @@ def judge_request(
         "raw": None,
         "error": str(last_err),
     }
+
+
+def judge_request(
+    model_cfg: dict,
+    judge_model_name: str,
+    instruction: str,
+    intercept: dict[str, Any],
+    *,
+    judge_context: dict[str, Any] | None = None,
+    retries: int = 2,
+) -> dict[str, Any]:
+    """Judge an intercepted HTTP request (Stage-2 for interception-mode tasks).
+
+    Returns dict with keys match/reason/judge_model/raw/error.
+    """
+    user = _build_user_msg(instruction, intercept, judge_context)
+    return _run_judge(model_cfg, judge_model_name, JUDGE_SYSTEM, user, retries)
+
+
+# Answer/rubric judge — for tasks whose success is a free-text answer or
+# rubric-scored outcome (no single interceptable request). Enables importing
+# rubric-based benchmarks (claw-eval, AssistantBench, WebVoyager) alongside the
+# interception path.
+ANSWER_JUDGE_SYSTEM = """You are a strict evaluator for a web-agent benchmark.
+
+A user gave a natural-language INSTRUCTION to an autonomous browser agent. The
+agent acted on real websites and produced a final ANSWER (and/or observable
+outcome). Decide whether the agent fulfilled the instruction.
+
+If a RUBRIC is provided, judge strictly against it. Otherwise judge whether the
+ANSWER correctly and completely satisfies the instruction.
+
+Rules:
+- Match = the answer/outcome does what the user asked (right result, complete,
+  correct). Cosmetic differences are OK.
+- Mismatch = wrong, incomplete, hallucinated, or unsupported by evidence.
+- If ambiguous or only partially correct, mark as mismatch.
+
+Reply with ONLY a single-line JSON object, no markdown fences, no extra prose:
+{"match": true|false, "reason": "<one short sentence>"}
+"""
+
+
+def _build_answer_msg(
+    instruction: str, answer: str, judge_context: dict[str, Any] | None
+) -> str:
+    rubric = ""
+    if isinstance(judge_context, dict):
+        pieces = []
+        for key in ("rubric", "reference_solution", "gold_answer", "source_task_yaml"):
+            value = judge_context.get(key)
+            if isinstance(value, str) and value.strip():
+                pieces.append(f"{key}:\n{value.strip()[:6000]}")
+        if pieces:
+            rubric = "\n\nRUBRIC:\n" + "\n\n".join(pieces)
+    answer_text = (answer or "").strip()[:8000] or "(the agent produced no answer)"
+    return f"INSTRUCTION:\n{instruction}\n\nAGENT ANSWER:\n{answer_text}\n{rubric}\n"
+
+
+def judge_answer(
+    model_cfg: dict,
+    judge_model_name: str,
+    instruction: str,
+    answer: str,
+    *,
+    judge_context: dict[str, Any] | None = None,
+    retries: int = 2,
+) -> dict[str, Any]:
+    """Judge a free-text agent answer/outcome against the instruction (+ rubric).
+
+    Returns the same dict shape as judge_request (match/reason/judge_model/raw/error).
+    """
+    user = _build_answer_msg(instruction, answer, judge_context)
+    return _run_judge(model_cfg, judge_model_name, ANSWER_JUDGE_SYSTEM, user, retries)

--- a/tests/test_answer_judge.py
+++ b/tests/test_answer_judge.py
@@ -1,0 +1,71 @@
+"""Tests for the answer/rubric judge (judge_answer) + the shared dispatch refactor."""
+
+from __future__ import annotations
+
+from clawbench.runner import judge
+
+CFG = {
+    "base_url": "https://j.example/v1",
+    "api_key": "k",
+    "api_type": "openai-completions",
+}
+
+
+def _mock_post(monkeypatch, content: str):
+    def fake_post(url, headers, payload):
+        return {"choices": [{"message": {"content": content}}]}
+
+    monkeypatch.setattr(judge, "_post_json", fake_post)
+
+
+def test_judge_answer_match(monkeypatch) -> None:
+    _mock_post(monkeypatch, '{"match": true, "reason": "answer is correct"}')
+    r = judge.judge_answer(
+        CFG, "m", "What is 2+2?", "4", judge_context={"rubric": "must be 4"}
+    )
+    assert r["match"] is True and r["error"] is None
+
+
+def test_judge_answer_mismatch(monkeypatch) -> None:
+    _mock_post(monkeypatch, '{"match": false, "reason": "wrong"}')
+    r = judge.judge_answer(CFG, "m", "What is 2+2?", "5")
+    assert r["match"] is False
+
+
+def test_build_answer_msg_includes_answer_and_rubric() -> None:
+    msg = judge._build_answer_msg(
+        "do the thing",
+        "my final answer",
+        {"rubric": "must include X", "gold_answer": "X"},
+    )
+    assert "do the thing" in msg
+    assert "my final answer" in msg
+    assert "RUBRIC" in msg and "must include X" in msg and "X" in msg
+
+
+def test_build_answer_msg_handles_empty_answer() -> None:
+    msg = judge._build_answer_msg("inst", "", None)
+    assert "no answer" in msg.lower()
+
+
+def test_answer_judge_unsupported_api_type() -> None:
+    r = judge.judge_answer(
+        {"base_url": "http://x", "api_key": "k", "api_type": "bogus"}, "m", "i", "a"
+    )
+    assert r["match"] is None and r["error"] == "unsupported_api_type"
+
+
+def test_judge_request_still_works_after_refactor(monkeypatch) -> None:
+    # the refactor to _run_judge must not change judge_request behaviour
+    _mock_post(monkeypatch, '{"match": true, "reason": "ok"}')
+    r = judge.judge_request(
+        CFG, "m", "book it", {"request": {"url": "x", "method": "POST"}}
+    )
+    assert r["match"] is True and r["judge_model"] == "m"
+
+
+def test_run_judge_is_shared() -> None:
+    assert callable(judge._run_judge)
+    # both judges route through it
+    assert "_run_judge" in judge.judge_request.__code__.co_names
+    assert "_run_judge" in judge.judge_answer.__code__.co_names


### PR DESCRIPTION
## Answer / rubric judge — the primitive for importing rubric-based benchmarks

Native ClawBench scores by **two-stage HTTP interception**. But the import-adapter issues (**claw-eval** #170, **AssistantBench** #188, **Online-Mind2Web** #189, **WebVoyager** #190) all target benchmarks that score a **free-text answer / rubric** with *no interceptable target request*. This lands the missing primitive so they can be imported without disturbing the interception path.

### What's here (additive, non-breaking)
- **`judge_answer(...)`** — judges the agent's final **answer/outcome** against the instruction + an optional **rubric** (`judge_context.{rubric, reference_solution, gold_answer}`); same verdict dict as `judge_request`.
- **Refactor**: both judges now share `_run_judge()` (dispatch by api_type + parse) — `judge_request` behaviour is **unchanged** (regression-tested).
- **`docs/answer-mode-tasks.md`** — the proposed opt-in `eval_schema.mode: "judge"` task shape and how e.g. claw-eval (`query→instruction`, `category→metadata`, eval-yaml rubric→`judge_context`) maps onto it.

### Why a foundation PR (not the full import)
Researched claw-eval directly (HF `claw-eval/Claw-Eval`, 300 tasks: `task_id, query, fixture, language, category`, rubric-scored, no url_pattern). A full import needs (a) this judge primitive, (b) a small runner branch on `eval_schema.mode`, and (c) the source rubric data. This PR lands **(a)** — tested + isolated — so the **direction can be reviewed first** before the core scoring is extended. 7 tests; ruff + pyright clean; full suite green.
