### PR TITLE
Add 60 public-registry verification tasks

### DIFF
--- a/test-cases/v1/887-academia-research-public-registry-crossref-10-1038-s41586-020-2649-2/task.json
+++ b/test-cases/v1/887-academia-research-public-registry-crossref-10-1038-s41586-020-2649-2/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 887,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1038/s41586-020-2649-2 and complete this verification: Use Crossref to look up DOI 10.1038/s41586-020-2649-2. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1038/s41586-020-2649-2"
+  },
+  "instruction": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1038/s41586-020-2649-2 and complete this verification: Use Crossref to look up DOI 10.1038/s41586-020-2649-2. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Array programming with NumPy\nPublication year: 2020\nCrossref type: journal-article\nDOI: 10.1038/s41586-020-2649-2"
+  }
+}

--- a/test-cases/v1/888-academia-research-public-registry-crossref-10-1126-science-169-3946-635/task.json
+++ b/test-cases/v1/888-academia-research-public-registry-crossref-10-1126-science-169-3946-635/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 888,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A release manager is checking a frozen public-record export before publication. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1126/science.169.3946.635 and complete this verification: Use Crossref to look up DOI 10.1126/science.169.3946.635. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1126/science.169.3946.635"
+  },
+  "instruction": "A release manager is checking a frozen public-record export before publication. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1126/science.169.3946.635 and complete this verification: Use Crossref to look up DOI 10.1126/science.169.3946.635. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: The Structure of Ordinary Water\nPublication year: 1970\nCrossref type: journal-article\nDOI: 10.1126/science.169.3946.635"
+  }
+}

--- a/test-cases/v1/889-academia-research-public-registry-crossref-10-1145-3290605-3300233/task.json
+++ b/test-cases/v1/889-academia-research-public-registry-crossref-10-1145-3290605-3300233/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 889,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1145/3290605.3300233 and complete this verification: Use Crossref to look up DOI 10.1145/3290605.3300233. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1145/3290605.3300233"
+  },
+  "instruction": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1145/3290605.3300233 and complete this verification: Use Crossref to look up DOI 10.1145/3290605.3300233. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Guidelines for Human-AI Interaction\nPublication year: 2019\nCrossref type: proceedings-article\nDOI: 10.1145/3290605.3300233"
+  }
+}

--- a/test-cases/v1/890-academia-research-public-registry-crossref-10-1371-journal-pone-0000308/task.json
+++ b/test-cases/v1/890-academia-research-public-registry-crossref-10-1371-journal-pone-0000308/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 890,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1371/journal.pone.0000308 and complete this verification: Use Crossref to look up DOI 10.1371/journal.pone.0000308. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1371/journal.pone.0000308"
+  },
+  "instruction": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1371/journal.pone.0000308 and complete this verification: Use Crossref to look up DOI 10.1371/journal.pone.0000308. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Sharing Detailed Research Data Is Associated with Increased Citation Rate\nPublication year: 2007\nCrossref type: journal-article\nDOI: 10.1371/journal.pone.0000308"
+  }
+}

--- a/test-cases/v1/891-academia-research-public-registry-crossref-10-1109-5-771073/task.json
+++ b/test-cases/v1/891-academia-research-public-registry-crossref-10-1109-5-771073/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 891,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A compliance workbook has one record whose public fields must be verified. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1109/5.771073 and complete this verification: Use Crossref to look up DOI 10.1109/5.771073. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1109/5.771073"
+  },
+  "instruction": "A compliance workbook has one record whose public fields must be verified. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1109/5.771073 and complete this verification: Use Crossref to look up DOI 10.1109/5.771073. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Toward unique identifiers\nPublication year: 1999\nCrossref type: journal-article\nDOI: 10.1109/5.771073"
+  }
+}

--- a/test-cases/v1/892-academia-research-public-registry-crossref-10-1038-227680a0/task.json
+++ b/test-cases/v1/892-academia-research-public-registry-crossref-10-1038-227680a0/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 892,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1038/227680a0 and complete this verification: Use Crossref to look up DOI 10.1038/227680a0. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1038/227680a0"
+  },
+  "instruction": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1038/227680a0 and complete this verification: Use Crossref to look up DOI 10.1038/227680a0. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Cleavage of Structural Proteins during the Assembly of the Head of Bacteriophage T4\nPublication year: 1970\nCrossref type: journal-article\nDOI: 10.1038/227680a0"
+  }
+}

--- a/test-cases/v1/893-academia-research-public-registry-crossref-10-1016-j-cell-2008-09-033/task.json
+++ b/test-cases/v1/893-academia-research-public-registry-crossref-10-1016-j-cell-2008-09-033/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 893,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A research librarian is reconciling a record against its authoritative source. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1016/j.cell.2008.09.033 and complete this verification: Use Crossref to look up DOI 10.1016/j.cell.2008.09.033. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1016/j.cell.2008.09.033"
+  },
+  "instruction": "A research librarian is reconciling a record against its authoritative source. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1016/j.cell.2008.09.033 and complete this verification: Use Crossref to look up DOI 10.1016/j.cell.2008.09.033. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: The RNA Polymerase “Switch Region” Is a Target for Inhibitors\nPublication year: 2008\nCrossref type: journal-article\nDOI: 10.1016/j.cell.2008.09.033"
+  }
+}

