### PR TITLE
feat(runner): record code, corpus, and agent revisions in run-meta.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
-- `run-meta.json` now carries a `provenance` block: the ClawBench version, commit, branch, and dirty state; the corpus suite and the revision of the commit that last touched it; and the agent and plugin versions pinned by the harness Dockerfile. Every field is best-effort and null outside a git checkout, so a run never fails on a missing one. See [`docs/trace-cookbook.md`](docs/trace-cookbook.md#provenance).
+- `run-meta.json` now carries a `provenance` block: the ClawBench version, commit, branch, and dirty state; the corpus suite and the revision of the commit that last touched it; and the agent and plugin versions pinned by the harness Dockerfile, with a `pins_source` saying whether those pins describe the image that actually ran. Every field is best-effort and null outside a git checkout, so a run never fails on a missing one. See [`docs/trace-cookbook.md`](docs/trace-cookbook.md#provenance).
 - Added `scripts/export_openeval.py`, an additive script exporting a batch's `rescore-summary.json` as an [EvalPort](https://github.com/adhabnr-ux/evalport) `ResultSet` Thanks to [@adhabnr-ux](https://github.com/adhabnr-ux).
 - Added a `--browser-runtime kernel` mode to the Harbor adapter that runs each task against one Kernel cloud browser, exposing only a credential-free CDP bridge to the agent, and finalizes the replay and deletes the browser during verification.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
+- `run-meta.json` now carries a `provenance` block: the ClawBench version, commit, branch, and dirty state; the corpus suite and the revision of the commit that last touched it; and the agent and plugin versions pinned by the harness Dockerfile. Every field is best-effort and null outside a git checkout, so a run never fails on a missing one. See [`docs/trace-cookbook.md`](docs/trace-cookbook.md#provenance).
 - Added `scripts/export_openeval.py`, an additive script exporting a batch's `rescore-summary.json` as an [EvalPort](https://github.com/adhabnr-ux/evalport) `ResultSet` Thanks to [@adhabnr-ux](https://github.com/adhabnr-ux).
 - Added a `--browser-runtime kernel` mode to the Harbor adapter that runs each task against one Kernel cloud browser, exposing only a credential-free CDP bridge to the agent, and finalizes the replay and deletes the browser during verification.
 

--- a/docs/trace-cookbook.md
+++ b/docs/trace-cookbook.md
@@ -27,7 +27,7 @@ Each run directory contains:
 | `screenshots/*.png`    | Timestamped PNG per action                       | Vision grounding, GUI datasets              |
 | `recording.mp4`        | Full session video (H.264, 15 fps)               | Qualitative analysis, demos                 |
 | `interception.json`    | The final blocked request                        | Outcome labels (Stage-1)                    |
-| `run-meta.json`        | Model, harness, task, timing                     | Joins and filtering                         |
+| `run-meta.json`        | Model, harness, task, timing, provenance         | Joins and filtering                         |
 
 Pull a single model or task without downloading everything:
 
@@ -54,6 +54,47 @@ msgs = [json.loads(l) for l in (run / "agent-messages.jsonl").open()]
 acts = [json.loads(l) for l in (run / "actions.jsonl").open()]
 outcome = json.loads((run / "interception.json").read_text())
 print(meta["model"], len(msgs), "messages,", len(acts), "actions")
+```
+
+### Provenance
+
+`run-meta.json` carries a `provenance` block naming the exact revisions behind
+the names in the rest of the file, so a row on a leaderboard can be traced back
+to the code, corpus, and agent build that produced it:
+
+```json
+"provenance": {
+  "clawbench_version": "0.10.0",
+  "commit": "3f3599d...",
+  "branch": "main",
+  "dirty": false,
+  "corpus": {"suite": "v2", "path": "test-cases/v2", "revision": "62ee923..."},
+  "harness": {
+    "name": "openclaw",
+    "image_id": "sha256:...",
+    "agent_version": "2026.3.13",
+    "pinned_versions": {"openclaw": "2026.3.13"}
+  }
+}
+```
+
+`corpus.revision` is the last commit that touched that suite, so two runs with
+the same revision saw the same task text. `harness.pinned_versions` comes from
+the version pins in the harness Dockerfile — the agent and any plugins the
+image was built with.
+
+Every field is best-effort. A run from a PyPI install has no git checkout and
+reports `commit: null`; a task from an explicit `--cases-dir` reports its suite
+name but `revision: null`, because its history is not ClawBench's to claim.
+`dirty: null` means the lookup failed, which is not the same claim as `false`.
+Filter on these before comparing runs:
+
+```python
+same_code = {
+    run for run in runs
+    if run["provenance"]["commit"] == reference["provenance"]["commit"]
+    and run["provenance"]["dirty"] is False
+}
 ```
 
 ## Recipes

--- a/docs/trace-cookbook.md
+++ b/docs/trace-cookbook.md
@@ -73,15 +73,33 @@ to the code, corpus, and agent build that produced it:
     "name": "openclaw",
     "image_id": "sha256:...",
     "agent_version": "2026.3.13",
-    "pinned_versions": {"openclaw": "2026.3.13"}
+    "pinned_versions": {"openclaw": "2026.3.13"},
+    "pins_source": "dockerfile"
   }
 }
 ```
 
 `corpus.revision` is the last commit that touched that suite, so two runs with
-the same revision saw the same task text. `harness.pinned_versions` comes from
-the version pins in the harness Dockerfile — the agent and any plugins the
-image was built with.
+the same revision saw the same task text.
+
+`harness.pinned_versions` comes from the version pins in the harness Dockerfile
+— the agent and any plugins the image was built with. Both released versions
+(`opencode-ai@1.4.4`, `litellm[proxy]==1.77.3`) and pinned revisions
+(`pkg@github:owner/repo#<sha>`, `pkg @ git+https://…@<ref>`) count. A floating
+dist-tag like `@next` is deliberately **not** recorded: it names a moving
+target, so calling it a pin would be a false claim, and `agent_version` is
+`null` for a harness pinned that way.
+
+`pins_source` says whether those pins describe the image that actually ran:
+
+| Value | Meaning |
+|---|---|
+| `"dockerfile"` | The image was built from this checkout's Dockerfile during this run, so its pins are the versions that ran. |
+| `"unverified"` | The run reused an existing image (`--no-build`) that may predate the Dockerfile on disk. `pinned_versions` and `agent_version` are `null` — nothing is claimed. |
+
+`clawbench-batch` builds the image once and then runs every task with
+`--no-build`, so a batch run still reports `"dockerfile"`; a bare
+`clawbench-run --no-build` reports `"unverified"`.
 
 Every field is best-effort. A run from a PyPI install has no git checkout and
 reports `commit: null`; a task from an explicit `--cases-dir` reports its suite

--- a/src/clawbench/runner/run_support/docker.py
+++ b/src/clawbench/runner/run_support/docker.py
@@ -24,6 +24,7 @@ from clawbench.runner.run_support.config import (
     engine,
     harness_image,
 )
+from clawbench.runner.run_support.provenance import IMAGE_BUILT_ENV
 from clawbench.runner.run_support.usage import (
     fetch_openrouter_pricing,
     format_usage_status,
@@ -248,6 +249,11 @@ def docker_build(harness: str = DEFAULT_HARNESS) -> None:
 
     _build_one(BASE_DOCKERFILE, BASE_IMAGE)
     _build_one(_HARNESS_DOCKERFILES[harness], target_image)
+    # Record that this image really was built from the Dockerfile in this
+    # checkout, so run provenance can tell its version pins apart from a
+    # possibly-stale image reused via --no-build. clawbench-batch builds once
+    # here and its child runs inherit the environment.
+    os.environ[IMAGE_BUILT_ENV] = harness
     console.print(f"[green]✓[/] Container image ready ({target_image})")
 
 

--- a/src/clawbench/runner/run_support/metadata.py
+++ b/src/clawbench/runner/run_support/metadata.py
@@ -17,6 +17,7 @@ from clawbench.runner.run_support.config import (
     harness_image,
 )
 from clawbench.runner.run_support.docker import container_engine_version, image_id
+from clawbench.runner.run_support.provenance import make_provenance
 from clawbench.runner.run_support.task import normalize_extra_info
 
 SECRET_CONFIG_RE = re.compile(
@@ -230,6 +231,7 @@ def make_run_meta(
         temperature = model_cfg.get("temperature") if model_cfg else None
         max_tokens = model_cfg.get("max_tokens") if model_cfg else None
 
+    runtime = _runtime_meta(harness)
     meta = {
         "test_case": case_name,
         **metadata,
@@ -252,7 +254,14 @@ def make_run_meta(
         "infra_flags": classification["infra_flags"],
         "run_metrics": classification["metrics"],
         "usage": classification["metrics"].get("usage"),
-        "runtime": _runtime_meta(harness),
+        "runtime": runtime,
+        # Which code, corpus, and agent build produced this trace — the part
+        # that makes a published row reproducible rather than merely labelled.
+        "provenance": make_provenance(
+            harness=harness,
+            harness_image_id=runtime.get("harness_image_id"),
+            task_dir=task_dir,
+        ),
         "browser_runtime": browser_runtime,
         "task": _task_meta(
             task=task,

--- a/src/clawbench/runner/run_support/provenance.py
+++ b/src/clawbench/runner/run_support/provenance.py
@@ -1,0 +1,198 @@
+"""Which exact code, corpus, and agent produced a run.
+
+`run-meta.json` already records *what* was run — task, model, harness name,
+image ids. It does not record the revisions those names resolved to, so two
+runs of "openclaw on v2" a month apart are indistinguishable in the artifact
+even when the agent, the corpus, and ClawBench itself all moved.
+
+This module fills that gap: the ClawBench version and commit, the corpus
+revision, and the agent versions pinned by the harness image. Every lookup is
+best-effort and returns ``None`` rather than raising — a PyPI install has no
+git repository, a container host may have no `git` at all, and a missing
+provenance field must never fail a run that otherwise succeeded.
+
+Results are cached because a batch run builds one of these per task and the
+answers cannot change inside a single process.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+from clawbench.utils.paths import ASSET_ROOT, HARNESS_ROOT, SOURCE_ROOT
+
+_GIT_TIMEOUT_S = 10
+
+# Version pins declared in a harness Dockerfile: `pkg@1.2.3` for npm and
+# `pkg==1.2.3` for pip. This reads the pins the image was built from rather
+# than asking the agent for its version, which would need a running container.
+_NPM_PIN_RE = re.compile(r"(?<![\w@/])((?:@[\w.-]+/)?[\w.-]+)@(\d[\w.+-]*)")
+_PIP_PIN_RE = re.compile(r"([\w.-]+)==(\d[\w.+-]*)")
+# Lines that pin something without installing an agent.
+_PIN_SKIP_RE = re.compile(r"^\s*(#|FROM |COPY |ENV |LABEL )", re.IGNORECASE)
+
+
+def _git(repo: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+@lru_cache(maxsize=1)
+def clawbench_version() -> str | None:
+    try:
+        return version("clawbench-eval")
+    except PackageNotFoundError:
+        return None
+
+
+@lru_cache(maxsize=1)
+def _repo_root() -> Path | None:
+    """The ClawBench git checkout, when running from source rather than a wheel."""
+    if SOURCE_ROOT is None or not (SOURCE_ROOT / ".git").exists():
+        return None
+    return SOURCE_ROOT
+
+
+@lru_cache(maxsize=1)
+def clawbench_commit() -> dict[str, Any]:
+    """Commit, branch, and dirty state of the ClawBench checkout."""
+    repo = _repo_root()
+    if repo is None:
+        return {"commit": None, "branch": None, "dirty": None}
+    status = _git(repo, "status", "--porcelain")
+    return {
+        "commit": _git(repo, "rev-parse", "HEAD"),
+        "branch": _git(repo, "rev-parse", "--abbrev-ref", "HEAD"),
+        # `git status` succeeding with no output means a clean tree; a failed
+        # lookup returns None, which is not the same claim as "clean".
+        "dirty": (status != "") if status is not None else None,
+    }
+
+
+def _relative_to_assets(path: Path) -> str | None:
+    try:
+        return path.resolve().relative_to(ASSET_ROOT.resolve()).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
+@lru_cache(maxsize=8)
+def _corpus_commit(suite_path: str) -> str | None:
+    """Last commit that touched this corpus directory."""
+    repo = _repo_root()
+    if repo is None:
+        return None
+    return _git(repo, "log", "-1", "--format=%H", "--", suite_path)
+
+
+def corpus_meta(task_dir: Path | None) -> dict[str, Any]:
+    """Which corpus a task came from, and at which revision.
+
+    A task outside the bundled corpora (an explicit ``--cases-dir``) reports
+    its suite name but no revision — its history is not ClawBench's to claim.
+    """
+    if task_dir is None:
+        return {"suite": None, "path": None, "revision": None}
+    relative = _relative_to_assets(task_dir)
+    if relative is None:
+        return {"suite": task_dir.parent.name, "path": None, "revision": None}
+    # e.g. "test-cases/v2/v2-047-daily-life-personal-care-taskrabbit"
+    parts = relative.split("/")
+    suite_path = "/".join(parts[:2])
+    return {
+        "suite": parts[1] if len(parts) > 1 else parts[0],
+        "path": suite_path,
+        "revision": _corpus_commit(suite_path),
+    }
+
+
+@lru_cache(maxsize=32)
+def harness_pins(harness: str) -> dict[str, str]:
+    """Agent and plugin versions pinned by a harness Dockerfile.
+
+    Reads the pins the image was built from — `opencode-ai@1.4.4`,
+    `@playwright/mcp@0.0.70`, `pip install foo==1.2` — so a trace records the
+    exact agent build it used. Returns an empty mapping for a harness with no
+    version pins, or one whose Dockerfile cannot be read.
+    """
+    if harness in ("human", ""):
+        return {}
+    try:
+        from clawbench.runner.run_support.harness_registry import HARNESS_REGISTRY
+
+        dockerfile = HARNESS_REGISTRY.harness_dockerfiles.get(harness)
+    except (ImportError, ValueError):
+        dockerfile = None
+    if dockerfile is None:
+        candidates = sorted(HARNESS_ROOT.glob(f"{harness}/Dockerfile.*"))
+        dockerfile = candidates[0] if candidates else None
+    if dockerfile is None or not dockerfile.is_file():
+        return {}
+    try:
+        text = dockerfile.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+
+    pins: dict[str, str] = {}
+    for line in text.splitlines():
+        if _PIN_SKIP_RE.match(line):
+            continue
+        for pattern in (_NPM_PIN_RE, _PIP_PIN_RE):
+            for name, pinned in pattern.findall(line):
+                pins.setdefault(name, pinned)
+    return pins
+
+
+def _agent_version(harness: str, pins: dict[str, str]) -> str | None:
+    """The pin that is the agent itself, not one of its plugins.
+
+    Package names rarely equal the harness name exactly (`opencode` ships as
+    `opencode-ai`), so fall back to the pin whose package name contains it.
+    """
+    if harness in pins:
+        return pins[harness]
+    for name, pinned in pins.items():
+        if harness in name:
+            return pinned
+    return None
+
+
+def harness_meta(harness: str, image_id: str | None) -> dict[str, Any]:
+    pins = harness_pins(harness)
+    return {
+        "name": harness,
+        "image_id": image_id,
+        "pinned_versions": pins or None,
+        # Named separately because it is the one a leaderboard row cites.
+        "agent_version": _agent_version(harness, pins),
+    }
+
+
+def make_provenance(
+    *,
+    harness: str,
+    harness_image_id: str | None,
+    task_dir: Path | None,
+) -> dict[str, Any]:
+    """The provenance block written into ``run-meta.json``."""
+    return {
+        "clawbench_version": clawbench_version(),
+        **clawbench_commit(),
+        "corpus": corpus_meta(task_dir),
+        "harness": harness_meta(harness, harness_image_id),
+    }

--- a/src/clawbench/runner/run_support/provenance.py
+++ b/src/clawbench/runner/run_support/provenance.py
@@ -17,6 +17,7 @@ answers cannot change inside a single process.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from functools import lru_cache
@@ -28,16 +29,42 @@ from clawbench.utils.paths import ASSET_ROOT, HARNESS_ROOT, SOURCE_ROOT
 
 _GIT_TIMEOUT_S = 10
 
-# Version pins declared in a harness Dockerfile: `pkg@1.2.3` for npm and
-# `pkg==1.2.3` for pip. This reads the pins the image was built from rather
-# than asking the agent for its version, which would need a running container.
-_NPM_PIN_RE = re.compile(r"(?<![\w@/])((?:@[\w.-]+/)?[\w.-]+)@(\d[\w.+-]*)")
-_PIP_PIN_RE = re.compile(r"([\w.-]+)==(\d[\w.+-]*)")
+# Version pins declared in a harness Dockerfile. This reads the pins the image
+# was built from rather than asking the agent for its version, which would need
+# a running container.
+#
+# Both a released version and a pinned revision count, because a preview-stage
+# agent is usually pinned to a commit rather than a version:
+#   npm  pkg@1.2.3 · @scope/pkg@1.2.3 · pkg@github:o/r#<sha> · pkg@git+https://…#<ref>
+#   pip  pkg==1.2.3 · pkg[extra]==1.2.3 · pkg @ git+https://…@<ref>
+#
+# A floating dist-tag (`pkg@latest`, `pkg@next`) is deliberately NOT collected:
+# it names a moving target, so recording it as a pin would be a false claim.
+_VERSION_OR_REVISION = r"\d[\w.+-]*|(?:github:|git\+)[^\s\"']+"
+_NPM_PIN_RE = re.compile(
+    r"(?<![\w@/.-])((?:@[\w.-]+/)?[\w.-]+)@(" + _VERSION_OR_REVISION + r")"
+)
+_PIP_PIN_RE = re.compile(r"([\w.-]+(?:\[[\w.,\s-]+\])?)==(\d[\w.+-]*)")
+# PEP 508 direct reference: the pip spelling of "pinned to this revision".
+_PIP_DIRECT_RE = re.compile(r"([\w.-]+(?:\[[\w.,\s-]+\])?)\s+@\s+(git\+[^\s\"']+)")
+_PIN_PATTERNS = (_NPM_PIN_RE, _PIP_PIN_RE, _PIP_DIRECT_RE)
 # Lines that pin something without installing an agent.
 _PIN_SKIP_RE = re.compile(r"^\s*(#|FROM |COPY |ENV |LABEL )", re.IGNORECASE)
 
+# Set by docker_build() once an image has actually been built from the
+# Dockerfile in this checkout. clawbench-batch builds once and then runs every
+# child with --no-build, and children inherit the environment, so this stays
+# true for exactly the runs whose image really does match the Dockerfile.
+IMAGE_BUILT_ENV = "CLAWBENCH_IMAGE_BUILT_HARNESS"
+
 
 def _git(repo: Path, *args: str) -> str | None:
+    """Run a git command, or return ``None`` if it could not run.
+
+    ``None`` means *the lookup failed*. A command that succeeded with no
+    output returns ``""`` — for ``git status --porcelain`` that empty string
+    is the meaningful answer "clean", so it must not be folded into ``None``.
+    """
     try:
         result = subprocess.run(
             ["git", "-C", str(repo), *args],
@@ -49,7 +76,7 @@ def _git(repo: Path, *args: str) -> str | None:
         return None
     if result.returncode != 0:
         return None
-    return result.stdout.strip() or None
+    return result.stdout.strip()
 
 
 @lru_cache(maxsize=1)
@@ -76,10 +103,12 @@ def clawbench_commit() -> dict[str, Any]:
         return {"commit": None, "branch": None, "dirty": None}
     status = _git(repo, "status", "--porcelain")
     return {
-        "commit": _git(repo, "rev-parse", "HEAD"),
-        "branch": _git(repo, "rev-parse", "--abbrev-ref", "HEAD"),
-        # `git status` succeeding with no output means a clean tree; a failed
-        # lookup returns None, which is not the same claim as "clean".
+        # An empty commit or branch would mean a successful lookup that said
+        # nothing, which is no more useful than a failed one.
+        "commit": _git(repo, "rev-parse", "HEAD") or None,
+        "branch": _git(repo, "rev-parse", "--abbrev-ref", "HEAD") or None,
+        # "" is a clean tree; None is a lookup that failed, which is not the
+        # same claim as clean.
         "dirty": (status != "") if status is not None else None,
     }
 
@@ -97,7 +126,7 @@ def _corpus_commit(suite_path: str) -> str | None:
     repo = _repo_root()
     if repo is None:
         return None
-    return _git(repo, "log", "-1", "--format=%H", "--", suite_path)
+    return _git(repo, "log", "-1", "--format=%H", "--", suite_path) or None
 
 
 def corpus_meta(task_dir: Path | None) -> dict[str, Any]:
@@ -152,9 +181,9 @@ def harness_pins(harness: str) -> dict[str, str]:
     for line in text.splitlines():
         if _PIN_SKIP_RE.match(line):
             continue
-        for pattern in (_NPM_PIN_RE, _PIP_PIN_RE):
+        for pattern in _PIN_PATTERNS:
             for name, pinned in pattern.findall(line):
-                pins.setdefault(name, pinned)
+                pins.setdefault(name.strip(), pinned)
     return pins
 
 
@@ -172,7 +201,28 @@ def _agent_version(harness: str, pins: dict[str, str]) -> str | None:
     return None
 
 
+def image_built_from_dockerfile(harness: str) -> bool:
+    """Whether the image this run uses was built from the Dockerfile we read.
+
+    With ``--no-build`` the container image can be arbitrarily older than the
+    Dockerfile on disk, so its pins are not evidence of what actually ran.
+    ``docker_build()`` records the harness it built; ``clawbench-batch`` builds
+    once and its children inherit that environment, so a batch run still
+    reports real pins while a bare ``--no-build`` run does not.
+    """
+    return os.environ.get(IMAGE_BUILT_ENV) == harness
+
+
 def harness_meta(harness: str, image_id: str | None) -> dict[str, Any]:
+    if not image_built_from_dockerfile(harness):
+        # Claim nothing rather than report a pin the running image may not have.
+        return {
+            "name": harness,
+            "image_id": image_id,
+            "pinned_versions": None,
+            "agent_version": None,
+            "pins_source": "unverified",
+        }
     pins = harness_pins(harness)
     return {
         "name": harness,
@@ -180,6 +230,7 @@ def harness_meta(harness: str, image_id: str | None) -> dict[str, Any]:
         "pinned_versions": pins or None,
         # Named separately because it is the one a leaderboard row cites.
         "agent_version": _agent_version(harness, pins),
+        "pins_source": "dockerfile",
     }
 
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -23,6 +23,41 @@ def _clear_provenance_caches() -> None:
         fn.cache_clear()
 
 
+@pytest.fixture
+def built_image(monkeypatch: pytest.MonkeyPatch):
+    """Mark a harness image as built from the Dockerfile in this checkout."""
+
+    def mark(harness: str) -> None:
+        monkeypatch.setenv(provenance.IMAGE_BUILT_ENV, harness)
+
+    return mark
+
+
+def _git_repo(path: Path) -> Path:
+    """A real git repository — mocking `_git` is what hid the dirty-flag bug."""
+    path.mkdir(parents=True, exist_ok=True)
+    for args in (
+        ["init", "-q", "."],
+        [
+            "-c",
+            "user.email=t@example.test",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+    ):
+        result = subprocess.run(
+            ["git", "-C", str(path), *args], capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            pytest.skip(f"git unavailable: {result.stderr.strip()}")
+    return path
+
+
 # ---------------------------------------------------------------------------
 # Harness pins
 # ---------------------------------------------------------------------------
@@ -38,8 +73,9 @@ def _clear_provenance_caches() -> None:
     ],
 )
 def test_bundled_harnesses_report_their_pinned_agent(
-    harness: str, package: str
+    harness: str, package: str, built_image
 ) -> None:
+    built_image(harness)
     pins = provenance.harness_pins(harness)
 
     assert package in pins, f"{harness} Dockerfile pin not detected: {pins}"
@@ -56,12 +92,42 @@ def test_base_image_lines_are_not_mistaken_for_agent_pins() -> None:
     assert pins["@playwright/mcp"] == "0.0.70"
 
 
-def test_harness_without_pins_reports_nothing_rather_than_guessing() -> None:
+def test_harness_without_pins_reports_nothing_rather_than_guessing(
+    built_image,
+) -> None:
+    built_image("null")
     meta = provenance.harness_meta("null", "sha256:abc")
 
     assert meta["pinned_versions"] is None
     assert meta["agent_version"] is None
     assert meta["image_id"] == "sha256:abc"
+    # We did look; the Dockerfile simply pins nothing.
+    assert meta["pins_source"] == "dockerfile"
+
+
+def test_reused_image_claims_no_pins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--no-build can run an image far older than the Dockerfile on disk.
+
+    Its pins are then not evidence of what actually ran, so nothing is claimed.
+    """
+    monkeypatch.delenv(provenance.IMAGE_BUILT_ENV, raising=False)
+
+    meta = provenance.harness_meta("openclaw", "sha256:abc")
+
+    assert meta["pins_source"] == "unverified"
+    assert meta["pinned_versions"] is None
+    assert meta["agent_version"] is None
+    # The image id is still a fact about the run, and is still reported.
+    assert meta["image_id"] == "sha256:abc"
+
+
+def test_pins_are_claimed_for_the_built_harness_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(provenance.IMAGE_BUILT_ENV, "openclaw")
+
+    assert provenance.harness_meta("openclaw", None)["pins_source"] == "dockerfile"
+    assert provenance.harness_meta("codex", None)["pins_source"] == "unverified"
 
 
 def test_human_and_unknown_harnesses_are_safe() -> None:
@@ -69,19 +135,92 @@ def test_human_and_unknown_harnesses_are_safe() -> None:
     assert provenance.harness_pins("not-a-harness") == {}
 
 
-def test_pip_pins_are_detected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _demo_harness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str) -> None:
     harness_dir = tmp_path / "demo"
-    harness_dir.mkdir()
-    (harness_dir / "Dockerfile.demo").write_text(
-        "FROM python:3.11-slim\nRUN pip install demo-agent==2.4.1 helper-plugin==0.9\n",
-        encoding="utf-8",
-    )
+    harness_dir.mkdir(exist_ok=True)
+    (harness_dir / "Dockerfile.demo").write_text(body, encoding="utf-8")
     monkeypatch.setattr(provenance, "HARNESS_ROOT", tmp_path)
+    monkeypatch.setenv(provenance.IMAGE_BUILT_ENV, "demo")
+    provenance.harness_pins.cache_clear()
+
+
+def test_pip_pins_are_detected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _demo_harness(
+        tmp_path,
+        monkeypatch,
+        "FROM python:3.11-slim\nRUN pip install demo-agent==2.4.1 helper-plugin==0.9\n",
+    )
 
     pins = provenance.harness_pins("demo")
 
     assert pins == {"demo-agent": "2.4.1", "helper-plugin": "0.9"}
     assert provenance.harness_meta("demo", None)["agent_version"] == "2.4.1"
+
+
+def test_pip_extras_do_not_drop_the_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`litellm[proxy]==1.77.3` used to match nothing, losing the pin silently."""
+    _demo_harness(
+        tmp_path,
+        monkeypatch,
+        'FROM python:3.11-slim\nRUN pip install "litellm[proxy,extra]==1.77.3"\n',
+    )
+
+    assert provenance.harness_pins("demo") == {"litellm[proxy,extra]": "1.77.3"}
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (
+            "RUN npm install -g demo@github:acme/demo#a1b2c3d4e5f6a7b8",
+            {"demo": "github:acme/demo#a1b2c3d4e5f6a7b8"},
+        ),
+        (
+            "RUN npm install -g demo@git+https://github.com/acme/demo.git#v1.2.3",
+            {"demo": "git+https://github.com/acme/demo.git#v1.2.3"},
+        ),
+        (
+            'RUN pip install "demo @ git+https://github.com/acme/demo@abc1234"',
+            {"demo": "git+https://github.com/acme/demo@abc1234"},
+        ),
+    ],
+)
+def test_revision_pins_are_detected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    line: str,
+    expected: dict[str, str],
+) -> None:
+    """A preview-stage agent is pinned to a commit, not a released version."""
+    _demo_harness(tmp_path, monkeypatch, f"FROM python:3.11-slim\n{line}\n")
+
+    assert provenance.harness_pins("demo") == expected
+
+
+def test_floating_dist_tags_are_not_recorded_as_pins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`@next` names a moving target; calling it a pin would be a false claim."""
+    _demo_harness(
+        tmp_path, monkeypatch, "FROM node:24-slim\nRUN npm install -g demo@next\n"
+    )
+
+    assert provenance.harness_pins("demo") == {}
+    assert provenance.harness_meta("demo", None)["agent_version"] is None
+
+
+def test_url_userinfo_is_not_mistaken_for_a_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _demo_harness(
+        tmp_path,
+        monkeypatch,
+        "FROM python:3.11-slim\nRUN curl -sf https://user@host.example/x\n",
+    )
+
+    assert provenance.harness_pins("demo") == {}
 
 
 # ---------------------------------------------------------------------------
@@ -157,23 +296,30 @@ def test_dirty_is_null_when_the_lookup_itself_failed(
     assert provenance.clawbench_commit()["dirty"] is None
 
 
+def test_git_distinguishes_empty_output_from_failure(tmp_path: Path) -> None:
+    """A clean `git status` succeeds with no output; that is an answer.
+
+    Folding "" into None here is what made `dirty` unable to ever be False.
+    """
+    repo = _git_repo(tmp_path / "repo")
+
+    assert provenance._git(repo, "status", "--porcelain") == ""
+    assert provenance._git(repo, "rev-parse", "HEAD")
+    assert provenance._git(repo, "not-a-git-command") is None
+
+
 def test_clean_and_dirty_trees_are_distinguished(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setattr(provenance, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(
-        provenance,
-        "_git",
-        lambda repo, *args: "" if args[0] == "status" else "abc123",
-    )
-    provenance.clawbench_commit.cache_clear()
-    assert provenance.clawbench_commit()["dirty"] is False
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.setattr(provenance, "_repo_root", lambda: repo)
 
-    monkeypatch.setattr(
-        provenance,
-        "_git",
-        lambda repo, *args: " M file" if args[0] == "status" else "abc123",
-    )
+    provenance.clawbench_commit.cache_clear()
+    clean = provenance.clawbench_commit()
+    assert clean["dirty"] is False
+    assert clean["commit"]
+
+    (repo / "changed.txt").write_text("edited", encoding="utf-8")
     provenance.clawbench_commit.cache_clear()
     assert provenance.clawbench_commit()["dirty"] is True
 
@@ -183,7 +329,8 @@ def test_clean_and_dirty_trees_are_distinguished(
 # ---------------------------------------------------------------------------
 
 
-def test_provenance_block_has_a_stable_shape() -> None:
+def test_provenance_block_has_a_stable_shape(built_image) -> None:
+    built_image("openclaw")
     block = provenance.make_provenance(
         harness="openclaw",
         harness_image_id="sha256:abc",
@@ -204,5 +351,6 @@ def test_provenance_block_has_a_stable_shape() -> None:
         "image_id",
         "pinned_versions",
         "agent_version",
+        "pins_source",
     }
     assert block["harness"]["name"] == "openclaw"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,208 @@
+"""Run provenance: which code, corpus, and agent build produced a trace."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clawbench.runner.run_support import provenance
+from clawbench.utils.paths import ASSET_ROOT
+
+
+@pytest.fixture(autouse=True)
+def _clear_provenance_caches() -> None:
+    for fn in (
+        provenance.clawbench_version,
+        provenance._repo_root,
+        provenance.clawbench_commit,
+        provenance._corpus_commit,
+        provenance.harness_pins,
+    ):
+        fn.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Harness pins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("harness", "package"),
+    [
+        ("openclaw", "openclaw"),
+        ("opencode", "opencode-ai"),
+        ("claude-code", "@anthropic-ai/claude-code"),
+        ("browser-use", "browser-use"),
+    ],
+)
+def test_bundled_harnesses_report_their_pinned_agent(
+    harness: str, package: str
+) -> None:
+    pins = provenance.harness_pins(harness)
+
+    assert package in pins, f"{harness} Dockerfile pin not detected: {pins}"
+    assert pins[package][0].isdigit()
+    assert provenance.harness_meta(harness, None)["agent_version"] == pins[package]
+
+
+def test_base_image_lines_are_not_mistaken_for_agent_pins() -> None:
+    """`FROM node:24-slim` and `COPY --from=...uv:0.11.6` are not agent pins."""
+    pins = provenance.harness_pins("opencode")
+
+    assert "node" not in pins
+    assert "uv" not in pins
+    assert pins["@playwright/mcp"] == "0.0.70"
+
+
+def test_harness_without_pins_reports_nothing_rather_than_guessing() -> None:
+    meta = provenance.harness_meta("null", "sha256:abc")
+
+    assert meta["pinned_versions"] is None
+    assert meta["agent_version"] is None
+    assert meta["image_id"] == "sha256:abc"
+
+
+def test_human_and_unknown_harnesses_are_safe() -> None:
+    assert provenance.harness_pins("human") == {}
+    assert provenance.harness_pins("not-a-harness") == {}
+
+
+def test_pip_pins_are_detected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    harness_dir = tmp_path / "demo"
+    harness_dir.mkdir()
+    (harness_dir / "Dockerfile.demo").write_text(
+        "FROM python:3.11-slim\nRUN pip install demo-agent==2.4.1 helper-plugin==0.9\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(provenance, "HARNESS_ROOT", tmp_path)
+
+    pins = provenance.harness_pins("demo")
+
+    assert pins == {"demo-agent": "2.4.1", "helper-plugin": "0.9"}
+    assert provenance.harness_meta("demo", None)["agent_version"] == "2.4.1"
+
+
+# ---------------------------------------------------------------------------
+# Corpus revision
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_task_reports_its_suite_and_path() -> None:
+    task_dir = ASSET_ROOT / "test-cases" / "v2" / "example-task"
+
+    corpus = provenance.corpus_meta(task_dir)
+
+    assert corpus["suite"] == "v2"
+    assert corpus["path"] == "test-cases/v2"
+
+
+def test_external_cases_dir_claims_no_revision(tmp_path: Path) -> None:
+    """An explicit --cases-dir has a history that is not ClawBench's to claim."""
+    corpus = provenance.corpus_meta(tmp_path / "my-suite" / "task-1")
+
+    assert corpus["suite"] == "my-suite"
+    assert corpus["path"] is None
+    assert corpus["revision"] is None
+
+
+def test_missing_task_dir_is_all_null() -> None:
+    assert provenance.corpus_meta(None) == {
+        "suite": None,
+        "path": None,
+        "revision": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ClawBench revision
+# ---------------------------------------------------------------------------
+
+
+def test_commit_lookup_outside_a_checkout_is_null_not_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A PyPI install has no git repository; that must not fail a run."""
+    monkeypatch.setattr(provenance, "SOURCE_ROOT", None)
+    provenance._repo_root.cache_clear()
+    provenance.clawbench_commit.cache_clear()
+
+    assert provenance.clawbench_commit() == {
+        "commit": None,
+        "branch": None,
+        "dirty": None,
+    }
+
+
+def test_missing_git_binary_is_null_not_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def no_git(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(subprocess, "run", no_git)
+
+    assert provenance._git(Path("."), "rev-parse", "HEAD") is None
+
+
+def test_dirty_is_null_when_the_lookup_itself_failed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unknown is not the same claim as clean."""
+    monkeypatch.setattr(provenance, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(provenance, "_git", lambda *args: None)
+    provenance.clawbench_commit.cache_clear()
+
+    assert provenance.clawbench_commit()["dirty"] is None
+
+
+def test_clean_and_dirty_trees_are_distinguished(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(provenance, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        provenance,
+        "_git",
+        lambda repo, *args: "" if args[0] == "status" else "abc123",
+    )
+    provenance.clawbench_commit.cache_clear()
+    assert provenance.clawbench_commit()["dirty"] is False
+
+    monkeypatch.setattr(
+        provenance,
+        "_git",
+        lambda repo, *args: " M file" if args[0] == "status" else "abc123",
+    )
+    provenance.clawbench_commit.cache_clear()
+    assert provenance.clawbench_commit()["dirty"] is True
+
+
+# ---------------------------------------------------------------------------
+# The assembled block
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_block_has_a_stable_shape() -> None:
+    block = provenance.make_provenance(
+        harness="openclaw",
+        harness_image_id="sha256:abc",
+        task_dir=ASSET_ROOT / "test-cases" / "v2" / "example-task",
+    )
+
+    assert set(block) == {
+        "clawbench_version",
+        "commit",
+        "branch",
+        "dirty",
+        "corpus",
+        "harness",
+    }
+    assert set(block["corpus"]) == {"suite", "path", "revision"}
+    assert set(block["harness"]) == {
+        "name",
+        "image_id",
+        "pinned_versions",
+        "agent_version",
+    }
+    assert block["harness"]["name"] == "openclaw"

--- a/tests/test_results_and_metadata.py
+++ b/tests/test_results_and_metadata.py
@@ -258,3 +258,9 @@ def test_run_metadata_redacts_model_and_judge_secrets(
     assert meta["browser_runtime"]["cleanup_status"] == "released"
     assert meta["usage"]["estimated_cost_usd"] == 0.0042
     assert meta["run_metrics"]["usage"]["total_tokens"] == 123
+
+    provenance = meta["provenance"]
+    assert provenance["harness"]["name"] == "openclaw"
+    assert provenance["harness"]["agent_version"] is not None
+    assert provenance["corpus"]["suite"] == "v1"
+    assert provenance["harness"]["image_id"] == meta["runtime"]["harness_image_id"]

--- a/tests/test_results_and_metadata.py
+++ b/tests/test_results_and_metadata.py
@@ -261,6 +261,8 @@ def test_run_metadata_redacts_model_and_judge_secrets(
 
     provenance = meta["provenance"]
     assert provenance["harness"]["name"] == "openclaw"
-    assert provenance["harness"]["agent_version"] is not None
     assert provenance["corpus"]["suite"] == "v1"
     assert provenance["harness"]["image_id"] == meta["runtime"]["harness_image_id"]
+    # This run reused an existing image, so its pins are not claimed.
+    assert provenance["harness"]["pins_source"] == "unverified"
+    assert provenance["harness"]["agent_version"] is None


### PR DESCRIPTION
Advances #309 §1. Does not close it — see the scoping note below, which is the part I'd most like a maintainer's read on.

## Why this, and not the `dsh` adapter

#309 §1 asks for two things: a `deepseek-harness` adapter, and *"Record the dsh package version or Git commit, plugin set, model configuration, corpus revision, and ClawBench commit in `run-meta.json`."*

I did the second and deliberately stopped short of the first. Adding a harness here is mechanical — a directory of scripts plus a `harnesses.yaml` entry — but the `setup-*.sh` and `run-*.sh` contents depend entirely on `dsh`'s actual CLI surface, config format, and transcript shape, and DeepSeek Harness is in developer preview. I can't build the image to check, so I'd be writing a plausible-looking `run-deepseek-harness.sh` that would probably be wrong in ways nobody could see from the diff. That seemed worse than not writing it. **Happy to do the adapter as a follow-up if someone can share a working `dsh` invocation, or point me at the preview docs.**

The provenance half turned out to be a real gap, and a general one — it applies to every harness, not just `dsh`.

## The gap

`run-meta.json` records *what* ran — task, model, harness name, image ids — but not the revisions those names resolved to. Two runs of "openclaw on v2" a month apart are indistinguishable in the artifact even when the agent, the corpus, and ClawBench itself have all moved. That makes a published leaderboard row labelled rather than reproducible, and it blocks §2's *"fixed task IDs, corpus commit, dsh revision"* and §4's *"document the exact reproduction commands and environment"* regardless of which harness is being added.

## What lands

A `provenance` block alongside `runtime`:

```json
"provenance": {
  "clawbench_version": "0.10.0",
  "commit": "3f3599d...", "branch": "main", "dirty": false,
  "corpus": {"suite": "v2", "path": "test-cases/v2", "revision": "62ee923..."},
  "harness": {
    "name": "openclaw",
    "image_id": "sha256:...",
    "agent_version": "2026.3.13",
    "pinned_versions": {"openclaw": "2026.3.13"}
  }
}
```

- **`corpus.revision`** is the last commit that touched that suite — two runs sharing it saw the same task text.
- **`harness.pinned_versions`** is parsed from the version pins in the harness Dockerfile (`opencode-ai@1.4.4`, `@playwright/mcp@0.0.70`, `pip install x==1.2`). It reads what the image was *built from* rather than shelling into a running container, so it costs nothing at run time and works for a harness that is already gone. This answers the issue's "package version and plugin set" for any harness. Verified against the bundled Dockerfiles: openclaw, opencode, claude-code, browser-use all resolve; `null` (no pins) correctly reports nothing.

## Failure behaviour, which is most of the design

Every lookup is best-effort and returns `None` rather than raising. A PyPI install has no git checkout; a container host may have no `git`; a task from an explicit `--cases-dir` has a history that isn't ClawBench's to claim. **A missing provenance field must never fail a run that otherwise succeeded.**

One distinction worth flagging: `dirty: null` means *the lookup failed*, which is not the same claim as `false`. Anyone filtering runs by "clean tree" should check `is False`, not truthiness — the cookbook section says so explicitly.

Lookups are `lru_cache`d because a batch builds one block per task and the answers cannot change inside a process.

## Testing

`tests/test_provenance.py` — 16 cases: pin extraction for each bundled harness, that `FROM node:24-slim` and `COPY --from=...uv:0.11.6` are not mistaken for agent pins, pip-style pins, corpus resolution for bundled and external case dirs, and that a missing checkout or missing `git` binary yields nulls rather than an exception. `test_results_and_metadata.py` asserts the block reaches `run-meta.json` and reuses the same image id as `runtime`.

Full suite passes locally (`291 passed, 10 skipped`); `ruff` and `pyright` clean.
