### PR TITLE
docs: announce EMNLP 2026 Findings acceptance (news entry + badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   </picture>
 </a>
 
+[![EMNLP 2026 Findings](https://img.shields.io/badge/%F0%9F%8F%86_EMNLP_2026-Findings-8C1D18?style=flat-square)](https://2026.emnlp.org/)
 [![arXiv](https://img.shields.io/badge/arXiv-2604.08523-B31B1B?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2604.08523)
 [![Leaderboard](https://img.shields.io/badge/Leaderboard-FFD21E?style=flat-square&logo=huggingface&logoColor=000)](https://huggingface.co/spaces/TIGER-Lab/ClawBench)
 [![HF Dataset](https://img.shields.io/badge/Dataset-FFD21E?style=flat-square&logo=huggingface&logoColor=000)](https://huggingface.co/datasets/NAIL-Group/ClawBench)
@@ -424,6 +425,7 @@ ClawBench ships **three** Hugging Face datasets — task definitions plus full e
 > **🏆 Live leaderboard:** [`claw-bench.com/leaderboard`](https://claw-bench.com/leaderboard) (V2 default, two-stage scoring — interception + LLM judge). Full scoring formula in [`eval/scoring.md`](eval/scoring.md). Add your run: PR to [`leaderboard/results.csv`](https://huggingface.co/datasets/TIGER-Lab/ClawBench/blob/main/leaderboard/results.csv).
 
 ## <img src="assets/icons/bullhorn.svg" width="20" height="20"> News
+- **[2026.08.20]** — 🏆 Our paper has been accepted to [EMNLP 2026 Findings](https://2026.emnlp.org/).
 - **[2026.08.20]** - Added [Kernel](https://www.kernel.sh) as a supported remote browser runtime. Thanks to @[rgarcia](https://github.com/rgarcia).
 - **[2026.08.18]** — Added [WebBrain](https://github.com/webbrain-one/webbrain) as a supported harness. Thanks to @[alectimison-maker](https://github.com/alectimison-maker).
 - **[2026.08.16]** — Released **[RewardHarness](https://github.com/TIGER-AI-Lab/RewardHarness)**, our self-evolving agentic reward framework: 47.4% on EditReward-Bench from just 100 preference demos, with no reward-model training. [Details →](https://arxiv.org/abs/2605.08703)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -368,6 +368,7 @@ ClawBench 提供 **三个** Hugging Face 数据集 —— 任务定义，以及 
 
 ## <img src="../assets/icons/bullhorn.svg" width="20" height="20"> 动态
 
+- **[2026.08.20]** —— 🏆 论文被 [EMNLP 2026 Findings](https://2026.emnlp.org/) 接收。
 - **[2026.08.20]** —— 新增 [Kernel](https://www.kernel.sh) 作为支持的远程浏览器运行时。感谢 @[rgarcia](https://github.com/rgarcia)。
 - **[2026.08.18]** —— 新增 [WebBrain](https://github.com/webbrain-one/webbrain) 作为支持的 harness。感谢 @[alectimison-maker](https://github.com/alectimison-maker)。
 - **[2026.08.16]** —— 发布姊妹项目 **[RewardHarness](https://github.com/TIGER-AI-Lab/RewardHarness)**：自进化的 agentic 奖励框架，仅用 100 条偏好示例即在 EditReward-Bench 上达到 47.4%，且无需训练奖励模型。[详情 →](https://arxiv.org/abs/2605.08703)

--- a/docs/news.md
+++ b/docs/news.md
@@ -4,6 +4,7 @@ The five most recent items live in the [README](../README.md#news). Everything e
 
 ## 2026
 
+- **[2026.08.20]** — 🏆 Our paper has been accepted to [EMNLP 2026 Findings](https://2026.emnlp.org/).
 - **[2026.08.16]** — Released **[RewardHarness](https://github.com/TIGER-AI-Lab/RewardHarness)**, our self-evolving agentic reward framework: 47.4% on EditReward-Bench from just 100 preference demos, with no reward-model training. [Details →](https://arxiv.org/abs/2605.08703)
 - **[2026.08.03]** — Added [Browserbase](https://www.browserbase.com) as a remote browser runtime for ClawBench. [Details →](browser-runtimes.md)
 - **[2026.07.30]** — v0.8.0 released: Gemini-as-judge, random-click baseline harness, EdgeBench/SForge adapter, remote-browser CDP support. [Details →](../CHANGELOG.md)


### PR DESCRIPTION
Our paper has been accepted to **EMNLP 2026 Findings**. This announces it.

## What changed

- **News entry** at the top of `README.md`, `docs/README.zh-CN.md`, and the `docs/news.md` archive.
- **A badge** leading the visible badge row, linking to the EMNLP 2026 site.

The existing `[2026.07.25] COLM 2026 WAB` entry stays. A non-archival workshop and a later archival publication are not in conflict, and the two lines together read as a timeline rather than a correction.

## On the badge

Findings is an archival venue and, until now, the only venue anywhere on the page was a workshop line buried in News — so this is the strongest credibility signal the README has, and it earns a slot in the visible row rather than the fold.

I rendered five variants inside the real badge row before picking. The deep maroon (`#8C1D18`) with a trophy sits next to the brighter arXiv red without reading as a second arXiv link, and at 148px the row still fits on one line at normal widths. Rejected: ACL-red (competes with arXiv), green (new hue, reads utilitarian), indigo (collides with the claw-bench.com badge two slots over), and `for-the-badge` (wrapped the row).

## Deliberately not in scope: the citation blocks

`README.md`'s BibTeX and `CITATION.cff` still point at the arXiv preprint. The ACL Anthology entry does not exist yet, so switching to `@inproceedings` today would publish a citation with no anthology ID and no page numbers — strictly less useful than the arXiv one it would replace. That swap is a clean follow-up once the proceedings are out; happy to open it then.

## Verification

`scripts/ci/check_markdown_links.py` → **all 156 repo-relative links resolve**. GitHub-rendered branch page screenshot-checked: badge renders first in the row without wrapping, News section renders with the new entry on top.

@Perry2004 — flagging two judgement calls for you: keeping the COLM line alongside this one, and holding the citation at arXiv until the Anthology entry exists.