--- a/test-cases/v1/894-academia-research-public-registry-crossref-10-1073-pnas-95-23-13459/task.json
+++ b/test-cases/v1/894-academia-research-public-registry-crossref-10-1073-pnas-95-23-13459/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 894,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1073/pnas.95.23.13459 and complete this verification: Use Crossref to look up DOI 10.1073/pnas.95.23.13459. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1073/pnas.95.23.13459"
+  },
+  "instruction": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1073/pnas.95.23.13459 and complete this verification: Use Crossref to look up DOI 10.1073/pnas.95.23.13459. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Defects in embryonic hindbrain development and fetal resorption resulting from vitamin A deficiency in the rat are prevented by feeding pharmacological levels of all-\n                    <i>trans-</i>\n                    retinoic acid\nPublication year: 1998\nCrossref type: journal-article\nDOI: 10.1073/pnas.95.23.13459"
+  }
+}

--- a/test-cases/v1/895-academia-research-public-registry-crossref-10-18653-v1-n19-1423/task.json
+++ b/test-cases/v1/895-academia-research-public-registry-crossref-10-18653-v1-n19-1423/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 895,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative crossref public record at https://search.crossref.org/?q=10.18653/v1/N19-1423 and complete this verification: Use Crossref to look up DOI 10.18653/v1/N19-1423. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.18653/v1/N19-1423"
+  },
+  "instruction": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative crossref public record at https://search.crossref.org/?q=10.18653/v1/N19-1423 and complete this verification: Use Crossref to look up DOI 10.18653/v1/N19-1423. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: \nPublication year: 2019\nCrossref type: proceedings-article\nDOI: 10.18653/v1/n19-1423"
+  }
+}

--- a/test-cases/v1/896-academia-research-public-registry-crossref-10-1145-3442188-3445922/task.json
+++ b/test-cases/v1/896-academia-research-public-registry-crossref-10-1145-3442188-3445922/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 896,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1145/3442188.3445922 and complete this verification: Use Crossref to look up DOI 10.1145/3442188.3445922. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "crossref.org"
+    ],
+    "platform": "crossref",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "10.1145/3442188.3445922"
+  },
+  "instruction": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative crossref public record at https://search.crossref.org/?q=10.1145/3442188.3445922 and complete this verification: Use Crossref to look up DOI 10.1145/3442188.3445922. Report its exact title, publication year, Crossref work type, and canonical DOI. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: On the Dangers of Stochastic Parrots\nPublication year: 2021\nCrossref type: proceedings-article\nDOI: 10.1145/3442188.3445922"
+  }
+}

--- a/test-cases/v1/897-academia-research-public-registry-pubmed-31452104/task.json
+++ b/test-cases/v1/897-academia-research-public-registry-pubmed-31452104/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 897,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/31452104/ and complete this verification: Open PubMed record 31452104. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "31452104"
+  },
+  "instruction": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/31452104/ and complete this verification: Open PubMed record 31452104. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Molegro Virtual Docker for Docking\nJournal: Methods in molecular biology (Clifton, N.J.)\nPublication date: 2019\nFirst listed author: Bitencourt-Ferreira G\nPMID: 31452104"
+  }
+}

--- a/test-cases/v1/898-academia-research-public-registry-pubmed-30049270/task.json
+++ b/test-cases/v1/898-academia-research-public-registry-pubmed-30049270/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 898,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A release manager is checking a frozen public-record export before publication. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/30049270/ and complete this verification: Open PubMed record 30049270. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "30049270"
+  },
+  "instruction": "A release manager is checking a frozen public-record export before publication. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/30049270/ and complete this verification: Open PubMed record 30049270. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Stigma and intersectionality: a systematic review of systematic reviews across HIV/AIDS, mental illness, and physical disability\nJournal: BMC public health\nPublication date: 2018 Jul 27\nFirst listed author: Jackson-Best F\nPMID: 30049270"
+  }
+}

--- a/test-cases/v1/899-academia-research-public-registry-pubmed-29302006/task.json
+++ b/test-cases/v1/899-academia-research-public-registry-pubmed-29302006/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 899,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/29302006/ and complete this verification: Open PubMed record 29302006. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "29302006"
+  },
+  "instruction": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/29302006/ and complete this verification: Open PubMed record 29302006. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Transferrin receptor 1 is a reticulocyte-specific receptor for Plasmodium vivax\nJournal: Science (New York, N.Y.)\nPublication date: 2018 Jan 5\nFirst listed author: Gruszczyk J\nPMID: 29302006"
+  }
+}

--- a/test-cases/v1/900-academia-research-public-registry-pubmed-30718840/task.json
+++ b/test-cases/v1/900-academia-research-public-registry-pubmed-30718840/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 900,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/30718840/ and complete this verification: Open PubMed record 30718840. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "30718840"
+  },
+  "instruction": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/30718840/ and complete this verification: Open PubMed record 30718840. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Patterned human microvascular grafts enable rapid vascularization and increase perfusion in infarcted rat hearts\nJournal: Nature communications\nPublication date: 2019 Feb 4\nFirst listed author: Redd MA\nPMID: 30718840"
+  }
+}

--- a/test-cases/v1/901-academia-research-public-registry-pubmed-32416070/task.json
+++ b/test-cases/v1/901-academia-research-public-registry-pubmed-32416070/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 901,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A compliance workbook has one record whose public fields must be verified. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/32416070/ and complete this verification: Open PubMed record 32416070. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "32416070"
+  },
+  "instruction": "A compliance workbook has one record whose public fields must be verified. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/32416070/ and complete this verification: Open PubMed record 32416070. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Imbalanced Host Response to SARS-CoV-2 Drives Development of COVID-19\nJournal: Cell\nPublication date: 2020 May 28\nFirst listed author: Blanco-Melo D\nPMID: 32416070"
+  }
+}

