### PR TITLE
refactor(interceptor): one implementation of Stage-1 matching, with a parity matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added a `--browser-runtime kernel` mode to the Harbor adapter that runs each task against one Kernel cloud browser, exposing only a credential-free CDP bridge to the agent, and finalizes the replay and deletes the browser during verification.
 
 ### Changed
+- Stage-1 interception matching now has a single implementation, `runtime/shared/matching.py`, imported by both the in-container interceptor and the offline EdgeBench judge; the two hand-maintained copies had drifted on repeated query keys and on malformed patterns. A task whose `eval_schema.url_pattern` is not a valid regex is now rejected at load time.
 - Container-engine detection is now lazy: `run_support.config.engine()` probes PATH on first use instead of at import time, so importing the runner modules no longer requires Docker or Podman. `config.ENGINE` still resolves but is deprecated.
 - `runner/batch.py` now uses the shared `config.engine()` instead of its own copy of the PATH probe.
 - The `claw-eval` port now uses the same `test-cases/<suite>/<task-identifier>/task.json` layout as the native corpora, instead of flat `<task-identifier>.json` files. Case discovery in `clawbench-batch` and the TUI is a plain `*/task.json` search again, and the `validate-task` workflow covers the suite without special-casing.
 - Changed the default Harbor version to `0.22.0`.
 
 ### Fixed
