### PR TITLE
fix(batch): resume from run-meta.json, not from log-file existence

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,8 @@ Execution:
 | --- | --- | --- |
 | `--max-concurrent <n>` | 2 local, 1 Kernel/Browserbase | Parallel jobs |
 | `--stagger-delay <s>` | 15 | Minimum seconds between consecutive container starts (rolling start) |
-| `--resume <dir>` | — | Reuse a previous batch's output directory and skip finished runs |
+| `--resume <dir>` | — | Reuse a previous batch's output directory and skip jobs whose `run-meta.json` records an outcome. Jobs that started but never finished are run again |
+| `--retry-failed` | off | With `--resume`, also re-run jobs whose recorded outcome was an infra-class failure (the categories excluded from adjusted scoring). Genuine model failures are kept |
 | `--dry-run` | off | Print the job matrix without running anything |
 | `--output-dir <path>` | `test-output` | Base output directory |
 

--- a/src/clawbench/runner/batch.py
+++ b/src/clawbench/runner/batch.py
@@ -18,6 +18,7 @@ from typing import Protocol
 import yaml
 
 from clawbench.runner.run_support.config import engine
+from clawbench.runner.run_support.results import NON_MODEL_FAILURE_CATEGORIES
 from clawbench.utils.paths import ASSET_ROOT, WORKSPACE_ROOT, ensure_workspace_templates
 from clawbench.utils.timeouts import (
     BATCH_JOB_GRACE_S,
@@ -239,7 +240,93 @@ class Job:
     case_name: str
     status: str = "pending"
     duration: float = 0.0
+    # True when --resume adopted a previous run's recorded outcome instead of
+    # running this job again. Its status is that run's result, not "skipped",
+    # so the rewritten batch-summary.json keeps the original tallies.
+    resumed: bool = False
     proc: asyncio.subprocess.Process | None = field(default=None, repr=False)
+
+
+def load_recorded_runs(base_output: Path) -> dict[tuple[str, str], dict]:
+    """Map (test_case, model) -> the newest run-meta.json under a batch output dir.
+
+    run.py writes run-meta.json for any run that got far enough to have an
+    outcome, failures included, and that file is the authoritative record of
+    what happened. A batch log file is not: it is created when a job starts,
+    so it exists for jobs that were killed mid-run and never finished.
+    """
+    if not base_output.is_dir():
+        return {}
+    newest: dict[tuple[str, str], tuple[str, dict]] = {}
+    for meta_file in sorted(base_output.glob("*/*/run-meta.json")):
+        try:
+            meta = json.loads(meta_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # A truncated run-meta.json means that run's outcome is unknown, so
+            # leave the job to be run again rather than guessing at it.
+            continue
+        if not isinstance(meta, dict):
+            continue
+        case, model = meta.get("test_case"), meta.get("model")
+        if not case or not model:
+            continue
+        key = (str(case), str(model))
+        # A case x model pair can have several run dirs across resumes; the
+        # timestamp in the metadata orders them, with the dir name as a
+        # fallback for older runs that predate the field.
+        stamp = str(meta.get("timestamp") or meta_file.parent.name)
+        if key not in newest or stamp >= newest[key][0]:
+            newest[key] = (stamp, meta)
+    return {key: meta for key, (_, meta) in newest.items()}
+
+
+def is_infra_class_failure(meta: dict) -> bool:
+    """Did this run fail for a reason that says nothing about the model?
+
+    Uses the same vocabulary as the scorer: these are the categories excluded
+    from adjusted scoring, so a re-run is the only way to get a usable result.
+    """
+    return bool(meta.get("infra_failure")) or (
+        meta.get("failure_category") in NON_MODEL_FAILURE_CATEGORIES
+    )
+
+
+def recorded_outcome(meta: dict) -> tuple[str, float]:
+    """Batch job status and duration for a run that already happened."""
+    try:
+        duration = float(meta.get("duration_seconds") or 0)
+    except (TypeError, ValueError):
+        duration = 0.0
+    if meta.get("intercepted"):
+        return "passed", duration
+    if is_infra_class_failure(meta):
+        return "error", duration
+    return "failed", duration
+
+
+def apply_resume(
+    jobs: list["Job"], base_output: Path, retry_failed: bool = False
+) -> tuple[int, int]:
+    """Adopt each finished run's recorded outcome. Returns (carried, retried).
+
+    A job is carried over only when base_output holds a run-meta.json for it.
+    Anything else stays pending and runs again -- including a job that has a
+    batch log but no metadata, which is what a job killed mid-run looks like
+    and exactly the case the old log-existence check skipped.
+    """
+    recorded = load_recorded_runs(base_output)
+    carried = retried = 0
+    for job in jobs:
+        meta = recorded.get((job.case_name, job.model))
+        if meta is None:
+            continue
+        if retry_failed and is_infra_class_failure(meta):
+            retried += 1
+            continue
+        job.status, job.duration = recorded_outcome(meta)
+        job.resumed = True
+        carried += 1
+    return carried, retried
 
 
 def fmt_duration(s: float) -> str:
@@ -660,6 +747,7 @@ def write_summary_json(
                 "case": j.case_name,
                 "status": j.status,
                 "duration_seconds": round(j.duration),
+                "resumed": j.resumed,
             }
             for j in jobs
         ],
@@ -739,15 +827,12 @@ async def async_main(args: argparse.Namespace) -> int:
             print(f"ERROR: --resume directory does not exist: {base_output}")
             return 1
         log_dir = base_output / "batch-logs"
-        skipped = 0
-        for job in jobs:
-            safe_model = re.sub(r"[/:]+", "--", job.model)
-            if (log_dir / f"{job.case_name}-{safe_model}.log").exists():
-                job.status = "skipped"
-                skipped += 1
+        carried, retried = apply_resume(jobs, base_output, args.retry_failed)
         remaining = sum(1 for j in jobs if j.status == "pending")
         print(f"\n[RESUME] Reusing {base_output}")
-        print(f"[RESUME] {skipped} job(s) already done, {remaining} remaining")
+        print(f"[RESUME] {carried} job(s) already recorded, {remaining} to run")
+        if retried:
+            print(f"[RESUME] {retried} of those are infra failures being re-run")
         if remaining == 0:
             print("[RESUME] All jobs already completed.")
             return 0
@@ -803,11 +888,12 @@ async def async_main(args: argparse.Namespace) -> int:
     throttle = StartupThrottle(args.stagger_delay)
 
     async def _noop() -> None:
-        """Placeholder for jobs already marked skipped (e.g. by --resume)."""
+        """Placeholder for jobs that are not being run: skipped, or resumed
+        from a previous batch and carrying that run's recorded outcome."""
 
     all_tasks = [
         asyncio.create_task(_noop())
-        if j.status == "skipped"
+        if j.resumed or j.status == "skipped"
         else asyncio.create_task(
             run_job(
                 j,
@@ -946,7 +1032,19 @@ def main() -> None:
         metavar="BATCH_DIR",
         help=(
             "Resume a previous batch run: reuse its output directory and skip "
-            "any (case x model) job whose batch-logs/<case>-<model>.log already exists."
+            "any (case x model) job whose run-meta.json records an outcome. "
+            "Jobs that started but never finished are run again."
+        ),
+    )
+    p.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help=(
+            "With --resume, also re-run jobs whose recorded outcome was an "
+            "infra-class failure (infra_failure, api_or_credit, task_data, "
+            "build_instruction) -- the categories excluded from adjusted "
+            "scoring, where the run says nothing about the model. Genuine "
+            "model failures are kept."
         ),
     )
     from clawbench.runner.run import DEFAULT_HARNESS, HARNESSES

--- a/src/clawbench/runner/batch.py
+++ b/src/clawbench/runner/batch.py
@@ -292,15 +292,26 @@ def is_infra_class_failure(meta: dict) -> bool:
 
 
 def recorded_outcome(meta: dict) -> tuple[str, float]:
-    """Batch job status and duration for a run that already happened."""
+    """Batch job status and duration for a run that already happened.
+
+    Mirrors the exit-code map a live job goes through: run-meta's `pass` is
+    exactly what run.py exits 0 on (stage 1 and, unless --no-judge, stage 2),
+    and a judge that never rendered a verdict is exit 3, not a failure.
+    """
     try:
         duration = float(meta.get("duration_seconds") or 0)
     except (TypeError, ValueError):
         duration = 0.0
-    if meta.get("intercepted"):
+    passed = meta.get("pass")
+    if passed is None:
+        # Pre-judge run-meta: stage 1 was the whole verdict.
+        passed = meta.get("intercepted")
+    if passed:
         return "passed", duration
     if is_infra_class_failure(meta):
         return "error", duration
+    if meta.get("intercepted") and "judge" in meta and meta.get("judge_match") is None:
+        return "judge_inconclusive", duration
     return "failed", duration
 
 

--- a/tests/test_batch_resume.py
+++ b/tests/test_batch_resume.py
@@ -1,0 +1,266 @@
+"""--resume must re-run what never finished, and must not destroy the summary.
+
+Resume used to decide completion from `batch-logs/<case>-<model>.log`. That
+file is created when a job *starts*, so every job killed mid-run -- the network
+blip, the OOM, the wedged container -- looked complete and was skipped, which
+inverts the flag's whole purpose. The rewritten batch-summary.json then recorded
+every previously finished job as `status: "skipped", duration_seconds: 0`,
+destroying the tallies that downstream stats and the HF upload read.
+
+run-meta.json is the authoritative record: run.py writes it for any run that got
+far enough to have an outcome, failures included.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from clawbench.runner.batch import (
+    Job,
+    apply_resume,
+    is_infra_class_failure,
+    load_recorded_runs,
+    recorded_outcome,
+    write_summary_json,
+)
+
+
+def _job(case: str, model: str) -> Job:
+    return Job(model=model, case_dir=Path("test-cases/v2") / case, case_name=case)
+
+
+def _safe(model: str) -> str:
+    return model.replace("/", "--").replace(":", "--")
+
+
+def _record_run(
+    base: Path,
+    case: str,
+    model: str,
+    *,
+    intercepted: bool = False,
+    failure_category: str | None = None,
+    infra_failure: bool = False,
+    duration: int = 90,
+    stamp: str = "20260101-000000",
+) -> Path:
+    """Write a run-meta.json where a real run would put one."""
+    run_dir = base / _safe(model) / f"claw-code-{case}-{_safe(model)}-{stamp}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "run-meta.json").write_text(
+        json.dumps(
+            {
+                "test_case": case,
+                "model": model,
+                "timestamp": stamp,
+                "duration_seconds": duration,
+                "intercepted": intercepted,
+                "result_category": "intercepted" if intercepted else failure_category,
+                "failure_category": failure_category,
+                "infra_failure": infra_failure,
+            }
+        )
+    )
+    return run_dir
+
+
+def _start_log(base: Path, case: str, model: str) -> Path:
+    """The log batch.py opens when a job starts, before it has any outcome."""
+    log_dir = base / "batch-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    path = log_dir / f"{case}-{_safe(model)}.log"
+    path.write_text("[START] ...\n")
+    return path
+
+
+# --- the regression -----------------------------------------------------------
+
+
+def test_a_job_that_started_but_never_finished_is_run_again(tmp_path: Path) -> None:
+    """The bug: a log file means "started", not "done". A job killed before it
+    could write run-meta.json is exactly the job --resume exists to re-run."""
+    _start_log(tmp_path, "002-food", "glm-5.1")
+    jobs = [_job("002-food", "glm-5.1")]
+
+    carried, retried = apply_resume(jobs, tmp_path)
+
+    assert (carried, retried) == (0, 0)
+    assert jobs[0].status == "pending"
+    assert jobs[0].resumed is False
+
+
+def test_a_finished_job_is_not_run_again(tmp_path: Path) -> None:
+    _record_run(tmp_path, "002-food", "glm-5.1", intercepted=True)
+    jobs = [_job("002-food", "glm-5.1")]
+
+    carried, _ = apply_resume(jobs, tmp_path)
+
+    assert carried == 1
+    assert jobs[0].resumed is True
+
+
+def test_resume_keeps_the_recorded_outcome_not_a_skipped_row(tmp_path: Path) -> None:
+    """Second half of the bug: the rewritten summary replaced real results with
+    `skipped` / 0s, so a resumed batch reported nothing it had actually done."""
+    _record_run(tmp_path, "002-food", "glm-5.1", intercepted=True, duration=214)
+    jobs = [_job("002-food", "glm-5.1")]
+
+    apply_resume(jobs, tmp_path)
+
+    assert jobs[0].status == "passed"
+    assert jobs[0].duration == 214
+
+
+def test_the_written_summary_preserves_carried_over_totals(tmp_path: Path) -> None:
+    _record_run(tmp_path, "002-food", "glm-5.1", intercepted=True, duration=214)
+    _record_run(
+        tmp_path, "003-mail", "glm-5.1", failure_category="model_not_intercepted"
+    )
+    jobs = [_job("002-food", "glm-5.1"), _job("003-mail", "glm-5.1")]
+    apply_resume(jobs, tmp_path)
+
+    write_summary_json(jobs, tmp_path, 12.0, 2, "2026-01-01T00:00:00+00:00")
+    summary = json.loads((tmp_path / "batch-summary.json").read_text())
+
+    assert summary["totals"] == {"passed": 1, "failed": 1, "error": 0, "skipped": 0}
+    assert [j["duration_seconds"] for j in summary["jobs"]] == [214, 90]
+    assert all(j["resumed"] for j in summary["jobs"])
+
+
+# --- outcome mapping ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "meta, expected",
+    [
+        ({"intercepted": True}, "passed"),
+        ({"intercepted": False, "failure_category": "model_not_intercepted"}, "failed"),
+        ({"intercepted": False, "infra_failure": True}, "error"),
+        ({"intercepted": False, "failure_category": "api_or_credit"}, "error"),
+    ],
+)
+def test_recorded_outcome_maps_a_run_to_a_batch_status(
+    meta: dict, expected: str
+) -> None:
+    assert recorded_outcome(meta)[0] == expected
+
+
+def test_a_missing_or_unparsable_duration_does_not_crash_resume() -> None:
+    assert recorded_outcome({"intercepted": True})[1] == 0.0
+    assert recorded_outcome({"intercepted": True, "duration_seconds": None})[1] == 0.0
+    assert recorded_outcome({"intercepted": True, "duration_seconds": "?"})[1] == 0.0
+
+
+def test_infra_class_uses_the_scorers_own_vocabulary() -> None:
+    """These are the categories excluded from adjusted scoring, so the run
+    carries no signal about the model and re-running it is the only recourse."""
+    for category in (
+        "infra_failure",
+        "api_or_credit",
+        "task_data",
+        "build_instruction",
+    ):
+        assert is_infra_class_failure({"failure_category": category}), category
+    assert not is_infra_class_failure({"failure_category": "model_not_intercepted"})
+
+
+# --- --retry-failed -----------------------------------------------------------
+
+
+def test_retry_failed_reruns_infra_failures(tmp_path: Path) -> None:
+    _record_run(
+        tmp_path,
+        "002-food",
+        "glm-5.1",
+        infra_failure=True,
+        failure_category="infra_failure",
+    )
+    jobs = [_job("002-food", "glm-5.1")]
+
+    carried, retried = apply_resume(jobs, tmp_path, retry_failed=True)
+
+    assert (carried, retried) == (0, 1)
+    assert jobs[0].status == "pending"
+
+
+def test_retry_failed_keeps_genuine_model_failures(tmp_path: Path) -> None:
+    """The model was asked and it failed. Re-running buys the same answer."""
+    _record_run(
+        tmp_path, "002-food", "glm-5.1", failure_category="model_not_intercepted"
+    )
+    jobs = [_job("002-food", "glm-5.1")]
+
+    carried, retried = apply_resume(jobs, tmp_path, retry_failed=True)
+
+    assert (carried, retried) == (1, 0)
+    assert jobs[0].status == "failed"
+
+
+def test_without_the_flag_a_failed_run_is_left_alone(tmp_path: Path) -> None:
+    _record_run(
+        tmp_path,
+        "002-food",
+        "glm-5.1",
+        infra_failure=True,
+        failure_category="infra_failure",
+    )
+    jobs = [_job("002-food", "glm-5.1")]
+
+    carried, retried = apply_resume(jobs, tmp_path)
+
+    assert (carried, retried) == (1, 0)
+    assert jobs[0].status == "error"
+
+
+# --- reading the recorded runs ------------------------------------------------
+
+
+def test_the_newest_run_for_a_pair_wins(tmp_path: Path) -> None:
+    """Resuming repeatedly leaves several run dirs for one case x model."""
+    _record_run(
+        tmp_path,
+        "002-food",
+        "glm-5.1",
+        stamp="20260101-000000",
+        failure_category="infra_failure",
+        infra_failure=True,
+    )
+    _record_run(
+        tmp_path, "002-food", "glm-5.1", stamp="20260102-000000", intercepted=True
+    )
+
+    recorded = load_recorded_runs(tmp_path)
+
+    assert recorded[("002-food", "glm-5.1")]["intercepted"] is True
+
+
+def test_a_truncated_run_meta_is_not_guessed_at(tmp_path: Path) -> None:
+    """#312/#325 showed run-meta.json can be truncated. An unreadable outcome is
+    an unknown outcome, so the job runs again rather than being invented."""
+    run_dir = _record_run(tmp_path, "002-food", "glm-5.1", intercepted=True)
+    (run_dir / "run-meta.json").write_text('{"test_case": "002-food", "mod')
+    jobs = [_job("002-food", "glm-5.1")]
+
+    carried, _ = apply_resume(jobs, tmp_path)
+
+    assert carried == 0
+    assert jobs[0].status == "pending"
+
+
+def test_a_model_name_with_a_slash_still_matches_its_job(tmp_path: Path) -> None:
+    """Run dirs sanitize `/` to `--`, so the match keys off the metadata."""
+    _record_run(tmp_path, "002-food", "anthropic/claude-sonnet-4-6", intercepted=True)
+    jobs = [_job("002-food", "anthropic/claude-sonnet-4-6")]
+
+    carried, _ = apply_resume(jobs, tmp_path)
+
+    assert carried == 1
+    assert jobs[0].status == "passed"
+
+
+def test_an_empty_or_missing_output_dir_reads_as_nothing_done(tmp_path: Path) -> None:
+    assert load_recorded_runs(tmp_path) == {}
+    assert load_recorded_runs(tmp_path / "nope") == {}

--- a/tests/test_batch_resume.py
+++ b/tests/test_batch_resume.py
@@ -44,26 +44,32 @@ def _record_run(
     intercepted: bool = False,
     failure_category: str | None = None,
     infra_failure: bool = False,
+    judge_match: bool | None | str = "unjudged",
     duration: int = 90,
     stamp: str = "20260101-000000",
 ) -> Path:
-    """Write a run-meta.json where a real run would put one."""
+    """Write a run-meta.json where a real run would put one.
+
+    `judge_match` mirrors run.py: leave it "unjudged" for a --no-judge run,
+    otherwise pass the judge's verdict (None = it never rendered one).
+    """
     run_dir = base / _safe(model) / f"claw-code-{case}-{_safe(model)}-{stamp}"
     run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "run-meta.json").write_text(
-        json.dumps(
-            {
-                "test_case": case,
-                "model": model,
-                "timestamp": stamp,
-                "duration_seconds": duration,
-                "intercepted": intercepted,
-                "result_category": "intercepted" if intercepted else failure_category,
-                "failure_category": failure_category,
-                "infra_failure": infra_failure,
-            }
-        )
-    )
+    meta: dict = {
+        "test_case": case,
+        "model": model,
+        "timestamp": stamp,
+        "duration_seconds": duration,
+        "intercepted": intercepted,
+        "result_category": "intercepted" if intercepted else failure_category,
+        "failure_category": failure_category,
+        "infra_failure": infra_failure,
+        "pass": intercepted and judge_match in ("unjudged", True),
+    }
+    if judge_match != "unjudged":
+        meta["judge"] = {"match": judge_match, "reason": ""}
+        meta["judge_match"] = judge_match
+    (run_dir / "run-meta.json").write_text(json.dumps(meta))
     return run_dir
 
 
@@ -125,7 +131,13 @@ def test_the_written_summary_preserves_carried_over_totals(tmp_path: Path) -> No
     write_summary_json(jobs, tmp_path, 12.0, 2, "2026-01-01T00:00:00+00:00")
     summary = json.loads((tmp_path / "batch-summary.json").read_text())
 
-    assert summary["totals"] == {"passed": 1, "failed": 1, "error": 0, "skipped": 0}
+    assert summary["totals"] == {
+        "passed": 1,
+        "failed": 1,
+        "error": 0,
+        "judge_inconclusive": 0,
+        "skipped": 0,
+    }
     assert [j["duration_seconds"] for j in summary["jobs"]] == [214, 90]
     assert all(j["resumed"] for j in summary["jobs"])
 
@@ -137,15 +149,37 @@ def test_the_written_summary_preserves_carried_over_totals(tmp_path: Path) -> No
     "meta, expected",
     [
         ({"intercepted": True}, "passed"),
+        ({"intercepted": True, "pass": True}, "passed"),
         ({"intercepted": False, "failure_category": "model_not_intercepted"}, "failed"),
         ({"intercepted": False, "infra_failure": True}, "error"),
         ({"intercepted": False, "failure_category": "api_or_credit"}, "error"),
+        # Stage 2 verdicts, as run.py exits them: mismatch is 1, no verdict is 3.
+        (
+            {"intercepted": True, "pass": False, "judge": {}, "judge_match": False},
+            "failed",
+        ),
+        (
+            {"intercepted": True, "pass": False, "judge": {}, "judge_match": None},
+            "judge_inconclusive",
+        ),
     ],
 )
 def test_recorded_outcome_maps_a_run_to_a_batch_status(
     meta: dict, expected: str
 ) -> None:
     assert recorded_outcome(meta)[0] == expected
+
+
+def test_a_judge_outage_resumes_as_inconclusive_not_passed(tmp_path: Path) -> None:
+    """Stage 1 succeeded but the judge never answered. Live, batch files that
+    under judge_inconclusive; a resume must not upgrade it to a pass."""
+    _record_run(tmp_path, "002-food", "glm-5.1", intercepted=True, judge_match=None)
+    _record_run(tmp_path, "003-mail", "glm-5.1", intercepted=True, judge_match=False)
+    jobs = [_job("002-food", "glm-5.1"), _job("003-mail", "glm-5.1")]
+
+    apply_resume(jobs, tmp_path)
+
+    assert [j.status for j in jobs] == ["judge_inconclusive", "failed"]
 
 
 def test_a_missing_or_unparsable_duration_does_not_crash_resume() -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes #297 — all three asks.

`--resume` decided a job was finished if `batch-logs/<case>-<model>.log` existed. That log is opened when a job **starts** (`batch.py:320`), so resume skipped every job that was ever *attempted* — including the ones killed mid-run. That inverts the flag: after a network blip or an OOM takes out 20 of 130 tasks, `--resume` skips exactly those 20 and reports the batch complete.

The second effect destroyed data rather than just omitting it. `write_summary_json` rewrites `batch-summary.json` from the in-memory job list, and every carried-over job was written as `status: "skipped", duration_seconds: 0`. A resumed batch reported none of the results it already had, in the artifact the per-run stats and the HuggingFace upload consume.

### Ask 1 — decide completion from `run-meta.json`

`run.py` writes `run-meta.json` for any run that got far enough to have an outcome, failures included — the invariant #303, #302 and #314 each protect. `load_recorded_runs()` indexes those by `(test_case, model)`, read from the metadata rather than the path, so:

- a model name containing `/` matches its job even though the run directory sanitises it to `--`;
- the newest run wins when repeated resumes have left several directories for one `case × model` pair;
- a **truncated** `run-meta.json` counts as an unknown outcome and the job runs again, rather than having a result invented for it. #312/#325 established that this file can be truncated.

A job with no recorded outcome stays pending and runs again. That is the whole fix for ask 1: "has a log" becomes "has a result".

### Ask 2 — `--retry-failed`

Re-runs jobs whose recorded outcome was an infra-class failure, using the scorer's own `NON_MODEL_FAILURE_CATEGORIES` (`infra_failure`, `api_or_credit`, `task_data`, `build_instruction`). Those are already the categories excluded from adjusted scoring, so such a run carries no signal about the model and a re-run is the only way to get one.

**One judgment call worth your eye:** genuine model failures (`model_not_intercepted`) are *kept*, not retried — the model was asked and it failed, so a re-run buys the same answer at full agent cost. The issue says "failure/infra error", which could be read either way. Say the word and I'll widen it to retry those too, or split it into two flags.

### Ask 3 — merge prior statuses into the summary

A carried-over job keeps its recorded result — `passed` / `failed` / `error` — with its real duration, so the rewritten `batch-summary.json` preserves the original tallies instead of zeroing them.

Jobs are marked `resumed`, which does two things: the scheduler still skips executing them (it previously keyed off `status == "skipped"`, which is no longer what a carried-over job looks like), and a reader of `batch-summary.json` can tell a carried-over row from one this invocation produced. That adds one key per job to the summary — flagging it since that file is consumed downstream, though it is additive and existing keys are unchanged.

## Corpus

- [ ] v2
- [ ] v1
- [ ] both
- [x] not applicable

<sub>Host-side batch driver; no task data involved.</sub>

## Test plan

- [x] New `tests/test_batch_resume.py`, 17 tests. This path had **no** coverage — every existing test passes `resume=None`, which #297 notes and #160 asks to fix.
- [x] **Control, because tests written after a fix prove nothing.** I swapped the log-existence heuristic back into `apply_resume`, held the tests constant, and re-ran: **8 of the 17 fail**, including the two that matter most — a started-but-unfinished job being skipped, and the summary losing its tallies.
- [x] Covered: a job with a start log but no metadata runs again; a finished job does not; carried-over status and duration survive into `batch-summary.json` (`totals` stay `passed: 1, failed: 1` rather than collapsing to `skipped: 2`); the outcome→status mapping; missing/unparsable `duration_seconds`; `--retry-failed` on and off; newest-run-wins; truncated metadata; a `/` in the model name; an empty or absent output directory.
- [x] Full suite: 227 passed, 4 skipped. The 4 deselected are `test_host_tasks.py::test_checked_task_json_files_parse_and_validate`, which fails only on this Windows checkout — the task files are git symlinks (mode `120000`) checked out as text — and is green on CI.
- [x] `ruff check` reports the same 8 pre-existing findings on `batch.py` as `main` does — no new ones. `ruff format --check` clean. `pyright --pythonplatform Linux` (matching the ubuntu runner) 0 errors.
- [x] `batch.py` must stay importable without a container engine (`test_batch_stays_importable_without_a_container_engine`). The new import is `run_support.results`, which does not pull in `run_support.config`; verified, and that test still passes.
- [x] Merge-clean against `main` and against all five of my other open PRs — including #316, which touches the same file.

**Not verified:** no live batch run — I don't have Docker on this machine. The resume decision logic is exercised against real-shaped `run-meta.json` fixtures on disk, not against an interrupted 130-task sweep.

## Related issues

Fixes #297. Related: #160 (resume/resilience testing) asks for exactly this path to be verified end-to-end; this adds the unit-level half.

<sub>`docs/cli.md`'s `--resume` row described skipping "finished runs", which was the intent but not the behaviour — updated to match what the code now does, plus a row for `--retry-failed`.</sub>