--- a/test-cases/v1/902-academia-research-public-registry-pubmed-32929240/task.json
+++ b/test-cases/v1/902-academia-research-public-registry-pubmed-32929240/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 902,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/32929240/ and complete this verification: Open PubMed record 32929240. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "32929240"
+  },
+  "instruction": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/32929240/ and complete this verification: Open PubMed record 32929240. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Tropical and Mediterranean biodiversity is disproportionately sensitive to land-use and climate change\nJournal: Nature ecology & evolution\nPublication date: 2020 Dec\nFirst listed author: Newbold T\nPMID: 32929240"
+  }
+}

--- a/test-cases/v1/903-academia-research-public-registry-pubmed-33911278/task.json
+++ b/test-cases/v1/903-academia-research-public-registry-pubmed-33911278/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 903,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A research librarian is reconciling a record against its authoritative source. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/33911278/ and complete this verification: Open PubMed record 33911278. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "33911278"
+  },
+  "instruction": "A research librarian is reconciling a record against its authoritative source. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/33911278/ and complete this verification: Open PubMed record 33911278. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: It's time to invite more people to join clinical trials\nJournal: Nature\nPublication date: 2021 Apr\nFirst listed author: \nPMID: 33911278"
+  }
+}

--- a/test-cases/v1/904-academia-research-public-registry-pubmed-34401850/task.json
+++ b/test-cases/v1/904-academia-research-public-registry-pubmed-34401850/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 904,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/34401850/ and complete this verification: Open PubMed record 34401850. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "34401850"
+  },
+  "instruction": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/34401850/ and complete this verification: Open PubMed record 34401850. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Commentary: What's old is new again: Atrial baffle for complex cardiac transplantation\nJournal: JTCVS techniques\nPublication date: 2021 Aug\nFirst listed author: Bryant R 3rd\nPMID: 34401850"
+  }
+}

--- a/test-cases/v1/905-academia-research-public-registry-pubmed-35031615/task.json
+++ b/test-cases/v1/905-academia-research-public-registry-pubmed-35031615/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 905,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/35031615/ and complete this verification: Open PubMed record 35031615. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "35031615"
+  },
+  "instruction": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/35031615/ and complete this verification: Open PubMed record 35031615. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Uncovering the reaction mechanism behind CoO as active phase for CO(2) hydrogenation\nJournal: Nature communications\nPublication date: 2022 Jan 14\nFirst listed author: Have ICT\nPMID: 35031615"
+  }
+}

--- a/test-cases/v1/906-academia-research-public-registry-pubmed-36326639/task.json
+++ b/test-cases/v1/906-academia-research-public-registry-pubmed-36326639/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 906,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/36326639/ and complete this verification: Open PubMed record 36326639. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "pubmed.ncbi.nlm.nih.gov"
+    ],
+    "platform": "pubmed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "36326639"
+  },
+  "instruction": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative pubmed public record at https://pubmed.ncbi.nlm.nih.gov/36326639/ and complete this verification: Open PubMed record 36326639. Report the exact article title, full journal name, displayed publication date, first listed author, and PMID. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Title: Number lines can be more effective at facilitating adults' performance on health-related ratio problems than risk ladders and icon arrays\nJournal: Journal of experimental psychology. Applied\nPublication date: 2023 Sep\nFirst listed author: Mielicki MK\nPMID: 36326639"
+  }
+}

--- a/test-cases/v1/907-academia-research-public-registry-clinicaltrials-gov-nct04280705/task.json
+++ b/test-cases/v1/907-academia-research-public-registry-clinicaltrials-gov-nct04280705/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 907,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04280705 and complete this verification: Open ClinicalTrials.gov study NCT04280705. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT04280705"
+  },
+  "instruction": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04280705 and complete this verification: Open ClinicalTrials.gov study NCT04280705. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: Adaptive COVID-19 Treatment Trial (ACTT)\nOverall status: COMPLETED\nStart date: 2020-02-21\nStudy type: INTERVENTIONAL\nNCT number: NCT04280705"
+  }
+}

--- a/test-cases/v1/908-academia-research-public-registry-clinicaltrials-gov-nct04368728/task.json
+++ b/test-cases/v1/908-academia-research-public-registry-clinicaltrials-gov-nct04368728/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 908,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A release manager is checking a frozen public-record export before publication. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04368728 and complete this verification: Open ClinicalTrials.gov study NCT04368728. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT04368728"
+  },
+  "instruction": "A release manager is checking a frozen public-record export before publication. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04368728 and complete this verification: Open ClinicalTrials.gov study NCT04368728. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: Study to Describe the Safety, Tolerability, Immunogenicity, and Efficacy of RNA Vaccine Candidates Against COVID-19 in Healthy Individuals\nOverall status: COMPLETED\nStart date: 2020-04-29\nStudy type: INTERVENTIONAL\nNCT number: NCT04368728"
+  }
+}

