### PR TITLE
test(corpus): pin per-suite task counts so corpus drift fails CI (re #244)

### DIFF
--- a/tests/test_host_tasks.py
+++ b/tests/test_host_tasks.py
@@ -65,3 +65,38 @@ def test_v1_lite_linked_files_are_readable_from_python() -> None:
     for path in linked_files:
         assert path.is_file(), f"{path} should resolve to a readable file"
         assert path.read_bytes(), f"{path} should not be empty"
+
+
+# Pinned corpus sizes. These are the numbers every published denominator, the
+# README, the HF dataset card, and the leaderboard must agree with. Changing a
+# corpus is fine — changing it *silently* is not, so update this table in the
+# same commit that adds or removes tasks (see issue #244).
+EXPECTED_SUITE_SIZES = {
+    "v1": 152,
+    "v2": 129,
+    "v1-lite": 20,
+    "claw-eval": 19,
+}
+
+
+@pytest.mark.parametrize("suite", sorted(EXPECTED_SUITE_SIZES))
+def test_case_suite_sizes_are_pinned(suite: str) -> None:
+    discovered = batch.discover_cases(
+        patterns=None,
+        all_cases=True,
+        cases_dir=batch.CASE_SUITES[suite],
+    )
+
+    assert len(discovered) == EXPECTED_SUITE_SIZES[suite], (
+        f"{suite} has {len(discovered)} cases but EXPECTED_SUITE_SIZES pins "
+        f"{EXPECTED_SUITE_SIZES[suite]}. If this change is intentional, update "
+        "EXPECTED_SUITE_SIZES and every published count (README, HF dataset "
+        "card, leaderboard denominators) in the same commit."
+    )
+
+
+def test_expected_sizes_cover_every_builtin_suite() -> None:
+    assert set(EXPECTED_SUITE_SIZES) == set(batch.CASE_SUITES), (
+        "a new built-in suite was added without pinning its size in "
+        "EXPECTED_SUITE_SIZES"
+    )


### PR DESCRIPTION
Closes the CI half of #244.

## Why

`test-cases/v2/` holds **129** tasks; the README, the HF dataset card, and the leaderboard denominators all say **130**. Nobody noticed because no test asserts a corpus size — `test_builtin_case_suites_are_discoverable` only checks that each suite is non-empty. The same blind spot let V1 drift to 152 while the README still advertises 153.

A ~1-task divergence silently changes every reported rate (a 3/129 row is not a 3/130 row), and it is exactly the kind of thing a reproducer notices before we do.

## What this adds

`EXPECTED_SUITE_SIZES` in `tests/test_host_tasks.py` pins all four built-in suites — v1 152, v2 129, v1-lite 20, claw-eval 19 — as they exist on `main` today. Adding or removing tasks is still fine; doing it *silently* now fails CI with a message that names the surfaces to update:

> v2 has 130 cases but EXPECTED_SUITE_SIZES pins 129. If this change is intentional, update EXPECTED_SUITE_SIZES and every published count (README, HF dataset card, leaderboard denominators) in the same commit.

A second test asserts the table covers every entry of `batch.CASE_SUITES`, so a new suite cannot slip in unpinned.

## Not in scope

Whether the truth should be 129 or 130 — i.e. restoring the missing task versus correcting the published number — is the maintainer decision in #244. This PR pins today's reality so the answer can't drift again while that's decided; flipping the pin to 130 is a one-line change once the task is restored.

`pytest tests/test_host_tasks.py` → 14 passed; ruff format/check clean.