+- A malformed `eval_schema.url_pattern` no longer kills the interceptor thread on the first request — which silently ended both interception and request logging for the rest of the run (#258). The pattern is compiled once at startup and a bad one is reported loudly.
 - Host-timeout container termination now uses the lazy container-engine resolver.
 - Added host-side container and batch-job timeouts so a wedged run cannot stall a batch indefinitely.
 - Fixed a judge-provider outage (or an unparseable judge reply) being recorded as an agent failure. `run.py` now exits 3 instead of 1 when the judge never renders a verdict, `batch.py` gives it its own `judge_inconclusive` bucket in `batch-summary.json` instead of folding it into `failed`, and `clawbench-rescore` now retries a cached `match: null` verdict even without `--force`.

--- a/eval/scoring.md
+++ b/eval/scoring.md
@@ -62,6 +62,8 @@ If `intercepted: false`, **reward = 0** for that task regardless of how close th
 - agent reached a different endpoint than the rubric expects (alternate-flow miss)
 - agent hit a CAPTCHA / login / verification wall and could not solve it
 
+The matching predicate — `url_pattern` regex search, `method`, and constant `body`/`params` fields, with query parameters always read from the URL — is implemented once in [`src/clawbench/runtime/shared/matching.py`](../src/clawbench/runtime/shared/matching.py). The in-container interceptor and the offline EdgeBench judge both import it, so a re-derived Stage 1 verdict is the same decision the run made, not a re-implementation of it. A task whose `url_pattern` is not a valid regex is rejected before a container starts.
+
 Note that **Stage 1 alone is too lenient** — an agent that intercepts but submits the wrong payload would pass. Stage 2 closes that gap.
 
 ## Stage 2 — LLM judge

--- a/src/clawbench/eval/edgebench_judge.py
+++ b/src/clawbench/eval/edgebench_judge.py
@@ -23,13 +23,12 @@ import hashlib
 import hmac
 import json
 import os
-import re
 import sys
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 from clawbench.runner.judge import judge_request
+from clawbench.runtime.shared.matching import stage1_match_schema
 
 
 def _verify_signature(intercept: dict[str, Any], secret: str) -> bool:
@@ -52,46 +51,15 @@ def _verify_signature(intercept: dict[str, Any], secret: str) -> bool:
     return hmac.compare_digest(sig, expected)
 
 
-def _const_fields_match(expected: Any, actual: Any) -> bool:
-    """All key/values in ``expected`` present in ``actual`` (mirrors runtime-server)."""
-    if not expected:
-        return True
-    if not actual:
-        return False
-    if isinstance(actual, list):
-        return any(_const_fields_match(expected, item) for item in actual)
-    if not isinstance(actual, dict):
-        return False
-    return all(actual.get(k) == v for k, v in expected.items())
-
-
 def _stage1_match(request: dict[str, Any], eval_schema: Any) -> bool:
     """Recompute Stage-1 against the task schema — do NOT trust the agent's flag.
 
     The agent controls the submitted evidence archive, so re-verify that the
-    submitted request actually hits the task's target (url_pattern regex + method
-    + const body/params), exactly as the runtime interceptor would.
+    submitted request actually hits the task's target. This is the same code
+    the runtime interceptor runs, not a mirror of it; query parameters are
+    derived from the URL, never from a submitted ``params`` field.
     """
-    if not isinstance(eval_schema, dict):
-        return False
-    url_pattern = eval_schema.get("url_pattern") or ""
-    if not url_pattern:
-        return False  # no target to verify against → cannot confirm interception
-    url = str(request.get("url") or "")
-    try:
-        if not re.search(url_pattern, url):
-            return False
-    except re.error:
-        return False
-    method = eval_schema.get("method")
-    if method and request.get("method") != method:
-        return False
-    if not _const_fields_match(eval_schema.get("body"), request.get("body")):
-        return False
-    # Always derive query params from the URL (like the runtime interceptor) — do
-    # not trust a submitted request["params"] field, which could be forged.
-    params = {k: v[0] for k, v in parse_qs(urlparse(url).query).items()}
-    return _const_fields_match(eval_schema.get("params"), params)
+    return stage1_match_schema(request, eval_schema)
 
 
 # SForge structured_json markers (grading._grade_structured looks for these).

--- a/src/clawbench/runner/run_support/task.py
+++ b/src/clawbench/runner/run_support/task.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from clawbench.runner.run_support.resume import generate_resume_pdf
+from clawbench.runtime.shared.matching import InvalidUrlPattern, compile_url_pattern
 
 RESUME_TEMPLATE = Path(__file__).resolve().parent / "resume_template.json"
 
@@ -254,6 +255,15 @@ def validate_task_data(task: Any, task_file: Path) -> dict:
         raise ValueError("task eval_schema must be an object")
     if not isinstance(eval_schema.get("url_pattern"), str):
         raise ValueError("task eval_schema.url_pattern must be a string")
+    # Reject a malformed regex here, before a container is paid for: the
+    # interceptor would otherwise disable itself at startup and the run would
+    # complete with Stage 1 silently impossible.
+    try:
+        compile_url_pattern(eval_schema["url_pattern"])
+    except InvalidUrlPattern as e:
+        raise ValueError(
+            f"task eval_schema.url_pattern is not a valid regex: {e}"
+        ) from None
     if not isinstance(eval_schema.get("method"), str):
         raise ValueError("task eval_schema.method must be a string")
     raw_time_limit = task.get("time_limit")

--- a/src/clawbench/runtime/harbor/Dockerfile
+++ b/src/clawbench/runtime/harbor/Dockerfile
@@ -27,6 +27,9 @@ RUN UV_PYTHON_PREFERENCE=only-system uv sync --frozen \
 
 WORKDIR /app
 COPY runtime-server/server.py ./src/runtime-server/server.py
+# Stage-1 matching is shared with the host-side judge; the canonical copy
+# lives in shared/ and is placed next to server.py so it imports as `matching`.
+COPY shared/matching.py ./src/runtime-server/matching.py
 COPY chrome-extension/ ./src/chrome-extension/
 COPY shared/ ./src/shared/
 COPY harbor/ ./src/harbor/

--- a/src/clawbench/runtime/harnesses/base/Dockerfile.base
+++ b/src/clawbench/runtime/harnesses/base/Dockerfile.base
@@ -29,6 +29,9 @@ RUN UV_PYTHON_PREFERENCE=only-system uv sync --frozen
 
 WORKDIR /app
 COPY runtime-server/server.py ./src/runtime-server/server.py
+# Stage-1 matching is shared with the host-side judge; the canonical copy
+# lives in shared/ and is placed next to server.py so it imports as `matching`.
+COPY shared/matching.py ./src/runtime-server/matching.py
 
 COPY chrome-extension/ ./src/chrome-extension/
 

--- a/src/clawbench/runtime/runtime-server/server.py
+++ b/src/clawbench/runtime/runtime-server/server.py
@@ -2,19 +2,27 @@ import asyncio
 import base64
 import json
 import os
-import re
 import signal
 import subprocess
 import threading
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
 import urllib.request
 
 import websocket
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse
+
+# Stage-1 matching is shared with the offline judge (eval/edgebench_judge.py).
+# The file is copied next to this one at image build; see shared/matching.py.
+from matching import (
+    InvalidUrlPattern,
+    compile_url_pattern,
+    parse_body,
+    query_params_from_url,
+    stage1_match,
+)
 
 DATA_DIR = Path(os.environ.get("CLAWBENCH_DATA_DIR", "/data"))
 ACTIONS_FILE = DATA_DIR / "actions.jsonl"
@@ -170,21 +178,6 @@ ACTION_CAPTURE_SCRIPT = r"""
 """
 
 
-def _const_fields_match(expected, actual):
-    """Check that all key-value pairs in expected match in actual data.
-    For list bodies (batched GraphQL), returns True if any item matches.
-    Returns True if all match or expected is empty/None."""
-    if not expected:
-        return True
-    if not actual:
-        return False
-    if isinstance(actual, list):
-        return any(_const_fields_match(expected, item) for item in actual)
-    if not isinstance(actual, dict):
-        return False
-    return all(actual.get(k) == v for k, v in expected.items())
-
-
 FILTERED_PREFIXES = (
     "http://localhost:7878",
     "http://127.0.0.1:7878",
@@ -192,22 +185,6 @@ FILTERED_PREFIXES = (
     "devtools://",
     "chrome://",
 )
-
-
-def _parse_body(post_data):
-    """Parse postData string into a structured body (JSON dict, form dict, or raw string)."""
-    if not post_data:
-        return None
-    try:
-        return json.loads(post_data)
-    except (json.JSONDecodeError, TypeError):
-        try:
-            parsed = parse_qs(post_data, keep_blank_values=True)
-            if parsed:
-                return {k: v[0] if len(v) == 1 else v for k, v in parsed.items()}
-        except Exception:
-            pass
-        return post_data
 
 
 def _log_request(log_file, params):
@@ -218,17 +195,14 @@ def _log_request(log_file, params):
     if any(request_url.startswith(p) for p in FILTERED_PREFIXES):
         return
 
-    parsed = urlparse(request_url)
-    query_params = {
-        k: v[0] if len(v) == 1 else v for k, v in parse_qs(parsed.query).items()
-    }
+    query_params = query_params_from_url(request_url)
 
     entry = {
         "timestamp": time.time(),
         "url": request_url,
         "method": request["method"],
         "headers": request.get("headers", {}),
-        "body": _parse_body(request.get("postData")),
+        "body": parse_body(request.get("postData")),
         "query_params": query_params,
         "resource_type": params.get("resourceType", "Other"),
     }
@@ -292,9 +266,12 @@ def start_cdp_handler(
         },
     )
 
-    if url_pattern:
+    if url_pattern is not None:
         eval_interceptor_ready = True
-        print(f"[cdp] Interceptor connected, watching for: {url_pattern}", flush=True)
+        print(
+            f"[cdp] Interceptor connected, watching for: {url_pattern.pattern}",
+            flush=True,
+        )
     else:
         print("[cdp] Request logger connected (no intercept pattern)", flush=True)
 
@@ -446,31 +423,21 @@ def start_cdp_handler(
             _log_request(requests_log_file, params)
 
             # If no intercept pattern, just continue the request
-            if not url_pattern:
+            if url_pattern is None:
                 send("Fetch.continueRequest", {"requestId": request_id}, session_id)
                 continue
 
             # --- Intercept: block if URL + method + body/params match ---
-            if not re.search(url_pattern, request_url):
-                send("Fetch.continueRequest", {"requestId": request_id}, session_id)
-                continue
-
-            if required_method and params["request"]["method"] != required_method:
-                send("Fetch.continueRequest", {"requestId": request_id}, session_id)
-                continue
-
-            # Parse request data for body/params matching
-            parsed = urlparse(request_url)
-            query_params = {
-                k: v[0] if len(v) == 1 else v for k, v in parse_qs(parsed.query).items()
-            }
-            body = _parse_body(params["request"].get("postData"))
-
-            if not _const_fields_match(match_body, body):
-                send("Fetch.continueRequest", {"requestId": request_id}, session_id)
-                continue
-
-            if not _const_fields_match(match_params, query_params):
+            body = parse_body(params["request"].get("postData"))
+            if not stage1_match(
+                url=request_url,
+                method=params["request"]["method"],
+                body=body,
+                url_pattern=url_pattern,
+                required_method=required_method,
+                match_body=match_body,
+                match_params=match_params,
+            ):
                 send("Fetch.continueRequest", {"requestId": request_id}, session_id)
                 continue
 
@@ -478,7 +445,7 @@ def start_cdp_handler(
             request_obj = {
                 "url": request_url,
                 "method": params["request"]["method"],
-                "params": query_params,
+                "params": query_params_from_url(request_url),
                 "body": body,
             }
 
@@ -525,8 +492,14 @@ async def lifespan(app: FastAPI):
     match_params = None
     if EVAL_SCHEMA_PATH.exists():
         eval_schema = json.loads(EVAL_SCHEMA_PATH.read_text())
-        url_pattern = eval_schema.get("url_pattern", "")
-        if not url_pattern:
+        # Compile once here so a malformed pattern fails loudly at startup.
+        # It used to be matched per request inside the CDP loop, where the
+        # regex error escaped, killed the thread, and silently ended both
+        # interception and request logging for the rest of the run (#258).
+        try:
+            url_pattern = compile_url_pattern(eval_schema.get("url_pattern"))
+        except InvalidUrlPattern as e:
+            print(f"[interceptor] ERROR: {e}; interception disabled", flush=True)
             url_pattern = None
         required_method = eval_schema.get("method")
         match_body = eval_schema.get("body")

--- a/src/clawbench/runtime/shared/matching.py
+++ b/src/clawbench/runtime/shared/matching.py
@@ -1,0 +1,147 @@
+"""Stage-1 interception matching — the one copy of the benchmark's ground truth.
+
+The decision "does this HTTP request hit the task's target?" is made in two
+places that must agree exactly:
+
+* ``runtime-server/server.py`` — live, inside the container, deciding which
+  request to block and record as ``interception.json``.
+* ``eval/edgebench_judge.py`` — offline, re-deriving Stage 1 from submitted
+  evidence rather than trusting the agent's own flag.
+
+They used to be two hand-maintained copies, and they had drifted: one kept
+repeated query keys as a list while the other silently took the first value,
+and one caught a malformed ``url_pattern`` while the other let ``re.error``
+escape inside the CDP loop and kill interception for the rest of the run.
+Both now import this module.
+
+Keep this file **stdlib-only**. It is copied verbatim into the runtime image
+next to ``server.py`` (see ``harnesses/base/Dockerfile.base``), where none of
+the ``clawbench`` package is installed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+class InvalidUrlPattern(ValueError):
+    """A task's ``eval_schema.url_pattern`` is not a valid regular expression."""
+
+
+def compile_url_pattern(url_pattern: Any) -> re.Pattern[str] | None:
+    """Compile a task's ``url_pattern`` once, up front.
+
+    Returns ``None`` for an empty or missing pattern, which means "log requests
+    but intercept nothing". Raises :class:`InvalidUrlPattern` for a malformed
+    one so the failure surfaces when the schema is loaded, not on the first
+    request that happens to arrive.
+    """
+    if not url_pattern:
+        return None
+    if not isinstance(url_pattern, str):
+        raise InvalidUrlPattern(
+            f"url_pattern must be a string, got {type(url_pattern).__name__}"
+        )
+    try:
+        return re.compile(url_pattern)
+    except re.error as e:
+        raise InvalidUrlPattern(f"invalid url_pattern {url_pattern!r}: {e}") from e
+
+
+def const_fields_match(expected: Any, actual: Any) -> bool:
+    """Every key/value in ``expected`` is present, equal, in ``actual``.
+
+    A list ``actual`` (a batched GraphQL body) matches if any item matches.
+    An empty ``expected`` places no constraint and always matches.
+    """
+    if not expected:
+        return True
+    if not actual:
+        return False
+    if isinstance(actual, list):
+        return any(const_fields_match(expected, item) for item in actual)
+    if not isinstance(actual, dict):
+        return False
+    return all(actual.get(k) == v for k, v in expected.items())
+
+
+def parse_body(post_data: Any) -> Any:
+    """Structure a raw request body: JSON, then form-encoded, else the raw text."""
+    if not post_data:
+        return None
+    try:
+        return json.loads(post_data)
+    except (json.JSONDecodeError, TypeError):
+        pass
+    try:
+        parsed = parse_qs(post_data, keep_blank_values=True)
+    except (TypeError, ValueError, AttributeError):
+        return post_data
+    if parsed:
+        return {k: v[0] if len(v) == 1 else v for k, v in parsed.items()}
+    return post_data
+
+
+def query_params_from_url(url: str) -> dict[str, Any]:
+    """Query parameters of ``url``; a repeated key becomes a list.
+
+    Always derived from the URL itself — never from a caller-supplied
+    ``params`` field, which submitted evidence could forge.
+    """
+    return {
+        k: v[0] if len(v) == 1 else v for k, v in parse_qs(urlparse(url).query).items()
+    }
+
+
+def stage1_match(
+    *,
+    url: str,
+    method: str | None,
+    body: Any,
+    url_pattern: re.Pattern[str] | None,
+    required_method: str | None,
+    match_body: Any,
+    match_params: Any,
+) -> bool:
+    """The Stage-1 decision: does this request hit the task's target?
+
+    ``url_pattern`` is a compiled pattern (see :func:`compile_url_pattern`);
+    ``None`` never matches. ``body`` is the already-structured request body
+    (see :func:`parse_body`). Query parameters are read from ``url``.
+    """
+    if url_pattern is None:
+        return False
+    if not url_pattern.search(url):
+        return False
+    if required_method and method != required_method:
+        return False
+    if not const_fields_match(match_body, body):
+        return False
+    return const_fields_match(match_params, query_params_from_url(url))
+
+
+def stage1_match_schema(request: dict[str, Any], eval_schema: Any) -> bool:
+    """:func:`stage1_match` driven straight from a task's ``eval_schema``.
+
+    A schema that is missing, has no ``url_pattern``, or has a malformed one
+    cannot confirm an interception and returns ``False`` rather than raising —
+    this is the offline-judge entry point, where a bad schema must fail closed.
+    """
+    if not isinstance(eval_schema, dict):
+        return False
+    try:
+        pattern = compile_url_pattern(eval_schema.get("url_pattern"))
+    except InvalidUrlPattern:
+        return False
+    return stage1_match(
+        url=str(request.get("url") or ""),
+        method=request.get("method"),
+        body=request.get("body"),
+        url_pattern=pattern,
+        required_method=eval_schema.get("method"),
+        match_body=eval_schema.get("body"),
+        match_params=eval_schema.get("params"),
+    )

--- a/tests/test_interceptor_matching.py
+++ b/tests/test_interceptor_matching.py
@@ -1,0 +1,292 @@
+"""Stage-1 interception matching has one implementation, and both users agree.
+
+The live interceptor (``runtime-server/server.py``) and the offline judge
+(``eval/edgebench_judge.py``) used to carry hand-maintained copies of the
+matching predicate — the benchmark's deterministic ground truth — and only the
+copy that never ran in production had tests (#301). Both now import
+``runtime/shared/matching.py``; these tests pin the predicate's behaviour and
+the wiring on both sides.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from clawbench.eval import edgebench_judge
+from clawbench.runner.run_support.task import validate_task_data
+from clawbench.runtime.shared import matching
+from clawbench.runtime.shared.matching import (
+    InvalidUrlPattern,
+    compile_url_pattern,
+    const_fields_match,
+    parse_body,
+    query_params_from_url,
+    stage1_match,
+    stage1_match_schema,
+)
+from clawbench.utils.paths import RUNTIME_ROOT
+
+SERVER_PY = RUNTIME_ROOT / "runtime-server" / "server.py"
+MATCHING_PY = RUNTIME_ROOT / "shared" / "matching.py"
+
+
+def _schema(**overrides: Any) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "url_pattern": r"example\.com/api/submit",
+        "method": "POST",
+    }
+    schema.update(overrides)
+    return schema
+
+
+def _request(**overrides: Any) -> dict[str, Any]:
+    request: dict[str, Any] = {
+        "url": "https://example.com/api/submit",
+        "method": "POST",
+        "body": {"action": "book"},
+    }
+    request.update(overrides)
+    return request
+
+
+# ---------------------------------------------------------------------------
+# The fixture matrix: url_pattern / method / body / params, plus the regex
+# edge cases from #258.
+# ---------------------------------------------------------------------------
+
+MATRIX: list[tuple[str, Any, dict[str, Any], bool]] = [
+    ("plain hit", _schema(), _request(), True),
+    ("url miss", _schema(), _request(url="https://example.com/api/other"), False),
+    (
+        "regex is a search, not a full match",
+        _schema(url_pattern="submit"),
+        _request(),
+        True,
+    ),
+    ("method mismatch", _schema(), _request(method="GET"), False),
+    ("method unconstrained", _schema(method=None), _request(method="GET"), True),
+    (
+        "body subset matches",
+        _schema(body={"action": "book"}),
+        _request(body={"action": "book", "extra": 1}),
+        True,
+    ),
+    ("body value differs", _schema(body={"action": "cancel"}), _request(), False),
+    (
+        "body required but absent",
+        _schema(body={"action": "book"}),
+        _request(body=None),
+        False,
+    ),
+    ("body constraint empty", _schema(body={}), _request(body=None), True),
+    (
+        "batched graphql: any item matches",
+        _schema(body={"operationName": "Submit"}),
+        _request(body=[{"operationName": "Other"}, {"operationName": "Submit"}]),
+        True,
+    ),
+    (
+        "string body cannot satisfy a dict constraint",
+        _schema(body={"a": 1}),
+        _request(body="raw"),
+        False,
+    ),
+    (
+        "params from url",
+        _schema(params={"id": "5"}),
+        _request(url="https://example.com/api/submit?id=5"),
+        True,
+    ),
+    (
+        "params value differs",
+        _schema(params={"id": "6"}),
+        _request(url="https://example.com/api/submit?id=5"),
+        False,
+    ),
+    (
+        "params: a submitted params field is ignored",
+        _schema(params={"id": "5"}),
+        _request(url="https://example.com/api/submit", params={"id": "5"}),
+        False,
+    ),
+    (
+        "repeated query key is a list",
+        _schema(params={"tag": ["a", "b"]}),
+        _request(url="https://example.com/api/submit?tag=a&tag=b"),
+        True,
+    ),
+    (
+        "repeated query key does not collapse to its first value",
+        _schema(params={"tag": "a"}),
+        _request(url="https://example.com/api/submit?tag=a&tag=b"),
+        False,
+    ),
+    # #258 edge cases.
+    ("empty pattern intercepts nothing", _schema(url_pattern=""), _request(), False),
+    ("missing pattern intercepts nothing", {"method": "POST"}, _request(), False),
+    (
+        "malformed pattern fails closed, does not raise",
+        _schema(url_pattern="submit("),
+        _request(),
+        False,
+    ),
+    ("schema is not an object", "nope", _request(), False),
+]
+
+
+@pytest.mark.parametrize(
+    ("schema", "req", "expected"),
+    [case[1:] for case in MATRIX],
+    ids=[case[0] for case in MATRIX],
+)
+def test_stage1_decision(schema: Any, req: dict[str, Any], expected: bool) -> None:
+    assert stage1_match_schema(req, schema) is expected
+
+
+@pytest.mark.parametrize(
+    ("schema", "req"),
+    [case[1:3] for case in MATRIX],
+    ids=[case[0] for case in MATRIX],
+)
+def test_offline_judge_agrees_with_the_shared_predicate(
+    schema: Any, req: dict[str, Any]
+) -> None:
+    """The judge's entry point is the shared function, not a mirror of it."""
+    assert edgebench_judge._stage1_match(req, schema) is stage1_match_schema(
+        req, schema
+    )
+
+
+# ---------------------------------------------------------------------------
+# Building blocks
+# ---------------------------------------------------------------------------
+
+
+def test_compile_url_pattern_distinguishes_empty_from_malformed() -> None:
+    assert compile_url_pattern("") is None
+    assert compile_url_pattern(None) is None
+    assert isinstance(compile_url_pattern(r"a\.b"), re.Pattern)
+    with pytest.raises(InvalidUrlPattern, match="invalid url_pattern"):
+        compile_url_pattern("submit(")
+    with pytest.raises(InvalidUrlPattern, match="must be a string"):
+        compile_url_pattern(["not", "a", "pattern"])
+
+
+def test_stage1_match_never_matches_without_a_pattern() -> None:
+    assert (
+        stage1_match(
+            url="https://example.com/x",
+            method="POST",
+            body=None,
+            url_pattern=None,
+            required_method=None,
+            match_body=None,
+            match_params=None,
+        )
+        is False
+    )
+
+
+def test_parse_body_prefers_json_then_form_then_raw() -> None:
+    assert parse_body(None) is None
+    assert parse_body("") is None
+    assert parse_body('{"a": 1}') == {"a": 1}
+    assert parse_body("a=1&b=2&b=3") == {"a": "1", "b": ["2", "3"]}
+    assert parse_body("a=") == {"a": ""}
+    # Bare text is form-parsed as a blank-valued key — long-standing interceptor
+    # behaviour, pinned here so the judge cannot quietly diverge from it.
+    assert parse_body("just text") == {"just text": ""}
+    assert parse_body("&") == "&"
+
+
+def test_query_params_keep_repeated_keys() -> None:
+    assert query_params_from_url("https://x/?a=1&b=2&b=3") == {
+        "a": "1",
+        "b": ["2", "3"],
+    }
+    assert query_params_from_url("https://x/") == {}
+
+
+def test_const_fields_match_semantics() -> None:
+    assert const_fields_match(None, None) is True
+    assert const_fields_match({}, None) is True
+    assert const_fields_match({"a": 1}, None) is False
+    assert const_fields_match({"a": 1}, {"a": 1, "b": 2}) is True
+    assert const_fields_match({"a": 1}, [{"a": 2}, {"a": 1}]) is True
+    assert const_fields_match({"a": 1}, "a=1") is False
+
+
+# ---------------------------------------------------------------------------
+# A malformed pattern is caught before a container is paid for.
+# ---------------------------------------------------------------------------
+
+
+def test_task_validation_rejects_a_malformed_url_pattern(tmp_path: Path) -> None:
+    task = {
+        "instruction": "do it",
+        "eval_schema": {"url_pattern": "submit(", "method": "POST"},
+        "time_limit": 5,
+    }
+    with pytest.raises(ValueError, match="not a valid regex"):
+        validate_task_data(task, tmp_path / "task.json")
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the live interceptor really does use the shared module.
+# ---------------------------------------------------------------------------
+
+
+def test_server_imports_the_shared_matcher_and_keeps_no_copy() -> None:
+    source = SERVER_PY.read_text(encoding="utf-8")
+
+    assert "from matching import" in source
+    assert "stage1_match(" in source
+    assert "compile_url_pattern(" in source
+    # No second implementation, and no per-request re.search that can raise
+    # inside the CDP loop.
+    assert "def _const_fields_match" not in source
+    assert "def _parse_body" not in source
+    assert "re.search(" not in source
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    [
+        RUNTIME_ROOT / "harnesses" / "base" / "Dockerfile.base",
+        RUNTIME_ROOT / "harbor" / "Dockerfile",
+    ],
+    ids=["base", "harbor"],
+)
+def test_runtime_images_ship_the_shared_matcher_next_to_server(
+    dockerfile: Path,
+) -> None:
+    source = dockerfile.read_text(encoding="utf-8")
+
+    assert "COPY shared/matching.py ./src/runtime-server/matching.py" in source
+
+
+def test_shared_matcher_is_stdlib_only_and_loads_as_a_top_level_module() -> None:
+    """Inside the container it is imported as bare `matching`, with no package."""
+    source = MATCHING_PY.read_text(encoding="utf-8")
+    imported = re.findall(r"^(?:from|import)\s+([\w.]+)", source, re.MULTILINE)
+    assert all(name.split(".")[0] in sys.stdlib_module_names for name in imported), (
+        imported
+    )
+
+    spec = importlib.util.spec_from_file_location("matching", MATCHING_PY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    request = _request(url="https://example.com/api/submit?id=5")
+    assert module.stage1_match_schema(request, _schema(params={"id": "5"})) is True
+    # And it is byte-for-byte the module the host side imports.
+    assert module.stage1_match_schema.__code__.co_code == (
+        matching.stage1_match_schema.__code__.co_code
+    )


### PR DESCRIPTION
Closes #301.

## The problem

The Stage-1 decision — *does this request hit the task's target?* — is the benchmark's deterministic ground truth, and it lived in two hand-maintained copies: the live interceptor in `runtime-server/server.py` and a "mirrors runtime-server" re-implementation in `eval/edgebench_judge.py`. Only the mirror had tests. And the two had **already drifted**:

| | interceptor (live) | judge (offline) |
|---|---|---|
| repeated query key `?tag=a&tag=b` | kept as `["a","b"]` | silently collapsed to `"a"` |
| malformed `url_pattern` | `re.search()` raised inside the CDP loop → thread died → **interception and request logging both silently off for the rest of the run** (#258) | caught, returned `False` |

So a schema with `params: {"tag": ["a","b"]}` matched during the run and failed when re-judged offline, and a bad regex produced a full-length run whose `intercepted: false` looked like an agent miss.

## What this does

**One module, two importers.** `src/clawbench/runtime/shared/matching.py` holds `compile_url_pattern`, `const_fields_match`, `parse_body`, `query_params_from_url`, `stage1_match`, and the schema-driven `stage1_match_schema`. `edgebench_judge._stage1_match` is now a one-line call into it. `server.py` imports it, drops its private copies, and its CDP loop calls `stage1_match(...)` in place of the four inline checks.

**Why it lives in `runtime/shared/` and is stdlib-only.** The container has none of the `clawbench` package — the base image copies only `server.py`. So the module has no package imports, and both `Dockerfile.base` and the Harbor `Dockerfile` `COPY shared/matching.py` next to `server.py`, where it imports as bare `matching`. A test loads it by file path under that name to prove it works that way. This follows the repo's existing pattern for sharing code with the container (`harbor_adapter.copy_environment` already ships `providers.py` the same way).

**The #258 crash is gone by construction.** `server.py` compiles the pattern once at startup via `compile_url_pattern`; a malformed one is reported loudly and interception disabled, and the CDP loop no longer contains a call that can raise `re.error`. On top of that, `validate_task_data` now rejects a malformed `url_pattern` on the host, so a broken task fails before a container is paid for instead of after a full run.

**Behaviour preserved otherwise.** The predicate is the interceptor's semantics verbatim, including `parse_body`'s form-parse of bare text — the test pins that so the judge can't quietly diverge from it again.

## Testing

`tests/test_interceptor_matching.py` — 50 cases:

- a 20-row fixture matrix over `url_pattern` / `method` / `body` / `params`, including batched-GraphQL list bodies, repeated query keys, a forged `request["params"]` field being ignored, and the #258 edge cases (empty pattern, missing pattern, malformed pattern → `False`, not a raise)
- the same matrix asserting `edgebench_judge._stage1_match` is the shared function
- `validate_task_data` rejecting a malformed regex — and the existing corpus test confirms every bundled task's pattern compiles
- wiring: `server.py` imports the shared module and keeps no copy or `re.search`; both Dockerfiles ship it; the module is stdlib-only and loads as top-level `matching` with the same bytecode as the host import

Full suite: `325 passed, 10 skipped` locally; `ruff` and `pyright` clean on the touched files.

## Not done here

`server.py` is still excluded from pyright (`pyproject.toml` excludes `src/clawbench/runtime`), as #301 notes. The predicate it depends on is now typed and tested, but un-excluding the 800-line server is a separate change. The `check-harness-build` workflow will exercise the new `COPY` lines.