--- a/test-cases/v1/909-academia-research-public-registry-clinicaltrials-gov-nct04470427/task.json
+++ b/test-cases/v1/909-academia-research-public-registry-clinicaltrials-gov-nct04470427/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 909,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04470427 and complete this verification: Open ClinicalTrials.gov study NCT04470427. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT04470427"
+  },
+  "instruction": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04470427 and complete this verification: Open ClinicalTrials.gov study NCT04470427. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: A Study to Evaluate Efficacy, Safety, and Immunogenicity of mRNA-1273 Vaccine in Adults Aged 18 Years and Older to Prevent COVID-19\nOverall status: COMPLETED\nStart date: 2020-07-27\nStudy type: INTERVENTIONAL\nNCT number: NCT04470427"
+  }
+}

--- a/test-cases/v1/910-academia-research-public-registry-clinicaltrials-gov-nct04516746/task.json
+++ b/test-cases/v1/910-academia-research-public-registry-clinicaltrials-gov-nct04516746/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 910,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04516746 and complete this verification: Open ClinicalTrials.gov study NCT04516746. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT04516746"
+  },
+  "instruction": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04516746 and complete this verification: Open ClinicalTrials.gov study NCT04516746. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: Phase III Double-blind, Placebo-controlled Study of AZD1222 for the Prevention of COVID-19 in Adults\nOverall status: COMPLETED\nStart date: 2020-08-28\nStudy type: INTERVENTIONAL\nNCT number: NCT04516746"
+  }
+}

--- a/test-cases/v1/911-academia-research-public-registry-clinicaltrials-gov-nct04611802/task.json
+++ b/test-cases/v1/911-academia-research-public-registry-clinicaltrials-gov-nct04611802/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 911,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A compliance workbook has one record whose public fields must be verified. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04611802 and complete this verification: Open ClinicalTrials.gov study NCT04611802. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT04611802"
+  },
+  "instruction": "A compliance workbook has one record whose public fields must be verified. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04611802 and complete this verification: Open ClinicalTrials.gov study NCT04611802. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: A Study to Evaluate the Efficacy, Immune Response, and Safety of a COVID-19 Vaccine in Adults ≥ 18 Years With a Pediatric Expansion in Adolescents (12 to<18 Years) at Risk for SARS-CoV-2\nOverall status: COMPLETED\nStart date: 2020-12-27\nStudy type: INTERVENTIONAL\nNCT number: NCT04611802"
+  }
+}

--- a/test-cases/v1/912-academia-research-public-registry-clinicaltrials-gov-nct04796896/task.json
+++ b/test-cases/v1/912-academia-research-public-registry-clinicaltrials-gov-nct04796896/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 912,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04796896 and complete this verification: Open ClinicalTrials.gov study NCT04796896. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT04796896"
+  },
+  "instruction": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT04796896 and complete this verification: Open ClinicalTrials.gov study NCT04796896. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: A Study to Evaluate Safety and Effectiveness of mRNA-1273 COVID-19 Vaccine in Healthy Children Between 6 Months of Age and Less Than 12 Years of Age\nOverall status: COMPLETED\nStart date: 2021-03-15\nStudy type: INTERVENTIONAL\nNCT number: NCT04796896"
+  }
+}

--- a/test-cases/v1/913-academia-research-public-registry-clinicaltrials-gov-nct05057234/task.json
+++ b/test-cases/v1/913-academia-research-public-registry-clinicaltrials-gov-nct05057234/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 913,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A research librarian is reconciling a record against its authoritative source. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT05057234 and complete this verification: Open ClinicalTrials.gov study NCT05057234. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT05057234"
+  },
+  "instruction": "A research librarian is reconciling a record against its authoritative source. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT05057234 and complete this verification: Open ClinicalTrials.gov study NCT05057234. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: PRecision Oncology Evidence Development in Cancer Treatment - Liquid\nOverall status: ACTIVE_NOT_RECRUITING\nStart date: 2021-06-18\nStudy type: INTERVENTIONAL\nNCT number: NCT05057234"
+  }
+}

--- a/test-cases/v1/914-academia-research-public-registry-clinicaltrials-gov-nct05249829/task.json
+++ b/test-cases/v1/914-academia-research-public-registry-clinicaltrials-gov-nct05249829/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 914,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT05249829 and complete this verification: Open ClinicalTrials.gov study NCT05249829. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT05249829"
+  },
+  "instruction": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT05249829 and complete this verification: Open ClinicalTrials.gov study NCT05249829. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: A Study to Evaluate the Immunogenicity and Safety of Omicron Variant Vaccines in Comparison With mRNA-1273 Booster Vaccine for COVID-19\nOverall status: COMPLETED\nStart date: 2022-02-16\nStudy type: INTERVENTIONAL\nNCT number: NCT05249829"
+  }
+}

--- a/test-cases/v1/915-academia-research-public-registry-clinicaltrials-gov-nct05590169/task.json
+++ b/test-cases/v1/915-academia-research-public-registry-clinicaltrials-gov-nct05590169/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 915,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT05590169 and complete this verification: Open ClinicalTrials.gov study NCT05590169. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT05590169"
+  },
+  "instruction": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT05590169 and complete this verification: Open ClinicalTrials.gov study NCT05590169. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: Effects of Telerehabilitation-based Exercises in Cystic Fibrosis\nOverall status: COMPLETED\nStart date: 2023-05-20\nStudy type: INTERVENTIONAL\nNCT number: NCT05590169"
+  }
+}

