### PR TITLE
fix(harbor): numeric verifier metrics, lenient + strict judge rubrics, and interception correctness

### DIFF
--- a/docs/harbor.md
+++ b/docs/harbor.md
@@ -45,7 +45,7 @@ uv run clawbench-harbor-adapt \
 
 ## 2. Wire up the judge
 
-Harbor's verifier calls the same judge ClawBench uses. Export the four variables once, then forward them into each run with `--ve`:
+Harbor's verifier applies both ClawBench V2 judge rubrics to every intercepted request. `reward` and `reward_lenient` use the public leaderboard's no-explicit-contradiction rubric; `reward_strict` requires the payload to demonstrate complete fulfillment. The two judge calls run concurrently against the same request and use the model configured below. Export the four variables once, then forward them into each run with `--ve`:
 
 ```bash
 export CLAWBENCH_JUDGE_BASE_URL="https://your-judge-provider.example/v1"
@@ -140,7 +140,7 @@ uvx --from harbor==0.15.0 harbor run -p ./harbor-datasets/clawbench-v2-smoke \
 
 Each converted task directory carries its own `environment/` (Chromium, the ClawBench recorder/interceptor, noVNC, runtime helper scripts), a `run/` step with `instruction.md`, the original `task.json`, the `eval-schema.json`, and a verifier under `tests/`. It deliberately contains **no ClawBench-native harness** — Harbor installs and runs whatever agent you pass to `-a` inside the task container.
 
-Scoring is the same two-stage rule as the native runner: the interceptor must catch a request matching the task schema, and the judge must agree the payload fulfills the instruction.
+Scoring uses the same two-stage rule as the native runner: the interceptor must catch a request matching the task schema, then the verifier emits both the public lenient reward and the conservative strict reward. Harbor uses the lenient result as the primary `reward` metric and retains both verdicts and reasons in `clawbench-result.json`.
 
 ## Troubleshooting
 

--- a/src/clawbench/eval/harbor_adapter.py
+++ b/src/clawbench/eval/harbor_adapter.py
@@ -199,6 +199,10 @@ cp /app/eval-schema.json /eval-schema.json
   --extra-info-dir /app/extra_info \
   --output-dir /app/my-info
 
+# Harbor installs its stock agent before step setup. Wrap that executable so
+# ClawBench's existing /data/.stop-requested signal ends the agent cleanly.
+/app/src/harbor/wrap-harbor-agent.sh
+
 /app/src/harbor/start-runtime.sh
 
 for _ in $(seq 1 60); do

--- a/src/clawbench/eval/harbor_adapter.py
+++ b/src/clawbench/eval/harbor_adapter.py
@@ -175,7 +175,7 @@ name = "{STEP_NAME}"
 timeout_sec = {float(timeout_sec):.1f}
 
 [steps.verifier]
-timeout_sec = 180.0
+timeout_sec = 300.0
 
 [steps.healthcheck]
 command = "curl -sf http://127.0.0.1:7878/api/status | grep -q '\\\"eval_interceptor_ready\\\":true' && curl -sf http://127.0.0.1:9223/json/version >/dev/null"

--- a/src/clawbench/runtime/harbor/verify.py
+++ b/src/clawbench/runtime/harbor/verify.py
@@ -35,8 +35,16 @@ def write_reward(
     out = output_dir
     out.mkdir(parents=True, exist_ok=True)
     result = {"reward": reward, **payload}
+    metrics = {
+        "reward": reward,
+        "intercepted": float(bool(payload.get("intercepted"))),
+    }
+    judge_match = payload.get("judge_match")
+    if isinstance(judge_match, bool):
+        metrics["judge_match"] = float(judge_match)
+
     (out / "reward.txt").write_text(str(reward))
-    (out / "reward.json").write_text(json.dumps(result, indent=2, ensure_ascii=False))
+    (out / "reward.json").write_text(json.dumps(metrics, indent=2))
     (out / "clawbench-result.json").write_text(
         json.dumps(result, indent=2, ensure_ascii=False)
     )

--- a/src/clawbench/runtime/harbor/verify.py
+++ b/src/clawbench/runtime/harbor/verify.py
@@ -5,10 +5,11 @@ import json
 import os
 import time
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-JUDGE_SYSTEM = """You are a strict evaluator for a web-agent benchmark.
+JUDGE_SYSTEM_STRICT = """You are a strict evaluator for a web-agent benchmark.
 
 A user gave a natural-language INSTRUCTION to an autonomous browser agent.
 The agent navigated a real website and finally produced a single HTTP request
@@ -28,6 +29,49 @@ Reply with ONLY a single-line JSON object:
 {"match": true|false, "reason": "<one short sentence>"}
 """
 
+JUDGE_SYSTEM_LENIENT = """You are a lenient evaluator for a web-agent benchmark.
+
+A user gave a natural-language INSTRUCTION to an autonomous browser agent.
+The agent navigated a real website and finally produced a single HTTP request
+(URL + method + body) that we INTERCEPTED before it was sent to the server.
+
+You decide whether this intercepted request ALIGNS with the user's instruction.
+
+# Rubric (CRITICAL — read carefully)
+
+match = TRUE if there is NO EXPLICIT CONTRADICTION between the request and
+the instruction. The default verdict is TRUE.
+
+match = FALSE only if the request EXPLICITLY contradicts a field the user
+EXPLICITLY specified in the instruction. Examples of contradiction:
+- Instruction says "red shirt", request body shows "color: blue"
+- Instruction says "quantity 2", request body shows "qty: 5"
+- Instruction says "deliver to home", request body shows "deliver to work"
+- Instruction asks to enroll in CS50, request enrolls in CS61
+
+# What is NOT a contradiction (default to match = TRUE)
+
+- Instruction did not specify a field, request omits or has any value for it
+  → MATCH (the user did not constrain it)
+- Instruction said "3pm", request body has no time field at all
+  → MATCH (info absent, not contradicted)
+- PDF resume left blank where instruction did not require content
+  → MATCH
+- Cosmetic differences (timestamps, session IDs, affiliate codes, currency
+  symbols, formatting) → MATCH
+- Ambiguous wording where multiple interpretations work → MATCH
+- Agent picked a reasonable default for unspecified options → MATCH
+- Color, size, time, quantity not mentioned in instruction → MATCH
+
+# Output
+
+Reply with ONLY a single-line JSON object, no markdown fences, no extra prose:
+{"match": true|false, "reason": "<one short sentence>"}
+
+Default is true. Only return false when you can name a SPECIFIC explicit
+field from the instruction that the request EXPLICITLY contradicts.
+"""
+
 
 def write_reward(
     reward: float, payload: dict[str, Any], output_dir: Path = Path("/logs/verifier")
@@ -39,9 +83,16 @@ def write_reward(
         "reward": reward,
         "intercepted": float(bool(payload.get("intercepted"))),
     }
-    judge_match = payload.get("judge_match")
-    if isinstance(judge_match, bool):
-        metrics["judge_match"] = float(judge_match)
+    for name in (
+        "reward_lenient",
+        "reward_strict",
+        "judge_match",
+        "judge_match_lenient",
+        "judge_match_strict",
+    ):
+        value = payload.get(name)
+        if isinstance(value, (bool, int, float)):
+            metrics[name] = float(value)
 
     (out / "reward.txt").write_text(str(reward))
     (out / "reward.json").write_text(json.dumps(metrics, indent=2))
@@ -112,6 +163,8 @@ def call_judge(
     instruction: str,
     intercept: dict[str, Any],
     judge_context: dict[str, Any] | None,
+    system_prompt: str,
+    max_tokens: int,
 ) -> dict[str, Any]:
     api_type = model_cfg["api_type"]
     model = model_cfg["model"]
@@ -124,10 +177,10 @@ def call_judge(
             {
                 "model": model,
                 "messages": [
-                    {"role": "system", "content": JUDGE_SYSTEM},
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user},
                 ],
-                "max_tokens": 4096,
+                "max_tokens": max_tokens,
                 "temperature": 0,
             },
         )
@@ -138,9 +191,9 @@ def call_judge(
             {"Authorization": f"Bearer {model_cfg['api_key']}"},
             {
                 "model": model,
-                "instructions": JUDGE_SYSTEM,
+                "instructions": system_prompt,
                 "input": user,
-                "max_output_tokens": 4096,
+                "max_output_tokens": max_tokens,
             },
         )
         raw = resp.get("output_text") or ""
@@ -160,8 +213,8 @@ def call_judge(
             },
             {
                 "model": model,
-                "max_tokens": 4096,
-                "system": JUDGE_SYSTEM,
+                "max_tokens": max_tokens,
+                "system": system_prompt,
                 "messages": [{"role": "user", "content": user}],
             },
         )
@@ -175,6 +228,37 @@ def call_judge(
         }
     match, reason = parse_verdict(raw)
     return {"match": match, "reason": reason, "raw": raw, "error": None}
+
+
+def call_judge_with_retries(
+    model_cfg: dict[str, str],
+    instruction: str,
+    intercept: dict[str, Any],
+    judge_context: dict[str, Any] | None,
+    system_prompt: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    last_error = ""
+    for attempt in range(3):
+        try:
+            return call_judge(
+                model_cfg,
+                instruction,
+                intercept,
+                judge_context,
+                system_prompt,
+                max_tokens,
+            )
+        except Exception as exc:
+            last_error = str(exc)
+            if attempt < 2:
+                time.sleep(2**attempt)
+    return {
+        "match": None,
+        "reason": f"judge_call_failed: {last_error}",
+        "raw": None,
+        "error": last_error,
+    }
 
 
 def main() -> int:
@@ -193,8 +277,12 @@ def main() -> int:
         write_reward(
             0.0,
             {
+                "reward_lenient": 0.0,
+                "reward_strict": 0.0,
                 "intercepted": False,
                 "judge_match": None,
+                "judge_match_lenient": None,
+                "judge_match_strict": None,
                 "reason": "missing /data/interception.json",
                 "task_id": task_id,
             },
@@ -206,8 +294,12 @@ def main() -> int:
         write_reward(
             0.0,
             {
+                "reward_lenient": 0.0,
+                "reward_strict": 0.0,
                 "intercepted": False,
                 "judge_match": None,
+                "judge_match_lenient": None,
+                "judge_match_strict": None,
                 "reason": intercept.get("stop_description")
                 or intercept.get("stop_reason")
                 or "not intercepted",
@@ -226,54 +318,69 @@ def main() -> int:
         write_reward(
             0.0,
             {
+                "reward_lenient": 0.0,
+                "reward_strict": 0.0,
                 "intercepted": True,
                 "judge_match": None,
+                "judge_match_lenient": None,
+                "judge_match_strict": None,
                 "reason": "missing judge configuration",
                 "task_id": task_id,
             },
         )
         return 0
 
-    judge_result: dict[str, Any] | None = None
-    last_error = ""
-    for attempt in range(3):
-        try:
-            judge_result = call_judge(
-                cfg,
-                str(task.get("instruction") or ""),
-                intercept,
-                task.get("judge_context")
-                if isinstance(task.get("judge_context"), dict)
-                else None,
-            )
-            break
-        except Exception as exc:
-            last_error = str(exc)
-            if attempt < 2:
-                time.sleep(2**attempt)
-
-    if judge_result is None:
-        write_reward(
-            0.0,
-            {
-                "intercepted": True,
-                "judge_match": None,
-                "reason": f"judge_call_failed: {last_error}",
-                "task_id": task_id,
-            },
+    instruction = str(task.get("instruction") or "")
+    judge_context = (
+        task.get("judge_context")
+        if isinstance(task.get("judge_context"), dict)
+        else None
+    )
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        lenient_future = executor.submit(
+            call_judge_with_retries,
+            cfg,
+            instruction,
+            intercept,
+            None,
+            JUDGE_SYSTEM_LENIENT,
+            800,
         )
-        return 0
+        strict_future = executor.submit(
+            call_judge_with_retries,
+            cfg,
+            instruction,
+            intercept,
+            judge_context,
+            JUDGE_SYSTEM_STRICT,
+            4096,
+        )
+        lenient_result = lenient_future.result()
+        strict_result = strict_future.result()
 
-    match = judge_result.get("match")
-    reward = 1.0 if match is True else 0.0
+    match_lenient = lenient_result.get("match")
+    match_strict = strict_result.get("match")
+    reward_lenient = 1.0 if match_lenient is True else 0.0
+    reward_strict = 1.0 if match_strict is True else 0.0
     write_reward(
-        reward,
+        reward_lenient,
         {
+            "reward_lenient": reward_lenient,
+            "reward_strict": reward_strict,
             "intercepted": True,
-            "judge_match": match,
-            "reason": judge_result.get("reason") or judge_result.get("error") or "",
-            "task_id": task_id,
+            "judge_match": match_lenient,
+            "judge_match_lenient": match_lenient,
+            "judge_match_strict": match_strict,
+            "reason": {
+                "lenient": lenient_result.get("reason")
+                or lenient_result.get("error")
+                or "",
+                "strict": strict_result.get("reason")
+                or strict_result.get("error")
+                or "",
+            },
             "judge_model": cfg["model"],
+            "task_id": task_id,
         },
     )
     return 0

--- a/src/clawbench/runtime/harbor/wrap-harbor-agent.sh
+++ b/src/clawbench/runtime/harbor/wrap-harbor-agent.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+wrap_agent() {
+  local executable=$1
+  local path real
+
+  path=$(command -v "$executable" 2>/dev/null || true)
+  if [[ -z "$path" && -x "$HOME/.local/bin/$executable" ]]; then
+    path="$HOME/.local/bin/$executable"
+  fi
+  [[ -n "$path" && -x "$path" ]] || return 0
+
+  real="${path}.clawbench-real"
+  if [[ ! -e "$real" ]]; then
+    mv "$path" "$real"
+  fi
+
+  cat >"$path" <<'WRAPPER'
+#!/bin/bash
+set +e
+
+real="${BASH_SOURCE[0]}.clawbench-real"
+stop_file=${CLAWBENCH_STOP_FILE:-/data/.stop-requested}
+stop_result=${CLAWBENCH_STOP_RESULT:-/data/agent-stop.json}
+rm -f "$stop_file" "$stop_result"
+
+"$real" "$@" <&0 &
+agent_pid=$!
+(
+  while kill -0 "$agent_pid" 2>/dev/null; do
+    if [[ -f "$stop_file" ]]; then
+      detected_at=$(date +%s.%N)
+      printf '{"stop_detected_at":%s,"signal":"INT"}\n' "$detected_at" >"$stop_result"
+      kill -INT "$agent_pid" 2>/dev/null || true
+      for _ in $(seq 1 20); do
+        kill -0 "$agent_pid" 2>/dev/null || break
+        sleep 0.1
+      done
+      if kill -0 "$agent_pid" 2>/dev/null; then
+        kill -TERM "$agent_pid" 2>/dev/null || true
+      fi
+      exit 0
+    fi
+    sleep 0.1
+  done
+) &
+watcher_pid=$!
+
+wait "$agent_pid"
+status=$?
+kill "$watcher_pid" 2>/dev/null || true
+wait "$watcher_pid" 2>/dev/null || true
+
+if [[ -f "$stop_file" ]]; then
+  exit 0
+fi
+exit "$status"
+WRAPPER
+  chmod 0755 "$path"
+}
+
+if (( $# > 0 )); then
+  for executable in "$@"; do
+    wrap_agent "$executable"
+  done
+else
+  wrap_agent claude
+  wrap_agent codex
+fi

--- a/src/clawbench/runtime/runtime-server/server.py
+++ b/src/clawbench/runtime/runtime-server/server.py
@@ -493,6 +493,7 @@ def start_cdp_handler(
             if not INTERCEPTION_FILE.exists():
                 result = {
                     "intercepted": True,
+                    "intercepted_at": time.time(),
                     "request": request_obj,
                     "schema": eval_schema,
                 }

--- a/test-cases/v2/v2-1134-chapter-finder-redcross/task.json
+++ b/test-cases/v2/v2-1134-chapter-finder-redcross/task.json
@@ -17,8 +17,11 @@
   },
   "instruction": "Find the nearest Red Cross chapter to zip code 90210 using the local chapter finder on redcross.org",
   "eval_schema": {
-    "url_pattern": "redcross\\.org\\/find-your-local-chapter",
-    "method": "GET"
+    "url_pattern": "redcross\\.org/api/lookup/v1/region-mappings/90210(?:\\?|$)",
+    "method": "GET",
+    "params": {
+      "type": "RCO"
+    }
   },
   "time_limit": 30,
   "extra_info": []

--- a/tests/test_harbor_adapter.py
+++ b/tests/test_harbor_adapter.py
@@ -14,6 +14,7 @@ from clawbench.eval.harbor_adapter import (
     unique_output_name,
     write_harbor_task,
 )
+from clawbench.runtime.harbor import verify as harbor_verify
 from clawbench.runtime.harbor.verify import write_reward
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
@@ -113,6 +114,7 @@ def test_write_harbor_task_emits_expected_tree_and_extra_info(tmp_path: Path) ->
     assert config["environment"]["env"]["BROWSER_CDP_URL"] == "http://127.0.0.1:9223"
     assert config["environment"]["env"]["PLAYWRIGHT_CDP_URL"] == "http://127.0.0.1:9223"
     assert config["steps"][0]["agent"]["timeout_sec"] == 1800.0
+    assert config["steps"][0]["verifier"]["timeout_sec"] == 300.0
     assert (
         "http://127.0.0.1:9223"
         in (out / "steps" / "run" / "instruction.md").read_text()
@@ -198,6 +200,74 @@ def test_harbor_verifier_separates_metrics_from_metadata(tmp_path: Path) -> None
         "judge_match": False,
         "reason": "wrong payload",
         "task_id": 47,
+    }
+
+
+def test_harbor_judge_supports_lenient_and_strict_prompts(monkeypatch) -> None:
+    requests = []
+
+    def fake_post_json(url, headers, payload, timeout=60):
+        requests.append(payload)
+        return {"choices": [{"message": {"content": '{"match": true}'}}]}
+
+    monkeypatch.setattr(harbor_verify, "post_json", fake_post_json)
+    config = {
+        "api_type": "openai-completions",
+        "model": "judge",
+        "base_url": "https://judge.example/v1",
+        "api_key": "key",
+    }
+    intercept = {"request": {"url": "https://example.com/submit", "method": "POST"}}
+
+    harbor_verify.call_judge(
+        config,
+        "submit the form",
+        intercept,
+        None,
+        harbor_verify.JUDGE_SYSTEM_LENIENT,
+        800,
+    )
+    harbor_verify.call_judge(
+        config,
+        "submit the form",
+        intercept,
+        {"rubric": "all fields are required"},
+        harbor_verify.JUDGE_SYSTEM_STRICT,
+        4096,
+    )
+
+    assert requests[0]["messages"][0]["content"] == harbor_verify.JUDGE_SYSTEM_LENIENT
+    assert requests[0]["max_tokens"] == 800
+    assert requests[1]["messages"][0]["content"] == harbor_verify.JUDGE_SYSTEM_STRICT
+    assert requests[1]["max_tokens"] == 4096
+    assert "all fields are required" in requests[1]["messages"][1]["content"]
+
+
+def test_harbor_verifier_emits_both_reward_rubrics(tmp_path: Path) -> None:
+    write_reward(
+        1.0,
+        {
+            "reward_lenient": 1.0,
+            "reward_strict": 0.0,
+            "intercepted": True,
+            "judge_match": True,
+            "judge_match_lenient": True,
+            "judge_match_strict": False,
+            "reason": {"lenient": "no contradiction", "strict": "missing time"},
+            "task_id": 47,
+        },
+        output_dir=tmp_path,
+    )
+
+    reward = json.loads((tmp_path / "reward.json").read_text())
+    assert reward == {
+        "reward": 1.0,
+        "intercepted": 1.0,
+        "reward_lenient": 1.0,
+        "reward_strict": 0.0,
+        "judge_match": 1.0,
+        "judge_match_lenient": 1.0,
+        "judge_match_strict": 0.0,
     }
 
 

--- a/tests/test_harbor_adapter.py
+++ b/tests/test_harbor_adapter.py
@@ -172,7 +172,7 @@ def test_harbor_adapter_help_without_container_runtime(tmp_path: Path) -> None:
     assert "usage" in (result.stdout + result.stderr).lower()
 
 
-def test_harbor_verifier_reward_json_contains_metadata(tmp_path: Path) -> None:
+def test_harbor_verifier_separates_metrics_from_metadata(tmp_path: Path) -> None:
     write_reward(
         0.0,
         {
@@ -187,11 +187,31 @@ def test_harbor_verifier_reward_json_contains_metadata(tmp_path: Path) -> None:
     assert (tmp_path / "reward.txt").read_text() == "0.0"
     reward = json.loads((tmp_path / "reward.json").read_text())
     detailed = json.loads((tmp_path / "clawbench-result.json").read_text())
-    assert reward == detailed
     assert reward == {
+        "reward": 0.0,
+        "intercepted": 1.0,
+        "judge_match": 0.0,
+    }
+    assert detailed == {
         "reward": 0.0,
         "intercepted": True,
         "judge_match": False,
         "reason": "wrong payload",
         "task_id": 47,
     }
+
+
+def test_harbor_verifier_omits_unknown_judge_match_metric(tmp_path: Path) -> None:
+    write_reward(
+        0.0,
+        {
+            "intercepted": False,
+            "judge_match": None,
+            "reason": "not intercepted",
+            "task_id": 47,
+        },
+        output_dir=tmp_path,
+    )
+
+    reward = json.loads((tmp_path / "reward.json").read_text())
+    assert reward == {"reward": 0.0, "intercepted": 0.0}

--- a/tests/test_harbor_correctness.py
+++ b/tests/test_harbor_correctness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 import time
@@ -53,3 +54,24 @@ def test_stop_wrapper_interrupts_agent_and_exits_cleanly(tmp_path: Path) -> None
     stop_file.touch()
     assert process.wait(timeout=3) == 0
     assert json.loads(stop_result.read_text())["signal"] == "INT"
+
+
+def test_redcross_task_intercepts_zip_lookup_not_chapter_finder_page() -> None:
+    task_path = (
+        REPO_ROOT
+        / "test-cases"
+        / "v2"
+        / "v2-1134-chapter-finder-redcross"
+        / "task.json"
+    )
+    schema = json.loads(task_path.read_text())["eval_schema"]
+
+    assert not re.search(
+        schema["url_pattern"],
+        "https://www.redcross.org/find-your-local-chapter.html",
+    )
+    assert re.search(
+        schema["url_pattern"],
+        "https://www.redcross.org/api/lookup/v1/region-mappings/90210?type=RCO",
+    )
+    assert schema["params"] == {"type": "RCO"}

--- a/tests/test_harbor_correctness.py
+++ b/tests/test_harbor_correctness.py
@@ -1,0 +1,55 @@
+"""Regression tests for ClawBench's Harbor integration."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARBOR_AGENT_WRAPPER = (
+    REPO_ROOT / "src" / "clawbench" / "runtime" / "harbor" / "wrap-harbor-agent.sh"
+)
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="wrap-harbor-agent.sh runs inside Harbor's Linux containers; "
+    "bash signal handling differs on mac and windows runners",
+)
+def test_stop_wrapper_interrupts_agent_and_exits_cleanly(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_agent = bin_dir / "claude"
+    started = tmp_path / "started"
+    stop_file = tmp_path / "stop-requested"
+    stop_result = tmp_path / "agent-stop.json"
+    fake_agent.write_text(
+        "#!/bin/bash\n"
+        "trap 'exit 130' INT\n"
+        'touch "$FAKE_AGENT_STARTED"\n'
+        "while true; do sleep 0.1; done\n"
+    )
+    fake_agent.chmod(0o755)
+    env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "HOME": str(tmp_path),
+        "FAKE_AGENT_STARTED": str(started),
+        "CLAWBENCH_STOP_FILE": str(stop_file),
+        "CLAWBENCH_STOP_RESULT": str(stop_result),
+    }
+
+    subprocess.run([HARBOR_AGENT_WRAPPER, "claude"], env=env, check=True)
+    process = subprocess.Popen([fake_agent], env=env)
+    deadline = time.monotonic() + 2
+    while not started.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert started.exists()
+
+    stop_file.touch()
+    assert process.wait(timeout=3) == 0
+    assert json.loads(stop_result.read_text())["signal"] == "INT"


### PR DESCRIPTION
## Summary

The Harbor verifier now reports the same scoring rubrics as the native runner, with machine-safe outputs:

- `reward.json` carries only numeric metrics (`reward`, `intercepted`, `judge_match`, `judge_match_lenient`, `judge_match_strict`, `reward_lenient`, `reward_strict`). Full metadata — including both verdict reasons — stays in `clawbench-result.json`, so Harbor's reward aggregation never sees booleans, strings, or nulls.
- Each intercepted request is judged concurrently under two rubrics: the lenient no-explicit-contradiction rubric (the public leaderboard's primary signal) and a conservative strict rubric. The primary `reward` remains the lenient verdict; strict is reported separately as `reward_strict`. Both verdicts and reasons are retained.
- Interception evidence is timestamped: the runtime server records `intercepted_at` when it captures the request.
- The Red Cross chapter-finder task now intercepts the actual ZIP lookup API call instead of blocking the chapter-finder landing page.
- Stock Harbor agents (Claude Code and Codex) are wrapped at install time so ClawBench's existing stop signal ends them cleanly after the final request is recorded, persisting stop timing to `/data/agent-stop.json`.
- Verifier step timeout is raised from 180s to 300s to fit two judge calls.

## Why

- Harbor 0.21.0 expects numeric reward metrics; the old `reward.json` mixed booleans, strings, and nested metadata into one blob.
- Non-intercepted tasks and judge-call failures previously emitted sparse or non-numeric payloads; both paths now produce well-formed numeric metrics, with failure reasons preserved in `clawbench-result.json`.
- Stopping stock agents after interception prevents them from continuing to act or hanging the trial after the scored request has been captured.

## Relation to #319

#319 collapses `runner/judge_llm.py` onto `judge.py`'s transport in the native runner. This PR is independent of that refactor but shares its goal for the Harbor path: the verifier's lenient rubric text mirrors `judge_llm.JUDGE_SYSTEM`.

The Harbor verifier runs standalone inside each task container via the runtime-server venv where the `clawbench` package is not installed, so it cannot import the shared prompt today. If a suitable shared home for rubric strings lands, we're happy to follow up and deduplicate.

## Tests

- `uv run pytest -q` — 208 passed
- `uv run ruff check src/clawbench tests` — clean
- `uv run ruff format --check src/clawbench tests` — clean
- `uv run --frozen pyright src/clawbench tests` — 0 errors
- Coverage includes numeric metric output, dual-rubric wiring, unknown verdicts, stop-wrapper behavior, and the Red Cross interception regression.

## Reproduction (Harbor 0.21.0)

Prerequisites: Docker, `uv`, agent-provider credentials, judge credentials, and the PurelyMail variables required by ClawBench.

```bash
git clone https://github.com/kernel/ClawBench
cd ClawBench
git checkout hypeship/upstream-harbor-correctness
uv sync --frozen

