### PR TITLE
docs: trace cookbook + trace-autopsy series opener + competition proposal draft

### DIFF
--- a/docs/blog/2026-08-trace-autopsy-001-uber-eats-lockout.md
+++ b/docs/blog/2026-08-trace-autopsy-001-uber-eats-lockout.md
@@ -1,0 +1,108 @@
+# Trace Autopsy #1: How Opus 4.6 Lost a Pad Thai to a Phone-Number Wall
+
+*First in a series where we dissect one failed ClawBench run at a time, using the benchmark's 5-layer recordings: agent messages, DOM actions, raw HTTP, network interception, and video.*
+
+## The task
+
+ClawBench task `001-daily-life-food-uber-eats`, about as everyday as it gets:
+
+> "On Uber Eats, order delivery: one Pad Thai, deliver to home address, note 'no peanuts'"
+
+The agent gets a dummy identity ("Alex Green", a Toronto address, a fresh disposable email inbox) and 30 minutes on the real ubereats.com. The grader is not an LLM judge — it's a network interceptor waiting for one specific HTTP request: a `POST` to `ubereats.com/_p/api/createDraftOrderV2` whose cart contains an item matching `[Pp]ad [Tt]hai` with `deliveryType: ASAP`. Fire that request with the right body and you pass. Nothing else counts.
+
+**Model:** `claude-opus-4-6` (thinking: medium), running the OpenClaw browser harness.
+**Verdict:** FAIL after 678 seconds. From `interception.json`:
+
+> `"Session stopped: agent went idle (300s no actions) before triggering the eval interceptor."`
+
+978 HTTP requests captured in `requests.jsonl`. Zero of them were the checkout call.
+
+## The timeline
+
+Timestamps from `agent-messages.jsonl` (UTC).
+
+**11:09:00 — Clean start.** The agent reads the identity files first, notes the delivery address, and opens ubereats.com. The bare domain throws an access-denied wall; it calmly reroutes to `/ca` and lands on an IP-geolocated Toronto feed. Good recovery, ~18 seconds in.
+
+**11:09:31 — Login begins.** It clicks "Log in", enters the disposable email at `auth.uber.com/v2`, and Uber emails a 4-digit code.
+
+**11:09:55 — The email side-quest.** It opens the PurelyMail webmail in a second tab and grinds through genuinely annoying UI: a `'selector' is not supported` tool error, a Roundcube keyboard-shortcuts dialog that pops up twice, a click that silently does nothing, and finally a hand-rolled `evaluate` dispatching synthetic mouse events on `tr.message`. It digs the code out of the "Welcome to Uber" email: *"I can see the verification code: **1539**."* The whole multi-tab, error-recovering detour succeeds.
+
+**11:11:51 — OTP accepted.** Name filled ("Alex" / "Green"), terms accepted. The account exists. The agent is one screen away from the food.
+
+**11:12:41 — The wall.** Uber shows "Keep your account secure": a radio group with **Phone** ("Provide a phone number to use at log in — Recommended", pre-checked) and **Passkey**, plus a Next button. No skip. The agent sees the problem immediately — the persona file has no phone number (`contact` holds only an email; we checked, it really doesn't) — and thinks:
+
+> "There's no skip option. I need to choose Phone and provide a phone number. But the user info doesn't have a phone number."
+
+**11:13:02 — The fatal bet.** Instead of testing the Passkey option it had just flagged, the agent gambles:
+
+> "Let me try navigating directly to Uber Eats to see if I'm already logged in — the account was created, this might just be an optional security step."
+
+It navigates away, mid-verification.
+
+**11:13:24 — Bet lost.** It briefly misreads the feed as success ("it looks like I'm logged in"), then the next snapshot corrects it: the "Log in" link is still there. It returns to `auth.uber.com/v2` and re-enters the email.
+
+**11:13:59 — The door slams.** The login screenshot shows the lock; the DOM snapshot moments later contains, verbatim:
+
+> alert: "Your account is currently disabled. Visit z.uber.com/account-disabled for more information."
+> dialog: "Account Locked — We are unable to log you in at this time. Please reach out to support for further assistance."
+
+Uber's anti-fraud system saw a brand-new account bail out of mandatory verification and killed it. The agent clicks "Start Over" and retries the email once more (`actions.jsonl` shows the input events on `#PHONE_NUMBER_or_EMAIL_ADDRESS` at 11:14:31–40). Still locked.
+
+**11:14:57 — The last message.** The agent writes a tidy, accurate post-mortem to the user and asks:
+
+> "Could you provide a phone number I can use for the Uber account, or if you already have an existing Uber Eats account, share those login credentials?"
+
+Nobody answers. This is an unattended benchmark run. Five minutes of silence later, the harness terminates the session — time of death 11:20:18, per run-meta's 678-second duration. The Pad Thai was never in a cart.
+
+## The failure mechanism
+
+Name it precisely: **mid-verification abandonment lockout**. The agent treated browser navigation as a free, reversible probe — "navigate away and see if the session stuck" — inside a flow where leaving *is* the destructive action. One optimistic click converted a recoverable blocker (no phone number on file) into an unrecoverable one (the only available account, on the only available email, permanently disabled). Everything after 11:13:02 was just the trace documenting a corpse.
+
+There's a secondary mechanism stacked on top: **terminal question in an unattended setting**. Asking the user for a phone number is exactly right for a human-in-the-loop assistant and exactly wrong as a final action when no human is watching; the idle timeout, not the model, formally ended the run.
+
+## What this says about agent design
+
+- **Perception wasn't the problem.** Opus 4.6 beat a bot wall, ran a two-tab OTP relay through a hostile webmail UI, and read every page correctly — the classically "hard" parts of browser use. The run died on a resource-and-risk judgment call.
+- **Agents need a one-way-door model.** Auth, verification, checkout, and account-creation flows have irreversible transitions. "Try it and see" is a fine policy on a search page and a catastrophic one mid-verification. The agent even *knew* the state was fragile — it just didn't price the exit.
+- **Cheap probes before destructive ones.** The non-destructive alternative (click Passkey, inspect what it asks for) was proposed twice in the agent's own thinking and never executed. The destructive probe ran first.
+- **Blocked ≠ dead.** Stopping at the wall and reporting "Uber requires a phone number; none is on file" would have been a *graceful* failure, leaving retries open. Burning the account is strictly worse — and current agents don't distinguish the two.
+
+Every claim above is checkable: the run is `001-daily-life-food-uber-eats-claude-opus-4-6-20260329-110845` in the public trace dump, five synced layers deep, mp4 included.
+
+**Traces:** [huggingface.co/datasets/NAIL-Group/ClawBenchV1Trace](https://huggingface.co/datasets/NAIL-Group/ClawBenchV1Trace) · **Benchmark:** [github.com/TIGER-AI-Lab/ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) · **Leaderboard:** [claw-bench.com](https://claw-bench.com)
+
+## X thread
+
+**1/**
+Trace autopsy: how a frontier model (Opus 4.6) failed to order one Pad Thai on Uber Eats.
+
+Not perception. Not the bot wall. Not the OTP dance — it nailed all of that.
+
+One optimistic click got its account permanently locked. Full trace inside. 🧵
+
+**2/**
+Setup: ClawBench runs agents on the REAL ubereats.com. Grader = network interceptor waiting for POST createDraftOrderV2 with a "Pad Thai" item. No LLM judge — either the checkout request fires or it doesn't.
+
+978 HTTP requests logged this run. 0 were checkout.
+
+**3/**
+First 3 min were genuinely impressive: rerouted around an access-denied wall, created an account, pulled OTP "1539" out of a disposable inbox in a second tab (fighting a Roundcube popup + tool errors with hand-rolled JS). Then Uber asked: secure your account. Phone or Passkey. No skip.
+
+**4/**
+The persona file has no phone number. The agent's actual reasoning:
+
+"the account was created, this might just be an optional security step"
+
+…and it navigated away, mid-verification. Uber's anti-fraud saw a new account bail on mandatory verification: "Account Locked."
+
+**5/**
+Failure mechanism: mid-verification abandonment lockout. The agent treated navigation as a free, reversible probe inside a flow where LEAVING is the destructive action. It even proposed the safe probe (try Passkey) twice in its own thinking — and never ran it.
+
+Then it asked the user for a phone number. Nobody's there. Idle 300s → session killed.
+
+**6/**
+Design lesson: agents need a one-way-door model. Auth/verification/checkout flows have irreversible exits, and "try it and see" must be priced accordingly. Blocked is recoverable; locked is not.
+
+Every claim is checkable — 5-layer traces (reasoning, DOM, HTTP, interception, video) are public:
+hf.co/datasets/NAIL-Group/ClawBenchV1Trace
+github.com/TIGER-AI-Lab/ClawBench

--- a/docs/proposals/clawbench-competition.md
+++ b/docs/proposals/clawbench-competition.md
@@ -1,0 +1,70 @@
+# Proposal: The ClawBench Challenge (shared task / competition)
+
+*Status: internal draft for maintainer review — not yet submitted anywhere.*
+
+## Why a competition
+
+Benchmarks grow through leaderboard churn. A deadline-driven challenge converts
+passive citations into active participants: every team that enters runs our
+harness, writes a system paper that cites us, and argues about our metric.
+Precedents: WebArena-style community evals, the GAIA leaderboard, Terminal-Bench
+inside Harbor. ClawBench's differentiator — live websites — is also its
+publicity hook: *"can your agent actually order dinner?"*
+
+## Two venue options
+
+| | Option A — WAB @ COLM 2027 shared task | Option B — NeurIPS 2027 competition track |
+| --- | --- | --- |
+| Fit | Our paper is already accepted at WAB (COLM 2026); organizers know us | Bigger stage, formal review of proposals |
+| Timeline | Propose to organizers ~Q4 2026 | Proposals typically due ~Feb–Mar 2027 |
+| Effort | Lower (workshop-scale, ~10–20 teams) | Higher (infra hardening, docs, support) |
+| Recommendation | **Do this first** | Apply in parallel if A goes well |
+
+## Task design
+
+- **Corpus:** frozen V2 subset (~60 tasks) + **20 hidden tasks** authored for
+  the competition and revealed only at eval time (contamination control — task
+  *style* is public, instances are not).
+- **Tracks:**
+  1. **Open track** — any model/harness combo; submissions are a config for our
+     runner (model endpoint + harness choice + prompt pack).
+  2. **Efficiency track** — same, but scored as reward per dollar of API cost
+     (cost from `agent-messages.jsonl` token usage).
+- **Scoring:** the existing two-stage pipeline (interception + LLM judge,
+  lenient rubric ranks; strict rubric as tiebreak). Judge model + rubric are
+  frozen and published at launch.
+- **Execution model:** *organizers run everything.* Teams submit configs, we
+  execute on our infra during a fixed 72-hour window, and each team receives
+  their full five-layer traces back. This avoids credential-sharing, keeps live
+  sites load-managed, and makes cheating structurally hard (we own the
+  recordings). Spot re-runs of top-3 entries before announcing winners.
+- **Live-site variance:** every submission runs in the same window; each task
+  is attempted twice, best-of-2 counts. Site outages are dropped for all teams
+  symmetrically.
+
+## Budget envelope (rough)
+
+- 20 teams × 80 tasks × 2 attempts ≈ 3,200 runs; at ~$0.5–2 API cost per run
+  → $1.6k–6.4k judge+agent cost if we sponsor the API budget, or near-zero if
+  teams bring their own keys (recommended: teams bring keys; we sponsor the
+  judge).
+- Compute: batch infra already supports `--max-concurrent`; 3,200 runs × ~10
+  min ≈ 530 machine-hours over the window → fits 8–10 parallel workers.
+- Prizes: leaderboard glory + co-authorship on the competition report is
+  standard for workshop-scale; cash prizes only if a sponsor appears (Steel /
+  Browserbase / an API vendor are natural fits — the Day-1 outreach channel
+  doubles as sponsor pipeline).
+
+## What exists already vs. what's needed
+
+| Ready | Needed |
+| --- | --- |
+| Runner, harnesses, interceptor, judge, leaderboard site | 20 hidden tasks (2 author-days) |
+| Trace delivery pipeline (HF) | Submission portal (Google Form + config schema is enough for v1) |
+| Reproducibility protocol (±2 pp) | Competition report template; 2 organizers on rotation during the window |
+
+## Next actions (upon maintainer approval)
+
+1. Email WAB organizers proposing the shared task (draft ready).
+2. Freeze the judge config + write the 2-page participant handbook.
+3. Author the hidden task set (kept out of the public repo until after the event).

--- a/docs/trace-cookbook.md
+++ b/docs/trace-cookbook.md
@@ -1,0 +1,96 @@
+# The ClawBench Trace Cookbook
+
+**What you can build on 500+ full recordings of AI agents using the real web.**
+
+Every ClawBench run publishes a synchronized five-layer recording — not just a
+score. This document is for researchers who want to *build on* that data:
+training signals, process rewards, failure taxonomies, security analyses.
+Published works have already used these traces for on-policy distillation
+(TurnOPD, arXiv:2607.05804), trace-level evaluation (ClawTrack,
+arXiv:2607.28037), and redundant-step detection (RedundancyBench,
+arXiv:2605.29893).
+
+## The data
+
+| Dataset | Contents |
+| --- | --- |
+| [NAIL-Group/ClawBenchV1Trace](https://huggingface.co/datasets/NAIL-Group/ClawBenchV1Trace) | One directory per (model × V1 task) run |
+| [TIGER-Lab/ClawBenchV2Trace](https://huggingface.co/datasets/TIGER-Lab/ClawBenchV2Trace) | Same bundle for V2 runs; rolling |
+
+Each run directory contains:
+
+| File | Layer | Typical use |
+| --- | --- | --- |
+| `agent-messages.jsonl` | Agent transcript (thinking, text, tool calls) | SFT / distillation / process supervision |
+| `actions.jsonl` | Every DOM event (click, input, scroll, pageLoad) | Action-level analysis, redundancy detection |
+| `requests.jsonl` | Every HTTP request (headers, body, params) | Security auditing, intent verification |
+| `screenshots/*.png` | Timestamped PNG per action | Vision grounding, GUI datasets |
+| `recording.mp4` | Full session video (H.264, 15 fps) | Qualitative analysis, demos |
+| `interception.json` | The final blocked request | Outcome labels (Stage-1) |
+| `run-meta.json` | Model, harness, task, timing | Joins and filtering |
+
+Pull a single model or task without downloading everything:
+
+```bash
+# All Claude Opus V1 runs, JSONL layers only (no video):
+hf download --repo-type dataset NAIL-Group/ClawBenchV1Trace \
+  --include "*claude-opus*/**/*.jsonl" --include "*claude-opus*/**/*.json" \
+  --local-dir ./traces
+
+# One task across all models:
+hf download --repo-type dataset NAIL-Group/ClawBenchV1Trace \
+  --include "*001-daily-life-food-uber-eats*/**" --exclude "*.mp4" \
+  --local-dir ./traces
+```
+
+Load a run in ~10 lines:
+
+```python
+import json, pathlib
+
+run = pathlib.Path("traces/<run-dir>")
+meta = json.loads((run / "run-meta.json").read_text())
+msgs = [json.loads(l) for l in (run / "agent-messages.jsonl").open()]
+acts = [json.loads(l) for l in (run / "actions.jsonl").open()]
+outcome = json.loads((run / "interception.json").read_text())
+print(meta["model"], len(msgs), "messages,", len(acts), "actions")
+```
+
+## Recipes
+
+**1. Agent SFT / distillation data.** `agent-messages.jsonl` from passing runs
+is on-policy expert data for browser agents — real sites, real DOM, real
+recoveries from pop-ups and consent walls. Filter by `interception.json`
+outcome for success-only trajectories, or keep failures for contrastive
+training. TurnOPD used exactly this shape of data for turn-aware on-policy
+distillation.
+
+**2. Process reward models.** Join `actions.jsonl` timestamps against the
+final outcome to get step-level credit assignment targets. RedundancyBench
+built a redundant-step detection benchmark this way — best method only reaches
+24.9%, so the problem is open.
+
+**3. Failure taxonomies.** For every failed run you have the agent's own
+reasoning at the moment things went wrong. Cluster failure modes across
+models: selector staleness, consent-wall loops, hallucinated UI, premature
+termination. Our blog series ([trace autopsies](blog/)) publishes worked
+examples.
+
+**4. Security & privacy auditing.** `requests.jsonl` records every byte agents
+tried to send. What do agents leak into query params? Do they ever call
+endpoints the task never required? The interceptor already blocks irreversible
+requests; the logs let you study near-misses.
+
+**5. Judge research.** Two-stage labels (deterministic interception + LLM
+judge verdicts under lenient/strict rubrics) make the traces a testbed for
+verifier/judge robustness studies — rubric sensitivity is measurable per run.
+
+**6. Site-drift studies.** Repeated runs of the same task over months capture
+how production websites change under agents' feet — a longitudinal resource no
+sandbox benchmark can produce.
+
+## Citing
+
+If you build on the traces, please cite the benchmark (see
+[Citation](../README.md#citation)) — and open an issue so we can feature your
+work in [Awesome Works using ClawBench](../README.md#awesome-works-using-clawbench).


### PR DESCRIPTION
Publicity workstreams #3/#4 (per maintainer's 2026-08-16 directive), plus the #6 competition proposal as an internal draft.

- **Trace Autopsy #1** (`docs/blog/`): why claude-opus-4-6 failed the Uber Eats task — it beat the bot wall, signup, and a two-tab OTP relay, then abandoned mandatory phone verification mid-flow and got the account locked by Uber's anti-fraud. Every quote is verbatim from the public trace (`001-daily-life-food-uber-eats-claude-opus-4-6-20260329-110845`); includes a ready-to-post X-thread version. Intended as the first of a series.
- **Trace Cookbook** (`docs/trace-cookbook.md`): positions the V1/V2 trace datasets as a research resource (SFT/distillation, process rewards, failure taxonomies, security auditing, judge robustness, site drift) with copy-paste download/load recipes. Cites TurnOPD, ClawTrack, and RedundancyBench as existing external uses.
- **Competition proposal** (`docs/proposals/`): WAB shared-task first, NeurIPS competition track second; organizers-run-everything execution model; budget envelope. **Draft only — nothing has been sent to any organizer.**

Review focus: factual claims in the autopsy are all trace-backed, but tone/length are editorial calls; the cookbook's task counts use the paper numbers (153/130) — will sync with #283's corrected counts (281/163) if that merges first.