--- a/test-cases/v1/916-academia-research-public-registry-clinicaltrials-gov-nct06000059/task.json
+++ b/test-cases/v1/916-academia-research-public-registry-clinicaltrials-gov-nct06000059/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 916,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT06000059 and complete this verification: Open ClinicalTrials.gov study NCT06000059. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "clinicaltrials.gov"
+    ],
+    "platform": "clinicaltrials-gov",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "NCT06000059"
+  },
+  "instruction": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative clinicaltrials-gov public record at https://clinicaltrials.gov/study/NCT06000059 and complete this verification: Open ClinicalTrials.gov study NCT06000059. Report its brief title, overall status, start date, study type, and NCT number exactly as displayed. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Brief title: Mental Health Stigma in Rural Uganda\nOverall status: COMPLETED\nStart date: 2023-08-10\nStudy type: INTERVENTIONAL\nNCT number: NCT06000059"
+  }
+}

--- a/test-cases/v1/917-academia-research-public-registry-github-python-cpython/task.json
+++ b/test-cases/v1/917-academia-research-public-registry-github-python-cpython/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 917,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative github public record at https://github.com/python/cpython and complete this verification: On GitHub, inspect repository python/cpython. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "python/cpython"
+  },
+  "instruction": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative github public record at https://github.com/python/cpython and complete this verification: On GitHub, inspect repository python/cpython. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: python/cpython\nCreated date: 2017-02-10\nDefault branch: main\nLicense SPDX: NOASSERTION"
+  }
+}

--- a/test-cases/v1/918-academia-research-public-registry-github-rust-lang-rust/task.json
+++ b/test-cases/v1/918-academia-research-public-registry-github-rust-lang-rust/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 918,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A release manager is checking a frozen public-record export before publication. Open the authoritative github public record at https://github.com/rust-lang/rust and complete this verification: On GitHub, inspect repository rust-lang/rust. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "rust-lang/rust"
+  },
+  "instruction": "A release manager is checking a frozen public-record export before publication. Open the authoritative github public record at https://github.com/rust-lang/rust and complete this verification: On GitHub, inspect repository rust-lang/rust. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: rust-lang/rust\nCreated date: 2010-06-16\nDefault branch: main\nLicense SPDX: Apache-2.0"
+  }
+}

--- a/test-cases/v1/919-academia-research-public-registry-github-kubernetes-kubernetes/task.json
+++ b/test-cases/v1/919-academia-research-public-registry-github-kubernetes-kubernetes/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 919,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative github public record at https://github.com/kubernetes/kubernetes and complete this verification: On GitHub, inspect repository kubernetes/kubernetes. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "kubernetes/kubernetes"
+  },
+  "instruction": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative github public record at https://github.com/kubernetes/kubernetes and complete this verification: On GitHub, inspect repository kubernetes/kubernetes. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: kubernetes/kubernetes\nCreated date: 2014-06-06\nDefault branch: master\nLicense SPDX: Apache-2.0"
+  }
+}

--- a/test-cases/v1/920-academia-research-public-registry-github-pandas-dev-pandas/task.json
+++ b/test-cases/v1/920-academia-research-public-registry-github-pandas-dev-pandas/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 920,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative github public record at https://github.com/pandas-dev/pandas and complete this verification: On GitHub, inspect repository pandas-dev/pandas. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "pandas-dev/pandas"
+  },
+  "instruction": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative github public record at https://github.com/pandas-dev/pandas and complete this verification: On GitHub, inspect repository pandas-dev/pandas. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: pandas-dev/pandas\nCreated date: 2010-08-24\nDefault branch: main\nLicense SPDX: BSD-3-Clause"
+  }
+}

--- a/test-cases/v1/921-academia-research-public-registry-github-numpy-numpy/task.json
+++ b/test-cases/v1/921-academia-research-public-registry-github-numpy-numpy/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 921,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A compliance workbook has one record whose public fields must be verified. Open the authoritative github public record at https://github.com/numpy/numpy and complete this verification: On GitHub, inspect repository numpy/numpy. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "numpy/numpy"
+  },
+  "instruction": "A compliance workbook has one record whose public fields must be verified. Open the authoritative github public record at https://github.com/numpy/numpy and complete this verification: On GitHub, inspect repository numpy/numpy. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: numpy/numpy\nCreated date: 2010-09-13\nDefault branch: main\nLicense SPDX: NOASSERTION"
+  }
+}

--- a/test-cases/v1/922-academia-research-public-registry-github-django-django/task.json
+++ b/test-cases/v1/922-academia-research-public-registry-github-django-django/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 922,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative github public record at https://github.com/django/django and complete this verification: On GitHub, inspect repository django/django. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "django/django"
+  },
+  "instruction": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative github public record at https://github.com/django/django and complete this verification: On GitHub, inspect repository django/django. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: django/django\nCreated date: 2012-04-28\nDefault branch: main\nLicense SPDX: BSD-3-Clause"
+  }
+}

--- a/test-cases/v1/923-academia-research-public-registry-github-pytorch-pytorch/task.json
+++ b/test-cases/v1/923-academia-research-public-registry-github-pytorch-pytorch/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 923,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A research librarian is reconciling a record against its authoritative source. Open the authoritative github public record at https://github.com/pytorch/pytorch and complete this verification: On GitHub, inspect repository pytorch/pytorch. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "pytorch/pytorch"
+  },
+  "instruction": "A research librarian is reconciling a record against its authoritative source. Open the authoritative github public record at https://github.com/pytorch/pytorch and complete this verification: On GitHub, inspect repository pytorch/pytorch. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: pytorch/pytorch\nCreated date: 2016-08-13\nDefault branch: main\nLicense SPDX: NOASSERTION"
+  }
+}