uv run clawbench-harbor-adapt \
  --output-dir ./harbor-datasets/clawbench-v2-smoke \
  --task-ids v2-1134-chapter-finder-redcross \
  --overwrite

cat > .harbor-smoke.env <<EOF
PURELY_MAIL_API_KEY=$PURELY_MAIL_API_KEY
PURELY_MAIL_DOMAIN=$PURELY_MAIL_DOMAIN
OPENROUTER_API_KEY=$OPENROUTER_API_KEY
CLAWBENCH_JUDGE_BASE_URL=https://openrouter.ai/api/v1
CLAWBENCH_JUDGE_API_KEY=$OPENROUTER_API_KEY
CLAWBENCH_JUDGE_MODEL=deepseek/deepseek-v4-pro
CLAWBENCH_JUDGE_API_TYPE=openai-completions
EOF
chmod 600 .harbor-smoke.env

uvx --from harbor==0.21.0 harbor run \
  --path ./harbor-datasets/clawbench-v2-smoke \
  --agent hermes \
  --model deepseek/deepseek-v4-flash \
  --env-file .harbor-smoke.env \
  --jobs-dir ./harbor-jobs \
  --max-retries 0 \
  --delete \
  --yes

trial=$(find ./harbor-jobs -path '*/steps/run/verifier/reward.json' -print -quit)
verifier_dir=$(dirname "$trial")

cat "$verifier_dir/reward.txt"
cat "$verifier_dir/reward.json"
cat "$verifier_dir/clawbench-result.json"

rm -f .harbor-smoke.env
```

Expected: `reward.txt` equals `reward_lenient`; `reward.json` contains numeric `intercepted`, `reward_lenient`, and `reward_strict` metrics; `clawbench-result.json` retains both rubric reasons.