### PR TITLE
feat(browser-runtime): add native Kernel support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Added Kernel as a managed remote browser runtime with live view and downloaded replay recordings.
 - Added support for the [WebBrain](https://github.com/webbrain-one/webbrain) harness. Thanks to @alectimison-maker.
 
 ## [0.9.1] - 2026-08-04

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Once the container starts, the script prints a **noVNC URL** (e.g. `http://local
 clawbench-batch --models your-model --cases-suite v2 --all-cases
 ```
 
-`your-model` is a key you configured in step 1; `--cases-suite v2` runs the full V2 corpus (swap in `v1-lite` for the 20-task subset). Add `--max-concurrent N` to run tasks in parallel (default 2 locally, 1 with Browserbase) and `--harness <name>` to pick an agent. Each task is intercepted and scored by the `deepseek-v4-pro` judge from step 1 — pass `--no-judge` to skip scoring. A `batch-summary.json` plus per-run recordings land under `./test-output/`.
+`your-model` is a key you configured in step 1; `--cases-suite v2` runs the full V2 corpus (swap in `v1-lite` for the 20-task subset). Add `--max-concurrent N` to run tasks in parallel (default 2 locally, 1 with Kernel or Browserbase) and `--harness <name>` to pick an agent. Each task is intercepted and scored by the `deepseek-v4-pro` judge from step 1 — pass `--no-judge` to skip scoring. A `batch-summary.json` plus per-run recordings land under `./test-output/`.
 
 **By hand, to produce a human reference run:**
 
@@ -330,7 +330,7 @@ Full registry: [`src/clawbench/runtime/harnesses/harnesses.yaml`](src/clawbench/
 
 | I want to… | Where |
 | --- | --- |
-| Use a managed remote browser instead of a local container | [`docs/browser-runtimes.md`](docs/browser-runtimes.md) — Browserbase setup, options, recording URLs |
+| Use a managed remote browser instead of a local container | [`docs/browser-runtimes.md`](docs/browser-runtimes.md) — Kernel and Browserbase setup, options, and recordings |
 | Run V2 through the Harbor framework (and run it fast) | [`docs/harbor.md`](docs/harbor.md) — conversion, judge wiring, concurrency, troubleshooting |
 | See every CLI command and flag | [`docs/cli.md`](docs/cli.md) |
 
@@ -709,7 +709,7 @@ Each session records five layers of synchronized data under `/data/`:
 
 | Layer              | File                   | Description                                                     |
 | ------------------ | ---------------------- | --------------------------------------------------------------- |
-| Session replay     | `recording.mp4` or `run-meta.json` recording URL | Local H.264 video or Browserbase Session Inspector replay |
+| Session replay     | `recording.mp4` or `run-meta.json` recording URL | Local/Kernel H.264 video or Browserbase Session Inspector replay |
 | Action screenshots | `screenshots/*.png`    | Throttled timestamped PNGs captured after browser actions       |
 | Browser actions    | `actions.jsonl`        | Every DOM event (click, keydown, input, pageLoad, scroll, etc.) |
 | HTTP traffic       | `requests.jsonl`       | Every HTTP request with headers, body, and query params         |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -243,7 +243,7 @@ uv run clawbench-run test-cases/v1/001-daily-life-food-uber-eats claude-sonnet-4
 clawbench-batch --models your-model --cases-suite v2 --all-cases
 ```
 
-`your-model` 是你在第 1 步里配置的 key；`--cases-suite v2` 跑完整 V2 语料（换成 `v1-lite` 则是 20 题子集）。`--max-concurrent N` 控制并发（本地默认 2，Browserbase 默认 1），`--harness <name>` 选择智能体。每个任务都会被拦截并由第 1 步配置的 `deepseek-v4-pro` judge 打分 —— 加 `--no-judge` 可跳过评分。`batch-summary.json` 和各次运行的录制都会写到 `./test-output/`。
+`your-model` 是你在第 1 步里配置的 key；`--cases-suite v2` 跑完整 V2 语料（换成 `v1-lite` 则是 20 题子集）。`--max-concurrent N` 控制并发（本地默认 2，Kernel 或 Browserbase 默认 1），`--harness <name>` 选择智能体。每个任务都会被拦截并由第 1 步配置的 `deepseek-v4-pro` judge 打分 —— 加 `--no-judge` 可跳过评分。`batch-summary.json` 和各次运行的录制都会写到 `./test-output/`。
 
 **自己上手操作，产出人工参考轨迹：**
 
@@ -277,7 +277,7 @@ harness 是驱动浏览器的智能体框架，和模型是两个独立维度。
 
 | 我想…… | 去哪看 |
 | --- | --- |
-| 用托管的远程浏览器代替本地容器 | [`docs/browser-runtimes.md`](browser-runtimes.md) —— Browserbase 配置、参数、录制地址 |
+| 用托管的远程浏览器代替本地容器 | [`docs/browser-runtimes.md`](browser-runtimes.md) —— Kernel 和 Browserbase 配置、参数与录制 |
 | 用 Harbor 框架跑 V2（并且跑得快） | [`docs/harbor.md`](harbor.md) —— 转换、judge 配置、并发、排错 |
 | 查所有 CLI 命令和参数 | [`docs/cli.md`](cli.md) |
 
@@ -649,7 +649,7 @@ ClawBench 的定位：**真实消费级网站、日常任务、端到端录制**
 
 | 层 | 文件 | 描述 |
 |-------|------|-------------|
-| 会话回放 | `recording.mp4` 或 `run-meta.json` 中的录制 URL | 本地 H.264 视频，或 Browserbase Session Inspector 回放 |
+| 会话回放 | `recording.mp4` 或 `run-meta.json` 中的录制 URL | 本地/Kernel H.264 视频，或 Browserbase Session Inspector 回放 |
 | 动作截图 | `screenshots/*.png` | 浏览器动作后经限流捕获的带时间戳 PNG |
 | 浏览器动作 | `actions.jsonl` | 每个 DOM 事件 (click, keydown, input, pageLoad, scroll 等) |
 | HTTP 流量 | `requests.jsonl` | 每个 HTTP 请求，包含 headers、body 和查询参数 |

--- a/docs/browser-runtimes.md
+++ b/docs/browser-runtimes.md
@@ -2,11 +2,41 @@
 
 By default ClawBench launches Chromium inside its own container. You can point it at a managed remote browser instead — useful when the host cannot run containers comfortably, or when you want the provider to handle scaling and session replay.
 
-`--browser-runtime` accepts `local` (default), `browserbase`, `remote-cdp`, and `steel`. **`steel` is reserved and not implemented yet** — selecting it raises an error.
+`--browser-runtime` accepts `local` (default), `kernel`, `browserbase`, `remote-cdp`, and `steel`. **`steel` is reserved and not implemented yet** — selecting it raises an error.
 
 ## Local container (default)
 
 Nothing to configure. Chromium, Xvfb, ffmpeg, noVNC, and the recorder/interceptor all run in the task container; the session video lands at `recording.mp4`.
+
+## Kernel
+
+Put the key in `.env.local`:
+
+```dotenv
+KERNEL_API_KEY=...
+```
+
+Then select the runtime on a single or batch run:
+
+```bash
+uv run clawbench-run test-cases/v1/<case> your-model \
+  --browser-runtime kernel
+
+uv run clawbench-batch --models your-model --all-cases \
+  --browser-runtime kernel
+```
+
+Kernel runs use ClawBench's existing CDP action capture, screenshots, HTTP logging, and request interception. ClawBench starts a Kernel replay with each browser and downloads the completed video to `data/recording.mp4` before deleting the session.
+
+Provider options are passed as JSON. Supported fields are `stealth`, `region`, `proxy`, and `tags`:
+
+```bash
+uv run clawbench-batch --models your-model --all-cases \
+  --browser-runtime kernel \
+  --browser-runtime-options '{"stealth":true,"region":"us-east"}'
+```
+
+Set `KERNEL_BASE_URL` to override the default `https://api.onkernel.com` API endpoint. Batch concurrency defaults to **1**; raise `--max-concurrent` only as far as your Kernel account limit allows.
 
 ## Browserbase
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,7 +42,7 @@ clawbench-run <case-dir> --human      # human reference run
 | `--output-dir <path>` | `<project>/test-output` | Where run directories are written |
 | `--no-build` | off | Skip building the container image (assumes it exists) |
 | `--no-upload` | off | Skip HuggingFace upload even if `HF_TOKEN` is configured |
-| `--browser-runtime <name>` | `local` | `local`, `browserbase`, `remote-cdp` — see [`browser-runtimes.md`](browser-runtimes.md) |
+| `--browser-runtime <name>` | `local` | `local`, `kernel`, `browserbase`, `remote-cdp` — see [`browser-runtimes.md`](browser-runtimes.md) |
 | `--browser-cdp-url <url>` | — | CDP endpoint for `--browser-runtime remote-cdp` |
 | `--browser-runtime-options <json>` | — | Provider-specific options, e.g. `'{"region":"us-west-2"}'` |
 
@@ -71,7 +71,7 @@ Execution:
 
 | Flag | Default | What it does |
 | --- | --- | --- |
-| `--max-concurrent <n>` | 2 local, 1 Browserbase | Parallel jobs |
+| `--max-concurrent <n>` | 2 local, 1 Kernel/Browserbase | Parallel jobs |
 | `--stagger-delay <s>` | 15 | Minimum seconds between consecutive container starts (rolling start) |
 | `--resume <dir>` | — | Reuse a previous batch's output directory and skip finished runs |
 | `--dry-run` | off | Print the job matrix without running anything |
@@ -125,6 +125,8 @@ See [Reproduce the leaderboard](../README.md#reproduce-the-leaderboard) for the 
 | `CONTAINER_ENGINE` | Force `docker` or `podman` |
 | `HF_TOKEN` | Optional upload of runs to HuggingFace |
 | `BROWSERBASE_API_KEY` | Browserbase runtime (from `.env.local`) |
+| `KERNEL_API_KEY` | Kernel runtime (from `.env.local`) |
+| `KERNEL_BASE_URL` | Optional Kernel API base URL override |
 | `CLAWBENCH_JUDGE_*` | Judge credentials for Harbor's verifier — see [`harbor.md`](harbor.md) |
 
 PurelyMail credentials for disposable run emails come from the committed `.env`.

--- a/src/README.md
+++ b/src/README.md
@@ -196,22 +196,22 @@ A stagger delay is applied between job starts since during container startup it 
 | `--cases-dir PATH`        | Custom case directory                                     | none                                            |
 | `--all-cases`             | Use all task directories in the selected suite/dir        | false                                            |
 | `--case-range START-END`  | Filter by numeric case ID prefix                          | none                                             |
-| `--max-concurrent N`      | Max parallel jobs; Browserbase defaults to 1               | 2 locally, 1 with Browserbase                    |
+| `--max-concurrent N`      | Max parallel jobs; managed runtimes default to 1            | 2 locally, 1 with Kernel/Browserbase             |
 | `--output-dir PATH`       | Base output directory                                     | `test-output`                                    |
 | `--stagger-delay SECONDS` | Minimum gap between consecutive container starts          | 15                                               |
 | `--dry-run`               | Print job matrix without running                          | false                                            |
 | `--no-upload`             | Skip HuggingFace upload for all runs                      | false                                            |
 | `--harness NAME`          | Harness image to use                                      | `openclaw`                                       |
-| `--browser-runtime NAME`  | Browser runtime (`local`, `remote-cdp`, or `browserbase`)  | `local`                                          |
+| `--browser-runtime NAME`  | Browser runtime (`local`, `remote-cdp`, `kernel`, or `browserbase`) | `local`                                  |
 | `--browser-cdp-url URL`   | CDP endpoint used with `--browser-runtime remote-cdp`      | none                                             |
 | `--browser-runtime-options JSON` | Provider options such as Browserbase region or proxies | none                                          |
 
-Browserbase reads `BROWSERBASE_API_KEY` from `.env.local` or the process
-environment. Its provider-hosted Session Inspector recording URL is stored in
-`browser_runtime.recording_url` in `run-meta.json`; local MP4 recording is
-thus omitted to save space and bandwidth. The signed provider CDP URL is mounted into the runtime
-container through a temporary read-only secret file and redacted from saved
-metadata.
+Kernel reads `KERNEL_API_KEY`; Browserbase reads `BROWSERBASE_API_KEY`. Both
+can be set in `.env.local` or the process environment. Kernel replay video is
+downloaded to `data/recording.mp4`; Browserbase's provider-hosted Session
+Inspector URL is stored in `browser_runtime.recording_url` in `run-meta.json`.
+Signed provider CDP URLs are mounted into the runtime container through a
+temporary read-only secret file and redacted from saved metadata.
 
 Signal handling:
 

--- a/src/clawbench/runner/batch.py
+++ b/src/clawbench/runner/batch.py
@@ -49,6 +49,7 @@ CASE_SUITES = {
     "claw-eval": "test-cases/claw-eval",
 }
 DEFAULT_CASES_SUITE = "v2"
+MANAGED_BROWSER_RUNTIMES = frozenset({"browserbase", "kernel"})
 
 
 def load_models_yaml() -> dict:
@@ -289,7 +290,7 @@ async def run_job(
                     cmd_parts += ["--harness", harness]
                 if browser_runtime:
                     cmd_parts += ["--browser-runtime", browser_runtime]
-                    if browser_runtime == "kernel":
+                    if browser_runtime in MANAGED_BROWSER_RUNTIMES:
                         cmd_parts.append("--hide-browser-viewer")
                 if browser_cdp_url:
                     cmd_parts += ["--browser-cdp-url", browser_cdp_url]
@@ -591,11 +592,10 @@ async def async_main(args: argparse.Namespace) -> int:
     shutdown_event = asyncio.Event()
     running_procs.clear()
     browser_runtime = getattr(args, "browser_runtime", None) or "local"
-    managed_browser_runtimes = {"browserbase", "kernel"}
     if getattr(args, "max_concurrent", None) is None:
-        args.max_concurrent = 1 if browser_runtime in managed_browser_runtimes else 2
+        args.max_concurrent = 1 if browser_runtime in MANAGED_BROWSER_RUNTIMES else 2
     if (
-        browser_runtime in managed_browser_runtimes
+        browser_runtime in MANAGED_BROWSER_RUNTIMES
         and args.harness == "claude-code-chrome-extension"
     ):
         print(

--- a/src/clawbench/runner/batch.py
+++ b/src/clawbench/runner/batch.py
@@ -289,6 +289,8 @@ async def run_job(
                     cmd_parts += ["--harness", harness]
                 if browser_runtime:
                     cmd_parts += ["--browser-runtime", browser_runtime]
+                    if browser_runtime == "kernel":
+                        cmd_parts.append("--hide-browser-viewer")
                 if browser_cdp_url:
                     cmd_parts += ["--browser-cdp-url", browser_cdp_url]
                 if browser_runtime_options:
@@ -589,14 +591,15 @@ async def async_main(args: argparse.Namespace) -> int:
     shutdown_event = asyncio.Event()
     running_procs.clear()
     browser_runtime = getattr(args, "browser_runtime", None) or "local"
+    managed_browser_runtimes = {"browserbase", "kernel"}
     if getattr(args, "max_concurrent", None) is None:
-        args.max_concurrent = 1 if browser_runtime == "browserbase" else 2
+        args.max_concurrent = 1 if browser_runtime in managed_browser_runtimes else 2
     if (
-        browser_runtime == "browserbase"
+        browser_runtime in managed_browser_runtimes
         and args.harness == "claude-code-chrome-extension"
     ):
         print(
-            "ERROR: browserbase runtime does not support the "
+            f"ERROR: {browser_runtime} runtime does not support the "
             "claude-code-chrome-extension harness"
         )
         return 1
@@ -821,7 +824,7 @@ def main() -> None:
         "--max-concurrent",
         type=int,
         default=None,
-        help="Max parallel jobs (default: 1 for browserbase, otherwise 2)",
+        help="Max parallel jobs (default: 1 for managed runtimes, otherwise 2)",
     )
     p.add_argument("--output-dir", default="test-output", help="Base output directory")
     p.add_argument(
@@ -863,7 +866,7 @@ def main() -> None:
         choices=BROWSER_RUNTIME_CHOICES,
         default=None,
         help=(
-            "Browser runtime provider: local, remote-cdp, steel, or browserbase "
+            "Browser runtime provider: local, remote-cdp, steel, browserbase, or kernel "
             "(default: local)"
         ),
     )

--- a/src/clawbench/runner/run.py
+++ b/src/clawbench/runner/run.py
@@ -127,7 +127,7 @@ def main():
         choices=BROWSER_RUNTIME_CHOICES,
         default=None,
         help=(
-            "Browser runtime provider: local, remote-cdp, steel, or browserbase "
+            "Browser runtime provider: local, remote-cdp, steel, browserbase, or kernel "
             "(default: CLAWBENCH_BROWSER_RUNTIME or local)"
         ),
     )
@@ -140,6 +140,11 @@ def main():
         "--browser-runtime-options",
         default=None,
         help="JSON object with provider-specific browser runtime options",
+    )
+    parser.add_argument(
+        "--hide-browser-viewer",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--judge",
@@ -184,11 +189,11 @@ def main():
     if args.human and browser_runtime_provider.name != "local":
         parser.error("human mode currently supports only --browser-runtime local")
     if (
-        browser_runtime_provider.name == "browserbase"
+        browser_runtime_provider.name in {"browserbase", "kernel"}
         and args.harness == "claude-code-chrome-extension"
     ):
         parser.error(
-            "browserbase runtime does not support the "
+            f"{browser_runtime_provider.name} runtime does not support the "
             "claude-code-chrome-extension harness"
         )
 
@@ -230,6 +235,7 @@ def main():
     judge_cfg: dict | None = None
     personal_info_metadata: dict[str, Any] | None = None
     browser_session: BrowserSession | None = None
+    browser_runtime_finalized = False
     browser_runtime_cleaned = False
     browser_cdp_secret_dir: Path | None = None
 
@@ -237,12 +243,10 @@ def main():
         if browser_session is not None:
             return browser_session.to_metadata()
         mode = "local" if browser_runtime_provider.name == "local" else "remote"
-        recording_mode = (
-            "x11"
-            if mode == "local"
-            else "provider"
-            if browser_runtime_provider.name == "browserbase"
-            else "disabled"
+        recording_mode = getattr(
+            browser_runtime_provider,
+            "default_recording_mode",
+            "x11" if mode == "local" else "disabled",
         )
         return {
             "provider": browser_runtime_provider.name,
@@ -260,7 +264,10 @@ def main():
         }
 
     def _recording_required() -> bool:
-        return browser_session is None or browser_session.recording_mode == "x11"
+        return browser_session is None or browser_session.recording_mode in {
+            "x11",
+            "provider-download",
+        }
 
     def _write_browser_cdp_secret(session: BrowserSession) -> Path | None:
         nonlocal browser_cdp_secret_dir
@@ -292,6 +299,13 @@ def main():
             secret_root.rmdir()
         except OSError:
             pass
+
+    def _finalize_browser_runtime() -> None:
+        nonlocal browser_runtime_finalized
+        if browser_session is None or browser_runtime_finalized:
+            return
+        browser_runtime_provider.finalize(browser_session, output_dir)
+        browser_runtime_finalized = True
 
     def _cleanup_browser_runtime() -> None:
         nonlocal browser_runtime_cleaned
@@ -527,10 +541,16 @@ def main():
                     )
                 console.print("  Open the URL above to watch the agent in real-time.\n")
             elif browser_session.viewer_url:
-                viewer_url = browser_session.to_metadata()["viewer_url"]
-                console.print(
-                    f"\n  Browser viewer: [link={viewer_url}]{viewer_url}[/link]\n"
-                )
+                if args.hide_browser_viewer:
+                    console.print(
+                        f"\n  Remote browser: {browser_session.provider} "
+                        "(viewer URL hidden in batch mode)\n"
+                    )
+                else:
+                    viewer_url = browser_session.viewer_url
+                    console.print(
+                        f"\n  Browser viewer: [link={viewer_url}]{viewer_url}[/link]\n"
+                    )
             else:
                 console.print(
                     f"\n  Remote browser: {browser_session.provider} "
@@ -564,6 +584,12 @@ def main():
             output_dir,
             model_cfg=None if args.human else model_cfg,
         )
+
+        phase = "finalizing_browser_runtime"
+        _finalize_browser_runtime()
+        phase = "cleaning_browser_runtime"
+        _cleanup_browser_runtime()
+        _cleanup_browser_cdp_secret()
 
         # Stage 2 — LLM judge (default on, --no-judge to skip).
         # Only invoked when stage 1 (intercepted) succeeded; otherwise the
@@ -615,10 +641,6 @@ def main():
                     json.dumps(judge_result, indent=2, ensure_ascii=False)
                 )
                 print(f"Judge skipped due to error: {e}")
-
-        phase = "cleaning_browser_runtime"
-        _cleanup_browser_runtime()
-        _cleanup_browser_cdp_secret()
 
         # Write run metadata
         phase = "writing_run_meta"

--- a/src/clawbench/runner/run_support/browser_runtime/providers.py
+++ b/src/clawbench/runner/run_support/browser_runtime/providers.py
@@ -6,13 +6,15 @@ import argparse
 import json
 import os
 import socket
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Protocol
 
-BROWSER_RUNTIME_CHOICES = ("local", "remote-cdp", "steel", "browserbase")
+BROWSER_RUNTIME_CHOICES = ("local", "remote-cdp", "steel", "browserbase", "kernel")
 _BROWSERBASE_API_URL = "https://api.browserbase.com/v1"
 _BROWSERBASE_ALLOWED_OPTIONS = {
     "browserSettings",
@@ -21,6 +23,13 @@ _BROWSERBASE_ALLOWED_OPTIONS = {
     "proxies",
     "region",
     "userMetadata",
+}
+_KERNEL_API_URL = "https://api.onkernel.com"
+_KERNEL_ALLOWED_OPTIONS = {
+    "proxy",
+    "region",
+    "stealth",
+    "tags",
 }
 DEFAULT_BROWSER_CDP_URL = os.environ.get(
     "CLAWBENCH_BROWSER_CDP_URL",
@@ -48,6 +57,7 @@ class BrowserSession:
     mode: str
     session_id: str | None = None
     viewer_url: str | None = None
+    viewer_url_sensitive: bool = False
     debug_url: str | None = None
     recording_url: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -62,7 +72,13 @@ class BrowserSession:
             "mode": self.mode,
             "session_id": self.session_id,
             "cdp_url": redact_cdp_url(self.cdp_url),
-            "viewer_url": redact_cdp_url(self.viewer_url) if self.viewer_url else None,
+            "viewer_url": (
+                "[REDACTED]"
+                if self.viewer_url_sensitive
+                else redact_cdp_url(self.viewer_url)
+                if self.viewer_url
+                else None
+            ),
             "debug_url": redact_cdp_url(self.debug_url) if self.debug_url else None,
             "recording_url": (
                 redact_cdp_url(self.recording_url) if self.recording_url else None
@@ -77,9 +93,14 @@ class BrowserSession:
 
 class BrowserRuntimeProvider(Protocol):
     name: str
+    default_recording_mode: str
 
     def start(self, task: dict[str, Any], time_limit_s: int) -> BrowserSession:
         """Start or reserve a browser runtime and return its CDP endpoint."""
+        ...
+
+    def finalize(self, session: BrowserSession, output_dir: Path) -> None:
+        """Collect provider artifacts after the browser workload finishes."""
         ...
 
     def cleanup(self, session: BrowserSession) -> None:
@@ -114,7 +135,8 @@ def redact_cdp_url(url: str) -> str:
     for key, val in query:
         normalized = key.lower().replace("-", "").replace("_", "")
         sensitive = any(
-            part in normalized for part in ("apikey", "token", "secret", "signingkey")
+            part in normalized
+            for part in ("apikey", "jwt", "token", "secret", "signingkey")
         )
         redacted.append((key, "[REDACTED]" if sensitive else val))
     return urllib.parse.urlunsplit(
@@ -123,6 +145,12 @@ def redact_cdp_url(url: str) -> str:
 
 
 class _BrowserbaseApiError(RuntimeError):
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class _KernelApiError(RuntimeError):
     def __init__(self, message: str, *, status: int | None = None) -> None:
         super().__init__(message)
         self.status = status
@@ -154,6 +182,7 @@ def _pick_free_port() -> int:
 
 class LocalBrowserRuntimeProvider:
     name = "local"
+    default_recording_mode = "x11"
 
     def start(self, task: dict[str, Any], time_limit_s: int) -> BrowserSession:
         return BrowserSession(
@@ -164,12 +193,16 @@ class LocalBrowserRuntimeProvider:
             local_viewer_port=_pick_free_port(),
         )
 
+    def finalize(self, session: BrowserSession, output_dir: Path) -> None:
+        pass
+
     def cleanup(self, session: BrowserSession) -> None:
         session.cleanup_status = "not_required"
 
 
 class RemoteCdpBrowserRuntimeProvider:
     name = "remote-cdp"
+    default_recording_mode = "disabled"
 
     def __init__(self, *, cdp_url: str | None, options: dict[str, Any]) -> None:
         self.cdp_url = cdp_url
@@ -191,12 +224,16 @@ class RemoteCdpBrowserRuntimeProvider:
             recording_mode="disabled",
         )
 
+    def finalize(self, session: BrowserSession, output_dir: Path) -> None:
+        pass
+
     def cleanup(self, session: BrowserSession) -> None:
         session.cleanup_status = "not_required"
 
 
 class SteelBrowserRuntimeProvider:
     name = "steel"
+    default_recording_mode = "disabled"
 
     def __init__(self, *, options: dict[str, Any]) -> None:
         self.options = options
@@ -206,12 +243,16 @@ class SteelBrowserRuntimeProvider:
             "steel browser runtime is reserved but not implemented yet"
         )
 
+    def finalize(self, session: BrowserSession, output_dir: Path) -> None:
+        pass
+
     def cleanup(self, session: BrowserSession) -> None:
         session.cleanup_status = "not_required"
 
 
 class BrowserbaseRuntimeProvider:
     name = "browserbase"
+    default_recording_mode = "provider"
 
     def __init__(
         self,
@@ -377,6 +418,9 @@ class BrowserbaseRuntimeProvider:
             recording_mode="provider",
         )
 
+    def finalize(self, session: BrowserSession, output_dir: Path) -> None:
+        pass
+
     def cleanup(self, session: BrowserSession) -> None:
         if not session.session_id:
             session.cleanup_status = "not_required"
@@ -384,6 +428,281 @@ class BrowserbaseRuntimeProvider:
         try:
             session.cleanup_status = self._release(session.session_id)
         except _BrowserbaseApiError as e:
+            raise BrowserRuntimeError(str(e)) from None
+
+
+class KernelRuntimeProvider:
+    name = "kernel"
+    default_recording_mode = "provider-download"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        options: dict[str, Any],
+        api_url: str = _KERNEL_API_URL,
+        replay_poll_interval_s: float = 1,
+        replay_poll_timeout_s: float = 30,
+    ) -> None:
+        unknown = sorted(set(options) - _KERNEL_ALLOWED_OPTIONS)
+        if unknown:
+            allowed = ", ".join(sorted(_KERNEL_ALLOWED_OPTIONS))
+            raise BrowserRuntimeError(
+                "kernel runtime options contain unsupported field(s): "
+                f"{', '.join(unknown)}; allowed fields: {allowed}"
+            )
+        stealth = options.get("stealth")
+        if stealth is not None and not isinstance(stealth, bool):
+            raise BrowserRuntimeError("kernel stealth option must be a boolean")
+        region = options.get("region")
+        if region is not None and region not in {"us-east", "eu-west"}:
+            raise BrowserRuntimeError(
+                "kernel region option must be 'us-east' or 'eu-west'"
+            )
+        proxy = options.get("proxy")
+        if proxy is not None and not isinstance(proxy, dict):
+            raise BrowserRuntimeError("kernel proxy option must be a JSON object")
+        tags = options.get("tags")
+        if tags is not None and not isinstance(tags, dict):
+            raise BrowserRuntimeError("kernel tags option must be a JSON object")
+        self.api_key = api_key
+        self.options = options
+        self.api_url = api_url.rstrip("/")
+        self.replay_poll_interval_s = replay_poll_interval_s
+        self.replay_poll_timeout_s = replay_poll_timeout_s
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        accept: str = "application/json",
+    ) -> bytes:
+        assert self.api_key is not None
+        data = (
+            json.dumps(payload, separators=(",", ":")).encode()
+            if payload is not None
+            else None
+        )
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": accept,
+                "Authorization": f"Bearer {self.api_key}",
+                **({"Content-Type": "application/json"} if data is not None else {}),
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return response.read()
+        except urllib.error.HTTPError as e:
+            if e.code in {401, 403}:
+                message = "Kernel authentication failed"
+            elif e.code in {402, 429}:
+                message = "Kernel quota or concurrency limit was exceeded"
+            else:
+                message = f"Kernel API returned HTTP {e.code}"
+            raise _KernelApiError(message, status=e.code) from None
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            reason = str(getattr(e, "reason", e))
+            for secret in (
+                self.api_key,
+                urllib.parse.quote(self.api_key, safe=""),
+                urllib.parse.quote_plus(self.api_key, safe=""),
+            ):
+                if secret:
+                    reason = reason.replace(secret, "[REDACTED]")
+            raise _KernelApiError(f"Kernel API request failed: {reason}") from None
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        raw = self._request(method, path, payload)
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise _KernelApiError("Kernel API returned malformed JSON") from None
+
+    def _delete(self, session_id: str) -> str:
+        try:
+            self._request("DELETE", f"/browsers/{session_id}")
+        except _KernelApiError as e:
+            if e.status == 404:
+                return "already_closed"
+            raise
+        return "deleted"
+
+    def _stop_replay(self, session_id: str, replay_id: str) -> None:
+        try:
+            self._request(
+                "POST",
+                f"/browsers/{session_id}/replays/{replay_id}/stop",
+            )
+        except _KernelApiError as e:
+            if e.status not in {404, 409}:
+                raise
+
+    def start(self, task: dict[str, Any], time_limit_s: int) -> BrowserSession:
+        if not self.api_key:
+            raise BrowserRuntimeError("kernel browser runtime requires KERNEL_API_KEY")
+
+        timeout_seconds = min(259200, max(10, time_limit_s + 120))
+        payload = {
+            **self.options,
+            "headless": False,
+            "timeout_seconds": timeout_seconds,
+            "viewport": {
+                "width": 1920,
+                "height": 1080,
+                "refresh_rate": 25,
+            },
+        }
+        try:
+            result = self._request_json("POST", "/browsers", payload)
+        except _KernelApiError as e:
+            raise BrowserRuntimeError(str(e)) from None
+        if not isinstance(result, dict):
+            raise BrowserRuntimeError("Kernel browser response was not a JSON object")
+
+        session_id = result.get("session_id")
+        cdp_url = result.get("cdp_ws_url")
+        viewer_url = result.get("browser_live_view_url")
+        if not isinstance(session_id, str) or not session_id:
+            raise BrowserRuntimeError(
+                "Kernel browser response did not include a valid session_id"
+            )
+        if not isinstance(cdp_url, str) or not cdp_url.startswith(("ws://", "wss://")):
+            try:
+                self._delete(session_id)
+            except _KernelApiError:
+                pass
+            raise BrowserRuntimeError(
+                "Kernel browser response did not include a valid cdp_ws_url"
+            )
+        if not isinstance(viewer_url, str) or not viewer_url.startswith(
+            ("http://", "https://")
+        ):
+            viewer_url = None
+
+        try:
+            replay = self._request_json(
+                "POST",
+                f"/browsers/{session_id}/replays",
+                {
+                    "framerate": 15,
+                    "max_duration_in_seconds": timeout_seconds,
+                },
+            )
+        except _KernelApiError as e:
+            try:
+                self._delete(session_id)
+            except _KernelApiError:
+                pass
+            raise BrowserRuntimeError(str(e)) from None
+        replay_id = replay.get("replay_id") if isinstance(replay, dict) else None
+        if not isinstance(replay_id, str) or not replay_id:
+            try:
+                self._delete(session_id)
+            except _KernelApiError:
+                pass
+            raise BrowserRuntimeError(
+                "Kernel replay response did not include a valid replay_id"
+            )
+
+        return BrowserSession(
+            provider=self.name,
+            mode="remote",
+            session_id=session_id,
+            cdp_url=cdp_url,
+            viewer_url=viewer_url,
+            viewer_url_sensitive=viewer_url is not None,
+            metadata={
+                "region": result.get("region"),
+                "replay_id": replay_id,
+                "stealth": result.get("stealth"),
+                "timeout_seconds": result.get("timeout_seconds"),
+            },
+            recording_mode="provider-download",
+        )
+
+    def finalize(self, session: BrowserSession, output_dir: Path) -> None:
+        if not session.session_id:
+            return
+        replay_id = session.metadata.get("replay_id")
+        if not isinstance(replay_id, str) or not replay_id:
+            raise BrowserRuntimeError(
+                "Kernel browser session is missing its replay_id",
+                category="browser_runtime_artifact_failed",
+            )
+
+        try:
+            self._stop_replay(session.session_id, replay_id)
+            deadline = time.monotonic() + self.replay_poll_timeout_s
+            while True:
+                replays = self._request_json(
+                    "GET", f"/browsers/{session.session_id}/replays"
+                )
+                if not isinstance(replays, list):
+                    raise _KernelApiError(
+                        "Kernel replay list response was not a JSON array"
+                    )
+                matching = next(
+                    (
+                        replay
+                        for replay in replays
+                        if isinstance(replay, dict)
+                        and replay.get("replay_id") == replay_id
+                    ),
+                    None,
+                )
+                if matching and matching.get("finished_at"):
+                    break
+                if time.monotonic() >= deadline:
+                    raise _KernelApiError(
+                        "Kernel replay did not finish processing before timeout"
+                    )
+                time.sleep(self.replay_poll_interval_s)
+
+            recording = self._request(
+                "GET",
+                f"/browsers/{session.session_id}/replays/{replay_id}",
+                accept="video/mp4",
+            )
+            if not recording:
+                raise _KernelApiError("Kernel replay download was empty")
+            recording_path = output_dir / "data" / "recording.mp4"
+            recording_path.parent.mkdir(parents=True, exist_ok=True)
+            recording_path.write_bytes(recording)
+            session.metadata["recording_bytes"] = len(recording)
+            session.metadata["replay_status"] = "downloaded"
+        except (_KernelApiError, OSError) as e:
+            raise BrowserRuntimeError(
+                str(e), category="browser_runtime_artifact_failed"
+            ) from None
+
+    def cleanup(self, session: BrowserSession) -> None:
+        if not session.session_id:
+            session.cleanup_status = "not_required"
+            return
+        replay_id = session.metadata.get("replay_id")
+        try:
+            if (
+                isinstance(replay_id, str)
+                and replay_id
+                and session.metadata.get("replay_status") != "downloaded"
+            ):
+                self._stop_replay(session.session_id, replay_id)
+        except _KernelApiError:
+            pass
+        try:
+            session.cleanup_status = self._delete(session.session_id)
+        except _KernelApiError as e:
             raise BrowserRuntimeError(str(e)) from None
 
 
@@ -426,6 +745,15 @@ def make_browser_runtime_provider(
                 "browserbase browser runtime requires BROWSERBASE_API_KEY"
             )
         return BrowserbaseRuntimeProvider(api_key=api_key, options=options)
+    if runtime == "kernel":
+        api_key = _env_value(env, "KERNEL_API_KEY")
+        if not api_key:
+            raise BrowserRuntimeError("kernel browser runtime requires KERNEL_API_KEY")
+        return KernelRuntimeProvider(
+            api_key=api_key,
+            options=options,
+            api_url=_env_value(env, "KERNEL_BASE_URL") or _KERNEL_API_URL,
+        )
     raise BrowserRuntimeError(
         f"unknown browser runtime {runtime!r}; expected one of {BROWSER_RUNTIME_CHOICES}"
     )

--- a/src/clawbench/runner/run_support/browser_runtime/providers.py
+++ b/src/clawbench/runner/run_support/browser_runtime/providers.py
@@ -442,7 +442,7 @@ class KernelRuntimeProvider:
         options: dict[str, Any],
         api_url: str = _KERNEL_API_URL,
         replay_poll_interval_s: float = 1,
-        replay_poll_timeout_s: float = 30,
+        replay_poll_timeout_s: float = 300,
     ) -> None:
         unknown = sorted(set(options) - _KERNEL_ALLOWED_OPTIONS)
         if unknown:
@@ -471,14 +471,14 @@ class KernelRuntimeProvider:
         self.replay_poll_interval_s = replay_poll_interval_s
         self.replay_poll_timeout_s = replay_poll_timeout_s
 
-    def _request(
+    def _request_response(
         self,
         method: str,
         path: str,
         payload: dict[str, Any] | None = None,
         *,
         accept: str = "application/json",
-    ) -> bytes:
+    ) -> tuple[int, Any, bytes]:
         assert self.api_key is not None
         data = (
             json.dumps(payload, separators=(",", ":")).encode()
@@ -497,7 +497,11 @@ class KernelRuntimeProvider:
         )
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
-                return response.read()
+                return (
+                    int(getattr(response, "status", 200)),
+                    getattr(response, "headers", {}),
+                    response.read(),
+                )
         except urllib.error.HTTPError as e:
             if e.code in {401, 403}:
                 message = "Kernel authentication failed"
@@ -516,6 +520,22 @@ class KernelRuntimeProvider:
                 if secret:
                     reason = reason.replace(secret, "[REDACTED]")
             raise _KernelApiError(f"Kernel API request failed: {reason}") from None
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        accept: str = "application/json",
+    ) -> bytes:
+        _status, _headers, raw = self._request_response(
+            method,
+            path,
+            payload,
+            accept=accept,
+        )
+        return raw
 
     def _request_json(
         self,
@@ -669,11 +689,31 @@ class KernelRuntimeProvider:
                     )
                 time.sleep(self.replay_poll_interval_s)
 
-            recording = self._request(
-                "GET",
-                f"/browsers/{session.session_id}/replays/{replay_id}",
-                accept="video/mp4",
-            )
+            while True:
+                status, headers, recording = self._request_response(
+                    "GET",
+                    f"/browsers/{session.session_id}/replays/{replay_id}",
+                    accept="video/mp4",
+                )
+                if status != 202:
+                    break
+                if time.monotonic() >= deadline:
+                    raise _KernelApiError(
+                        "Kernel replay did not finish downloading before timeout"
+                    )
+                retry_after: str | None = (
+                    headers.get("Retry-After") if headers else None
+                )
+                if retry_after is None:
+                    delay = self.replay_poll_interval_s
+                else:
+                    try:
+                        delay = float(retry_after)
+                    except ValueError:
+                        delay = self.replay_poll_interval_s
+                time.sleep(min(max(0, delay), max(0, deadline - time.monotonic())))
+            if status != 200:
+                raise _KernelApiError(f"Kernel replay download returned HTTP {status}")
             if not recording:
                 raise _KernelApiError("Kernel replay download was empty")
             recording_path = output_dir / "data" / "recording.mp4"

--- a/src/clawbench/tui.py
+++ b/src/clawbench/tui.py
@@ -527,11 +527,14 @@ def run_cmd(cmd: list[str], *, hint: str | None = None) -> None:
 def _pick_browser_runtime(harness: str) -> str | None:
     choices = [questionary.Choice("Local Chrome", value="local")]
     if harness != "claude-code-chrome-extension":
-        choices.append(
-            questionary.Choice(
-                "Browserbase cloud browser",
-                value="browserbase",
-            )
+        choices.extend(
+            [
+                questionary.Choice("Kernel cloud browser", value="kernel"),
+                questionary.Choice(
+                    "Browserbase cloud browser",
+                    value="browserbase",
+                ),
+            ]
         )
     return questionary.select(
         "Browser runtime:",
@@ -683,6 +686,9 @@ def mode_single(
             "  [dim]Tip: open the Browserbase Inspector URL printed below\n"
             "  to watch the cloud browser and access its recording.[/]"
             if browser_runtime == "browserbase"
+            else "  [dim]Tip: open the Kernel live-view URL printed below\n"
+            "  to watch the cloud browser in real time.[/]"
+            if browser_runtime == "kernel"
             else "  [dim]Tip: once the container starts, open the noVNC URL\n"
             "  printed below to watch the agent operate the browser\n"
             "  in real-time.[/]"
@@ -781,10 +787,10 @@ def mode_batch(
         case_args = ["--cases"] + [f"{cases_dir_name}/{c}" for c in selected_cases]
         case_summary = f"{len(selected_cases)} selected"
 
-    if browser_runtime == "browserbase":
+    if browser_runtime in {"browserbase", "kernel"}:
         recommended = 1
         console.print(
-            "  Browserbase concurrency depends on the account limit; "
+            f"  {browser_runtime.capitalize()} concurrency depends on the account limit; "
             "defaulting to [green bold]1[/]."
         )
     else:

--- a/tests/test_batch_and_tui_helpers.py
+++ b/tests/test_batch_and_tui_helpers.py
@@ -111,7 +111,49 @@ def test_browserbase_batch_defaults_to_one_concurrent_session(
     assert args.max_concurrent == 1
 
 
-def test_tui_hides_browserbase_for_extension_harness(
+def test_kernel_batch_defaults_to_one_concurrent_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        batch,
+        "load_models_yaml",
+        lambda: {
+            "model-a": {
+                "base_url": "https://api.example.test",
+                "api_type": "openai-completions",
+                "api_key": "secret",
+            }
+        },
+    )
+    args = argparse.Namespace(
+        models=["model-a"],
+        all_models=False,
+        cases=["test-cases/v1/001-daily-life-food-uber-eats"],
+        all_cases=False,
+        case_range=None,
+        cases_dir=batch.CASE_SUITES["v1"],
+        dry_run=True,
+        output_dir=str(tmp_path),
+        max_concurrent=None,
+        stagger_delay=0,
+        resume=None,
+        no_upload=True,
+        harness="openclaw",
+        browser_runtime="kernel",
+        browser_cdp_url=None,
+        browser_runtime_options=None,
+        judge="judge-model",
+        no_judge=True,
+    )
+
+    rc = asyncio.run(batch.async_main(args))
+
+    assert rc == 0
+    assert args.max_concurrent == 1
+
+
+def test_tui_hides_managed_runtimes_for_extension_harness(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_values: list[str] = []
@@ -131,3 +173,25 @@ def test_tui_hides_browserbase_for_extension_harness(
 
     assert selected == "local"
     assert captured_values == ["local"]
+
+
+def test_tui_lists_kernel_for_remote_capable_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_values: list[str] = []
+
+    class _Prompt:
+        def ask(self) -> str:
+            return "kernel"
+
+    def fake_select(*args: object, **kwargs: object) -> _Prompt:
+        choices = cast(list[Any], kwargs["choices"])
+        captured_values.extend(choice.value for choice in choices)
+        return _Prompt()
+
+    monkeypatch.setattr(tui.questionary, "select", fake_select)
+
+    selected = tui._pick_browser_runtime("openclaw")
+
+    assert selected == "kernel"
+    assert captured_values == ["local", "kernel", "browserbase"]

--- a/tests/test_browser_runtime.py
+++ b/tests/test_browser_runtime.py
@@ -7,6 +7,7 @@ import json
 import urllib.error
 import urllib.request
 from email.message import Message
+from pathlib import Path
 
 import pytest
 
@@ -17,6 +18,7 @@ from clawbench.runner.run_support.browser_runtime import (
 from clawbench.runner.run_support.browser_runtime.providers import (
     BrowserbaseRuntimeProvider,
     BrowserSession,
+    KernelRuntimeProvider,
     RemoteCdpBrowserRuntimeProvider,
     SteelBrowserRuntimeProvider,
     redact_cdp_url,
@@ -59,6 +61,8 @@ def _clear_browser_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "STEEL_BASE_URL",
         "STEEL_API_KEY",
         "BROWSERBASE_API_KEY",
+        "KERNEL_API_KEY",
+        "KERNEL_BASE_URL",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -117,11 +121,28 @@ def test_browserbase_requires_api_key() -> None:
         make_browser_runtime_provider(_args(browser_runtime="browserbase"), {})
 
 
+def test_kernel_requires_api_key() -> None:
+    provider = KernelRuntimeProvider(api_key=None, options={})
+
+    with pytest.raises(BrowserRuntimeError, match="KERNEL_API_KEY"):
+        provider.start({}, 60)
+    with pytest.raises(BrowserRuntimeError, match="KERNEL_API_KEY"):
+        make_browser_runtime_provider(_args(browser_runtime="kernel"), {})
+
+
 def test_browserbase_rejects_reserved_options() -> None:
     with pytest.raises(BrowserRuntimeError, match="keepAlive"):
         BrowserbaseRuntimeProvider(
             api_key="bb-secret",
             options={"keepAlive": True},
+        )
+
+
+def test_kernel_rejects_reserved_options() -> None:
+    with pytest.raises(BrowserRuntimeError, match="timeout_seconds"):
+        KernelRuntimeProvider(
+            api_key="kernel-secret",
+            options={"timeout_seconds": 300},
         )
 
 
@@ -296,11 +317,147 @@ def test_browserbase_malformed_response_is_safe(
         provider.start({}, 60)
 
 
+def test_kernel_session_replay_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, str, object, str | None]] = []
+
+    def fake_urlopen(
+        request: urllib.request.Request,
+        timeout: int,
+    ) -> _FakeResponse:
+        assert timeout == 30
+        if request.data:
+            assert isinstance(request.data, bytes)
+            payload = json.loads(request.data)
+        else:
+            payload = None
+        accept = request.headers.get("Accept")
+        calls.append((request.get_method(), request.full_url, payload, accept))
+        assert request.headers["Authorization"] == "Bearer kernel-secret"
+        if request.full_url.endswith("/browsers"):
+            return _FakeResponse(
+                {
+                    "session_id": "browser_123",
+                    "cdp_ws_url": "wss://proxy.onkernel.test/cdp?jwt=cdp-secret",
+                    "browser_live_view_url": (
+                        "https://proxy.onkernel.test/browser/live/viewer-secret"
+                    ),
+                    "region": "us-east",
+                    "stealth": True,
+                    "timeout_seconds": 1920,
+                }
+            )
+        if request.full_url.endswith("/browsers/browser_123/replays"):
+            if request.get_method() == "POST":
+                return _FakeResponse(
+                    {
+                        "replay_id": "replay_123",
+                        "replay_view_url": (
+                            "https://proxy.onkernel.test/replay?jwt=replay-secret"
+                        ),
+                    }
+                )
+            return _FakeResponse(
+                [
+                    {
+                        "replay_id": "replay_123",
+                        "finished_at": "2026-08-18T12:00:00Z",
+                        "replay_view_url": (
+                            "https://proxy.onkernel.test/replay?jwt=replay-secret"
+                        ),
+                    }
+                ]
+            )
+        if request.full_url.endswith("/replays/replay_123/stop"):
+            return _FakeResponse(b"")
+        if request.full_url.endswith("/replays/replay_123"):
+            return _FakeResponse(b"mp4-data")
+        if request.full_url.endswith("/browsers/browser_123"):
+            return _FakeResponse(b"")
+        raise AssertionError(f"unexpected request: {request.full_url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    provider = KernelRuntimeProvider(
+        api_key="kernel-secret",
+        options={"stealth": True, "region": "us-east"},
+        replay_poll_interval_s=0,
+        replay_poll_timeout_s=0,
+    )
+
+    session = provider.start({}, 1800)
+    provider.finalize(session, tmp_path)
+    provider.cleanup(session)
+
+    create_payload = calls[0][2]
+    assert create_payload == {
+        "stealth": True,
+        "region": "us-east",
+        "headless": False,
+        "timeout_seconds": 1920,
+        "viewport": {"width": 1920, "height": 1080, "refresh_rate": 25},
+    }
+    assert session.provider == "kernel"
+    assert session.recording_mode == "provider-download"
+    assert session.cleanup_status == "deleted"
+    assert (tmp_path / "data" / "recording.mp4").read_bytes() == b"mp4-data"
+    metadata = json.dumps(session.to_metadata())
+    assert "cdp-secret" not in metadata
+    assert "viewer-secret" not in metadata
+    assert "replay-secret" not in metadata
+    assert "jwt=%5BREDACTED%5D" in session.to_metadata()["cdp_url"]
+    assert session.to_metadata()["viewer_url"] == "[REDACTED]"
+    assert calls[-1][:2] == (
+        "DELETE",
+        "https://api.onkernel.com/browsers/browser_123",
+    )
+
+
+def test_kernel_factory_honors_base_url() -> None:
+    provider = make_browser_runtime_provider(
+        _args(browser_runtime="kernel"),
+        {
+            "KERNEL_API_KEY": "kernel-secret",
+            "KERNEL_BASE_URL": "https://kernel.example.test/",
+        },
+    )
+
+    assert isinstance(provider, KernelRuntimeProvider)
+    assert provider.api_url == "https://kernel.example.test"
+
+
+def test_kernel_http_errors_do_not_expose_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(
+        request: urllib.request.Request,
+        timeout: int,
+    ) -> _FakeResponse:
+        raise urllib.error.HTTPError(
+            request.full_url,
+            401,
+            "kernel-secret",
+            hdrs=Message(),
+            fp=None,
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    provider = KernelRuntimeProvider(api_key="kernel-secret", options={})
+
+    with pytest.raises(BrowserRuntimeError) as exc_info:
+        provider.start({}, 60)
+
+    assert "authentication failed" in str(exc_info.value)
+    assert "kernel-secret" not in str(exc_info.value)
+
+
 def test_redact_cdp_url_masks_common_secret_query_params() -> None:
     redacted = redact_cdp_url(
-        "wss://example.test/devtools?apiKey=secret&token=two&x=ok"
+        "wss://example.test/devtools?apiKey=secret&jwt=one&token=two&x=ok"
     )
 
     assert redacted == (
-        "wss://example.test/devtools?apiKey=%5BREDACTED%5D&token=%5BREDACTED%5D&x=ok"
+        "wss://example.test/devtools?apiKey=%5BREDACTED%5D&"
+        "jwt=%5BREDACTED%5D&token=%5BREDACTED%5D&x=ok"
     )

--- a/tests/test_browser_runtime.py
+++ b/tests/test_browser_runtime.py
@@ -26,8 +26,16 @@ from clawbench.runner.run_support.browser_runtime.providers import (
 
 
 class _FakeResponse:
-    def __init__(self, payload: object) -> None:
+    def __init__(
+        self,
+        payload: object,
+        *,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         self.payload = payload
+        self.status = status
+        self.headers = headers or {}
 
     def __enter__(self) -> _FakeResponse:
         return self
@@ -322,11 +330,13 @@ def test_kernel_session_replay_and_cleanup(
     tmp_path: Path,
 ) -> None:
     calls: list[tuple[str, str, object, str | None]] = []
+    replay_downloads = 0
 
     def fake_urlopen(
         request: urllib.request.Request,
         timeout: int,
     ) -> _FakeResponse:
+        nonlocal replay_downloads
         assert timeout == 30
         if request.data:
             assert isinstance(request.data, bytes)
@@ -373,6 +383,13 @@ def test_kernel_session_replay_and_cleanup(
         if request.full_url.endswith("/replays/replay_123/stop"):
             return _FakeResponse(b"")
         if request.full_url.endswith("/replays/replay_123"):
+            replay_downloads += 1
+            if replay_downloads == 1:
+                return _FakeResponse(
+                    b"not-ready",
+                    status=202,
+                    headers={"Retry-After": "0"},
+                )
             return _FakeResponse(b"mp4-data")
         if request.full_url.endswith("/browsers/browser_123"):
             return _FakeResponse(b"")
@@ -383,7 +400,7 @@ def test_kernel_session_replay_and_cleanup(
         api_key="kernel-secret",
         options={"stealth": True, "region": "us-east"},
         replay_poll_interval_s=0,
-        replay_poll_timeout_s=0,
+        replay_poll_timeout_s=1,
     )
 
     session = provider.start({}, 1800)
@@ -401,6 +418,7 @@ def test_kernel_session_replay_and_cleanup(
     assert session.provider == "kernel"
     assert session.recording_mode == "provider-download"
     assert session.cleanup_status == "deleted"
+    assert replay_downloads == 2
     assert (tmp_path / "data" / "recording.mp4").read_bytes() == b"mp4-data"
     metadata = json.dumps(session.to_metadata())
     assert "cdp-secret" not in metadata


### PR DESCRIPTION
## What does this PR do?

Adds Kernel as a managed browser runtime:

```bash
uv run clawbench-run test-cases/v2/<case> <model> \
  --browser-runtime kernel \
  --browser-runtime-options '{"stealth":true,"region":"us-east"}'
```

The integration creates a Kernel browser, connects the existing ClawBench runtime and harness over CDP, captures the standard action/request/screenshot/message artifacts, downloads the Kernel replay as `data/recording.mp4`, and deletes the browser after the run.

No new package dependency is required; the provider uses Kernel's REST API through the standard library.

## Lifecycle

The new `KernelRuntimeProvider` handles:

1. Browser creation using `KERNEL_API_KEY` and optional `KERNEL_BASE_URL`.
2. Runtime options for `stealth`, `region`, `proxy`, and `tags`.
3. Replay creation before the harness connects.
4. Replay stop, processing polling, documented HTTP 202 retry handling, and MP4 download.
5. Browser deletion on success, failure, interruption, or replay errors.

Replay finalization uses a shared five-minute deadline. Missing or invalid recordings produce `browser_runtime_artifact_failed` rather than silently marking the run successful.

## Managed-runtime behavior

This also generalizes behavior that was previously specific to Browserbase:

- managed runtimes default to batch concurrency 1;
- batch runs hide credential-bearing viewer URLs;
- recording behavior is selected through provider capabilities;
- `claude-code-chrome-extension` is rejected for managed runtimes because it requires its own browser process inside the container.

Local, remote-CDP, Steel, and Browserbase behavior remains unchanged.

## User-facing changes

- Adds `kernel` to CLI and TUI runtime selection.
- Documents configuration and runtime options.
- Adds provider-neutral managed-runtime messaging.
- Updates the English and Chinese documentation and changelog.

## Corpus

- [ ] v2
- [ ] v1
- [ ] both
- [x] not applicable

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pyright`
- [x] `uv run pytest -q` — 203 passed
- [x] Real Kernel + browser-use run completed with interception and all five artifact layers.
- [x] Kernel replay downloaded as a playable MP4 and the browser was deleted.
- [x] 20-task V2 Hermes batch at concurrency 4 completed with zero infrastructure failures; all 20 replays downloaded and all 20 browsers were deleted.
- [x] Failure-path and HTTP 202 replay-processing behavior covered by unit tests.

## Related issues

N/A