--- a/test-cases/v1/924-academia-research-public-registry-github-tensorflow-tensorflow/task.json
+++ b/test-cases/v1/924-academia-research-public-registry-github-tensorflow-tensorflow/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 924,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative github public record at https://github.com/tensorflow/tensorflow and complete this verification: On GitHub, inspect repository tensorflow/tensorflow. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "tensorflow/tensorflow"
+  },
+  "instruction": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative github public record at https://github.com/tensorflow/tensorflow and complete this verification: On GitHub, inspect repository tensorflow/tensorflow. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: tensorflow/tensorflow\nCreated date: 2015-11-07\nDefault branch: master\nLicense SPDX: Apache-2.0"
+  }
+}

--- a/test-cases/v1/925-academia-research-public-registry-github-scikit-learn-scikit-learn/task.json
+++ b/test-cases/v1/925-academia-research-public-registry-github-scikit-learn-scikit-learn/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 925,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative github public record at https://github.com/scikit-learn/scikit-learn and complete this verification: On GitHub, inspect repository scikit-learn/scikit-learn. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "scikit-learn/scikit-learn"
+  },
+  "instruction": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative github public record at https://github.com/scikit-learn/scikit-learn and complete this verification: On GitHub, inspect repository scikit-learn/scikit-learn. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: scikit-learn/scikit-learn\nCreated date: 2010-08-17\nDefault branch: main\nLicense SPDX: BSD-3-Clause"
+  }
+}

--- a/test-cases/v1/926-academia-research-public-registry-github-apache-airflow/task.json
+++ b/test-cases/v1/926-academia-research-public-registry-github-apache-airflow/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 926,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative github public record at https://github.com/apache/airflow and complete this verification: On GitHub, inspect repository apache/airflow. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "apache/airflow"
+  },
+  "instruction": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative github public record at https://github.com/apache/airflow and complete this verification: On GitHub, inspect repository apache/airflow. Report its canonical full name, creation date, default branch, and detected license SPDX identifier. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Repository: apache/airflow\nCreated date: 2015-04-13\nDefault branch: main\nLicense SPDX: Apache-2.0"
+  }
+}

--- a/test-cases/v1/927-academia-research-public-registry-world-bank-ca/task.json
+++ b/test-cases/v1/927-academia-research-public-registry-world-bank-ca/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 927,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=CA and complete this verification: Use the World Bank indicator page for CA. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "CA"
+  },
+  "instruction": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=CA and complete this verification: Use the World Bank indicator page for CA. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: Canada\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 41651653"
+  }
+}

--- a/test-cases/v1/928-academia-research-public-registry-world-bank-us/task.json
+++ b/test-cases/v1/928-academia-research-public-registry-world-bank-us/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 928,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A release manager is checking a frozen public-record export before publication. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=US and complete this verification: Use the World Bank indicator page for US. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "US"
+  },
+  "instruction": "A release manager is checking a frozen public-record export before publication. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=US and complete this verification: Use the World Bank indicator page for US. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: United States\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 341784857"
+  }
+}

--- a/test-cases/v1/929-academia-research-public-registry-world-bank-gb/task.json
+++ b/test-cases/v1/929-academia-research-public-registry-world-bank-gb/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 929,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=GB and complete this verification: Use the World Bank indicator page for GB. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "GB"
+  },
+  "instruction": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=GB and complete this verification: Use the World Bank indicator page for GB. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: United Kingdom\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 69487000"
+  }
+}

--- a/test-cases/v1/930-academia-research-public-registry-world-bank-fr/task.json
+++ b/test-cases/v1/930-academia-research-public-registry-world-bank-fr/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 930,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=FR and complete this verification: Use the World Bank indicator page for FR. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "FR"
+  },
+  "instruction": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=FR and complete this verification: Use the World Bank indicator page for FR. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: France\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 68720337"
+  }
+}

--- a/test-cases/v1/931-academia-research-public-registry-world-bank-de/task.json
+++ b/test-cases/v1/931-academia-research-public-registry-world-bank-de/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 931,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A compliance workbook has one record whose public fields must be verified. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=DE and complete this verification: Use the World Bank indicator page for DE. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "DE"
+  },
+  "instruction": "A compliance workbook has one record whose public fields must be verified. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=DE and complete this verification: Use the World Bank indicator page for DE. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: Germany\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 83491249"
+  }
+}

--- a/test-cases/v1/932-academia-research-public-registry-world-bank-jp/task.json
+++ b/test-cases/v1/932-academia-research-public-registry-world-bank-jp/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 932,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=JP and complete this verification: Use the World Bank indicator page for JP. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "JP"
+  },
+  "instruction": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=JP and complete this verification: Use the World Bank indicator page for JP. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: Japan\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 123366734"
+  }
+}

--- a/test-cases/v1/933-academia-research-public-registry-world-bank-in/task.json
+++ b/test-cases/v1/933-academia-research-public-registry-world-bank-in/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 933,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A research librarian is reconciling a record against its authoritative source. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=IN and complete this verification: Use the World Bank indicator page for IN. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "IN"
+  },
+  "instruction": "A research librarian is reconciling a record against its authoritative source. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=IN and complete this verification: Use the World Bank indicator page for IN. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: India\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 1463865525"
+  }
+}

