### PR TITLE
Fixes an `x11vnc` startup crash when running `clawbench-run` with `--human`.

### DIFF
--- a/src/clawbench/runtime/harnesses/base/entrypoint.sh
+++ b/src/clawbench/runtime/harnesses/base/entrypoint.sh
@@ -214,14 +214,13 @@ socat TCP-LISTEN:9223,fork,reuseaddr,bind=0.0.0.0 TCP:127.0.0.1:9222 &
 # Always start noVNC so users can watch the browser in any mode.
 # In human mode x11vnc also fires disconnect hooks for the watchdog.
 echo "Starting noVNC..."
-VNC_GONE_HOOK=""
-VNC_ACCEPT_HOOK=""
 if [ "$HUMAN_MODE" = "1" ]; then
-  VNC_GONE_HOOK="-gone touch /data/.vnc-disconnected"
-  VNC_ACCEPT_HOOK="-afteraccept rm -f /data/.vnc-disconnected"
+  x11vnc -display :99 -nopw -shared -forever -rfbport 5900 -xkb \
+    -gone "touch /data/.vnc-disconnected" \
+    -afteraccept "rm -f /data/.vnc-disconnected" &
+else
+  x11vnc -display :99 -nopw -shared -forever -rfbport 5900 -xkb &
 fi
-x11vnc -display :99 -nopw -shared -forever -rfbport 5900 -xkb \
-  $VNC_GONE_HOOK $VNC_ACCEPT_HOOK &
 sleep 1
 
 /opt/novnc/utils/novnc_proxy --vnc localhost:5900 --listen 6080 &


### PR DESCRIPTION
## What does this PR do?

In `src/clawbench/runtime/harnesses/base/entrypoint.sh`, the `$VNC_GONE_HOOK` and `$VNC_ACCEPT_HOOK` variables contained unquoted multi-token arguments (`-gone touch /data/.vnc-disconnected`). Upon shell parameter expansion, `x11vnc` received `/data/.vnc-disconnected` as an invalid command-line flag, causing `x11vnc` to fail to start.

Separated `HUMAN_MODE=1` `x11vnc` execution block and quoted `-gone` and `-afteraccept` parameters so `x11vnc` parses them as single string commands.


## Corpus

<!-- Tick the corpus this change applies to. V2 is the current default. -->

- [ ] v2
- [ ] v1
- [ ] both
- [x] not applicable

## Test plan

Tested using:
`uv run clawbench-run test-cases/v1-lite/002-daily-life-food-doordash --human`
Verified that `x11vnc` launches on port 5900 and noVNC connects smoothly without manual intervention.

## Related issues

N/A