--- a/test-cases/v1/934-academia-research-public-registry-world-bank-br/task.json
+++ b/test-cases/v1/934-academia-research-public-registry-world-bank-br/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 934,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=BR and complete this verification: Use the World Bank indicator page for BR. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "BR"
+  },
+  "instruction": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=BR and complete this verification: Use the World Bank indicator page for BR. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: Brazil\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 212812405"
+  }
+}

--- a/test-cases/v1/935-academia-research-public-registry-world-bank-za/task.json
+++ b/test-cases/v1/935-academia-research-public-registry-world-bank-za/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 935,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=ZA and complete this verification: Use the World Bank indicator page for ZA. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "ZA"
+  },
+  "instruction": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=ZA and complete this verification: Use the World Bank indicator page for ZA. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: South Africa\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 64747319"
+  }
+}

--- a/test-cases/v1/936-academia-research-public-registry-world-bank-au/task.json
+++ b/test-cases/v1/936-academia-research-public-registry-world-bank-au/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 936,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=AU and complete this verification: Use the World Bank indicator page for AU. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "worldbank.org"
+    ],
+    "platform": "world-bank",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "AU"
+  },
+  "instruction": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative world-bank public record at https://data.worldbank.org/indicator/SP.POP.TOTL?locations=AU and complete this verification: Use the World Bank indicator page for AU. Report the country name, indicator name and code, latest available year, and exact latest non-null value. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Country: Australia\nIndicator: Population, total (SP.POP.TOTL)\nLatest available year: 2025\nValue: 27614411"
+  }
+}

--- a/test-cases/v1/937-academia-research-public-registry-sec-edgar-0000320193/task.json
+++ b/test-cases/v1/937-academia-research-public-registry-sec-edgar-0000320193/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 937,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=320193 and complete this verification: Use SEC EDGAR for CIK 0000320193. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0000320193"
+  },
+  "instruction": "A citation-quality analyst must repair one incomplete audit row. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=320193 and complete this verification: Use SEC EDGAR for CIK 0000320193. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: Apple Inc.\nCIK: 0000320193\nPrimary ticker: AAPL\nPrimary exchange: Nasdaq\nSIC: 3571"
+  }
+}

--- a/test-cases/v1/938-academia-research-public-registry-sec-edgar-0000789019/task.json
+++ b/test-cases/v1/938-academia-research-public-registry-sec-edgar-0000789019/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 938,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A release manager is checking a frozen public-record export before publication. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=789019 and complete this verification: Use SEC EDGAR for CIK 0000789019. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0000789019"
+  },
+  "instruction": "A release manager is checking a frozen public-record export before publication. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=789019 and complete this verification: Use SEC EDGAR for CIK 0000789019. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: MICROSOFT CORP\nCIK: 0000789019\nPrimary ticker: MSFT\nPrimary exchange: Nasdaq\nSIC: 7372"
+  }
+}

--- a/test-cases/v1/939-academia-research-public-registry-sec-edgar-0001018724/task.json
+++ b/test-cases/v1/939-academia-research-public-registry-sec-edgar-0001018724/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 939,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1018724 and complete this verification: Use SEC EDGAR for CIK 0001018724. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0001018724"
+  },
+  "instruction": "A provenance reviewer needs an independently reproducible registry lookup. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1018724 and complete this verification: Use SEC EDGAR for CIK 0001018724. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: AMAZON COM INC\nCIK: 0001018724\nPrimary ticker: AMZN\nPrimary exchange: Nasdaq\nSIC: 5961"
+  }
+}

--- a/test-cases/v1/940-academia-research-public-registry-sec-edgar-0001652044/task.json
+++ b/test-cases/v1/940-academia-research-public-registry-sec-edgar-0001652044/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 940,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1652044 and complete this verification: Use SEC EDGAR for CIK 0001652044. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0001652044"
+  },
+  "instruction": "An evidence curator is resolving a conflict between two metadata snapshots. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1652044 and complete this verification: Use SEC EDGAR for CIK 0001652044. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: Alphabet Inc.\nCIK: 0001652044\nPrimary ticker: GOOGL\nPrimary exchange: Nasdaq\nSIC: 7370"
+  }
+}

--- a/test-cases/v1/941-academia-research-public-registry-sec-edgar-0001326801/task.json
+++ b/test-cases/v1/941-academia-research-public-registry-sec-edgar-0001326801/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 941,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A compliance workbook has one record whose public fields must be verified. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1326801 and complete this verification: Use SEC EDGAR for CIK 0001326801. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0001326801"
+  },
+  "instruction": "A compliance workbook has one record whose public fields must be verified. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1326801 and complete this verification: Use SEC EDGAR for CIK 0001326801. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: Meta Platforms, Inc.\nCIK: 0001326801\nPrimary ticker: META\nPrimary exchange: Nasdaq\nSIC: 7370"
+  }
+}

--- a/test-cases/v1/942-academia-research-public-registry-sec-edgar-0001045810/task.json
+++ b/test-cases/v1/942-academia-research-public-registry-sec-edgar-0001045810/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 942,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1045810 and complete this verification: Use SEC EDGAR for CIK 0001045810. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0001045810"
+  },
+  "instruction": "A data steward is validating a registry identifier before an archival freeze. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1045810 and complete this verification: Use SEC EDGAR for CIK 0001045810. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: NVIDIA CORP\nCIK: 0001045810\nPrimary ticker: NVDA\nPrimary exchange: Nasdaq\nSIC: 3674"
+  }
+}

--- a/test-cases/v1/943-academia-research-public-registry-sec-edgar-0001318605/task.json
+++ b/test-cases/v1/943-academia-research-public-registry-sec-edgar-0001318605/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 943,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A research librarian is reconciling a record against its authoritative source. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1318605 and complete this verification: Use SEC EDGAR for CIK 0001318605. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0001318605"
+  },
+  "instruction": "A research librarian is reconciling a record against its authoritative source. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1318605 and complete this verification: Use SEC EDGAR for CIK 0001318605. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: Tesla, Inc.\nCIK: 0001318605\nPrimary ticker: TSLA\nPrimary exchange: Nasdaq\nSIC: 3711"
+  }
+}

--- a/test-cases/v1/944-academia-research-public-registry-sec-edgar-0001067983/task.json
+++ b/test-cases/v1/944-academia-research-public-registry-sec-edgar-0001067983/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 944,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1067983 and complete this verification: Use SEC EDGAR for CIK 0001067983. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0001067983"
+  },
+  "instruction": "A benchmark auditor must confirm a small public fact set without using memory. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=1067983 and complete this verification: Use SEC EDGAR for CIK 0001067983. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: BERKSHIRE HATHAWAY INC\nCIK: 0001067983\nPrimary ticker: BRK-B\nPrimary exchange: NYSE\nSIC: 6331"
+  }
+}

--- a/test-cases/v1/945-academia-research-public-registry-sec-edgar-0000019617/task.json
+++ b/test-cases/v1/945-academia-research-public-registry-sec-edgar-0000019617/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 945,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=19617 and complete this verification: Use SEC EDGAR for CIK 0000019617. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0000019617"
+  },
+  "instruction": "A metadata engineer is checking a record before it enters a versioned catalog. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=19617 and complete this verification: Use SEC EDGAR for CIK 0000019617. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: JPMORGAN CHASE & CO\nCIK: 0000019617\nPrimary ticker: JPM\nPrimary exchange: NYSE\nSIC: 6021"
+  }
+}

--- a/test-cases/v1/946-academia-research-public-registry-sec-edgar-0000104169/task.json
+++ b/test-cases/v1/946-academia-research-public-registry-sec-edgar-0000104169/task.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 946,
+    "metaclass": "academia-research",
+    "class": "public-registry-verification",
+    "description": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=104169 and complete this verification: Use SEC EDGAR for CIK 0000104169. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+    "sites_involved": [
+      "sec.gov"
+    ],
+    "platform": "sec-edgar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "source_snapshot_date": "2026-08-18",
+    "source_key": "0000104169"
+  },
+  "instruction": "A reproducibility reviewer needs a source-grounded answer for one identifier. Open the authoritative sec-edgar public record at https://www.sec.gov/edgar/browse/?CIK=104169 and complete this verification: Use SEC EDGAR for CIK 0000104169. Report the registrant name, zero-padded CIK, primary ticker, primary exchange, and SIC code. Return only the requested labeled fields, one per line. Do not infer missing values, do not use a search-result snippet as the final source, and do not perform any write action.",
+  "eval_schema": {
+    "url_pattern": "__PLACEHOLDER_WILL_NOT_MATCH__",
+    "method": "POST"
+  },
+  "time_limit": 10,
+  "extra_info": [],
+  "judge_context": {
+    "rubric": "Award full credit only when every requested labeled field matches the frozen reference solution exactly in substance, the identifier is correct, and no extra unsupported fact is asserted. Minor punctuation or whitespace differences are acceptable.",
+    "reference_solution": "Registrant name: Walmart Inc.\nCIK: 0000104169\nPrimary ticker: WMT\nPrimary exchange: Nasdaq\nSIC: 5331"
+  }
+}


### PR DESCRIPTION
# Add 60 public-registry verification tasks

## Category and sites

This proposed V1 category adds 60 read-only `academia-research / public-registry-verification` tasks across six authoritative public registries:

- Crossref (10)
- PubMed (10)
- ClinicalTrials.gov (10)
- GitHub (10)
- World Bank Data (10)
- SEC EDGAR (10)

The tasks use IDs 887–946. Every task asks the agent to open one explicit authoritative record and return a small labeled fact set. No task asks the agent to purchase, submit, send, delete, edit, or otherwise mutate external state.

## Interceptor behavior

There is no Submit action. Every task is read-only and uses the repository's non-matching placeholder interceptor:

```json
{"url_pattern":"__PLACEHOLDER_WILL_NOT_MATCH__","method":"POST"}
```

## Validation performed

- 60/60 conform to `test-cases/task.schema.json`.
- IDs are unique and exactly cover 887–946.
- Frozen reference solutions match all 60 source records.
- All 60 prompts explicitly prohibit write actions.
- Maximum pairwise instruction-token Jaccard is 0.835616, below the 0.84 review threshold.
- Focused repository tests: 9 passed.
- Full repository tests: 180 passed.

## Draft status and remaining review gates

- Run each task in official `--human` mode and retain the completion receipt.
- Confirm each source remains navigable in the benchmark browser image.
- Refresh mutable public fields immediately before the final commit and record any drift.
- Confirm whether 10 minutes is appropriate after observed human completion times.

The branch has been pushed and this text is intended for a Draft PR. It deliberately does not claim human-mode completion, acceptance, merge, or paper credit. The Draft PR is the external submission receipt; it must remain a draft until the four gates above are resolved.
